### PR TITLE
fix: install parser deps before ingest in bootstrap

### DIFF
--- a/scaffold/scripts/bootstrap.sh
+++ b/scaffold/scripts/bootstrap.sh
@@ -36,6 +36,7 @@ mkdir -p "$MCP_DIR/.npm-cache"
 step "Installing MCP dependencies"
 info "note: upstream RyuGraph dependencies may print deprecation warnings during install"
 NPM_CONFIG_CACHE="$MCP_DIR/.npm-cache" npm --prefix "$MCP_DIR" install --no-fund --no-update-notifier --loglevel=warn
+NPM_CONFIG_CACHE="$REPO_ROOT/scripts/parsers/.npm-cache" npm --prefix "$REPO_ROOT/scripts/parsers" install --no-fund --no-update-notifier --loglevel=warn
 
 step "Indexing repository context"
 "$REPO_ROOT/scripts/ingest.sh"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -36,6 +36,7 @@ mkdir -p "$MCP_DIR/.npm-cache"
 step "Installing MCP dependencies"
 info "note: upstream RyuGraph dependencies may print deprecation warnings during install"
 NPM_CONFIG_CACHE="$MCP_DIR/.npm-cache" npm --prefix "$MCP_DIR" install --no-fund --no-update-notifier --loglevel=warn
+NPM_CONFIG_CACHE="$REPO_ROOT/scripts/parsers/.npm-cache" npm --prefix "$REPO_ROOT/scripts/parsers" install --no-fund --no-update-notifier --loglevel=warn
 
 step "Indexing repository context"
 "$REPO_ROOT/scripts/ingest.sh"


### PR DESCRIPTION
## Problem
  `cortex init --bootstrap` failed during ingest with:
 `node:internal/modules/package_json_reader:268
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'acorn' imported from /Users/nobbe/Repos/cortex/scripts/parsers/javascript.mjs
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:268:9)
    at packageResolve (node:internal/modules/esm/resolve:768:81)
    at moduleResolve (node:internal/modules/esm/resolve:854:18)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:685:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:634:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:617:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:273:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:135:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}`

  ## Root Cause
  Bootstrap installed only `mcp` dependencies, while ingest imports parser deps from `scripts/parsers`.

  ## Fix
  Install parser dependencies during bootstrap in both:
  - `scripts/bootstrap.sh`
  - `scaffold/scripts/bootstrap.sh`

  ## Validation
  Ran `bash scripts/bootstrap.sh` and verified ingest no longer fails with missing `acorn`.