### PR TITLE
feat: multi-level representations (Modules + enriched Chunks)

### DIFF
--- a/.context/ontology.cypher
+++ b/.context/ontology.cypher
@@ -45,10 +45,26 @@ CREATE NODE TABLE IF NOT EXISTS Chunk(
   kind STRING,
   signature STRING,
   body STRING,
+  description STRING,
   start_line INT64,
   end_line INT64,
   language STRING,
+  exported BOOL,
   checksum STRING,
+  updated_at STRING,
+  source_of_truth BOOL,
+  trust_level INT64,
+  status STRING,
+  PRIMARY KEY(id)
+);
+
+CREATE NODE TABLE IF NOT EXISTS Module(
+  id STRING,
+  path STRING,
+  name STRING,
+  summary STRING,
+  file_count INT64,
+  exported_symbols STRING,
   updated_at STRING,
   source_of_truth BOOL,
   trust_level INT64,
@@ -63,3 +79,6 @@ CREATE REL TABLE IF NOT EXISTS SUPERSEDES(FROM ADR TO ADR, reason STRING);
 CREATE REL TABLE IF NOT EXISTS DEFINES(FROM File TO Chunk);
 CREATE REL TABLE IF NOT EXISTS CALLS(FROM Chunk TO Chunk, call_type STRING);
 CREATE REL TABLE IF NOT EXISTS IMPORTS(FROM Chunk TO File, import_name STRING);
+CREATE REL TABLE IF NOT EXISTS CONTAINS(FROM Module TO File);
+CREATE REL TABLE IF NOT EXISTS CONTAINS_MODULE(FROM Module TO Module);
+CREATE REL TABLE IF NOT EXISTS EXPORTS(FROM Module TO Chunk);

--- a/mcp/src/embed.ts
+++ b/mcp/src/embed.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { env, pipeline } from "@xenova/transformers";
+import { readJsonl, asString, asNumber, asBoolean } from "./jsonl.js";
+import type { JsonObject, JsonValue } from "./types.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -16,9 +18,7 @@ const MODEL_CACHE_DIR = path.join(EMBEDDINGS_DIR, "models");
 
 const DEFAULT_MODEL_ID = "Xenova/all-MiniLM-L6-v2";
 const DEFAULT_MAX_TEXT_CHARS = 7000;
-
-type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
-type JsonObject = { [key: string]: JsonValue };
+const CHUNK_BODY_PREVIEW_CHARS = 2000;
 
 type FileEntity = {
   id: string;
@@ -117,18 +117,6 @@ function parseArgs(argv: string[]): { mode: "full" | "changed" } {
   };
 }
 
-function asString(value: JsonValue | undefined, fallback = ""): string {
-  return typeof value === "string" ? value : fallback;
-}
-
-function asNumber(value: JsonValue | undefined, fallback = 0): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
-}
-
-function asBoolean(value: JsonValue | undefined, fallback = false): boolean {
-  return typeof value === "boolean" ? value : fallback;
-}
-
 function hashText(value: string): string {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
@@ -139,26 +127,6 @@ function normalizeText(value: string): string {
 
 function clampText(value: string, maxChars: number): string {
   return value.slice(0, maxChars);
-}
-
-function readJsonl(filePath: string): JsonObject[] {
-  if (!fs.existsSync(filePath)) {
-    return [];
-  }
-
-  return fs
-    .readFileSync(filePath, "utf8")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      try {
-        return JSON.parse(line) as JsonObject;
-      } catch {
-        return null;
-      }
-    })
-    .filter((value): value is JsonObject => value !== null);
 }
 
 function writeJsonl(filePath: string, records: EmbeddingRecord[]): void {
@@ -321,7 +289,7 @@ function parseChunkEntities(raw: JsonObject[], filePathById: Map<string, string>
       const body = asString(item.body);
       const updatedAt = asString(item.updated_at);
       const checksum = asString(item.checksum, hashText(body));
-      const text = clampText(`${filePath}\n${name}\n${sig}\n${description}\n${body.slice(0, 2000)}`, maxChars);
+      const text = clampText(`${filePath}\n${name}\n${sig}\n${description}\n${body.slice(0, CHUNK_BODY_PREVIEW_CHARS)}`, maxChars);
 
       return {
         id,

--- a/mcp/src/embed.ts
+++ b/mcp/src/embed.ts
@@ -62,7 +62,35 @@ type AdrEntity = {
   signature: string;
 };
 
-type SearchEntity = FileEntity | RuleEntity | AdrEntity;
+type ModuleEntity = {
+  id: string;
+  type: "Module";
+  kind: "MODULE";
+  label: string;
+  path: string;
+  status: string;
+  source_of_truth: boolean;
+  trust_level: number;
+  updated_at: string;
+  text: string;
+  signature: string;
+};
+
+type ChunkEntity = {
+  id: string;
+  type: "Chunk";
+  kind: string;
+  label: string;
+  path: string;
+  status: string;
+  source_of_truth: boolean;
+  trust_level: number;
+  updated_at: string;
+  text: string;
+  signature: string;
+};
+
+type SearchEntity = FileEntity | RuleEntity | AdrEntity | ModuleEntity | ChunkEntity;
 
 type EmbeddingRecord = {
   id: string;
@@ -243,6 +271,73 @@ function parseAdrEntities(raw: JsonObject[], maxChars: number): AdrEntity[] {
     .filter((value): value is AdrEntity => value !== null);
 }
 
+function parseModuleEntities(raw: JsonObject[], maxChars: number): ModuleEntity[] {
+  return raw
+    .map((item) => {
+      const id = asString(item.id);
+      if (!id) {
+        return null;
+      }
+
+      const modulePath = asString(item.path);
+      const name = asString(item.name);
+      const summary = asString(item.summary);
+      const exportedSymbols = asString(item.exported_symbols);
+      const updatedAt = asString(item.updated_at);
+      const text = clampText(`${modulePath}\n${name}\n${summary}\n${exportedSymbols}`, maxChars);
+
+      return {
+        id,
+        type: "Module" as const,
+        kind: "MODULE" as const,
+        label: name || modulePath,
+        path: modulePath,
+        status: asString(item.status, "active"),
+        source_of_truth: asBoolean(item.source_of_truth, false),
+        trust_level: asNumber(item.trust_level, 75),
+        updated_at: updatedAt,
+        text,
+        signature: hashText(`module|${id}|${updatedAt}|${hashText(text)}`)
+      };
+    })
+    .filter((value): value is ModuleEntity => value !== null);
+}
+
+function parseChunkEntities(raw: JsonObject[], filePathById: Map<string, string>, maxChars: number): ChunkEntity[] {
+  return raw
+    .map((item) => {
+      const id = asString(item.id);
+      if (!id) {
+        return null;
+      }
+
+      const fileId = asString(item.file_id);
+      const filePath = filePathById.get(fileId) ?? "";
+      const name = asString(item.name);
+      const sig = asString(item.signature);
+      const description = asString(item.description);
+      const body = asString(item.body);
+      const updatedAt = asString(item.updated_at);
+      const checksum = asString(item.checksum, hashText(body));
+      const text = clampText(`${filePath}\n${name}\n${sig}\n${description}\n${body.slice(0, 2000)}`, maxChars);
+
+      return {
+        id,
+        type: "Chunk" as const,
+        kind: asString(item.kind, "chunk"),
+        label: name || id,
+        path: filePath,
+        status: asString(item.status, "active"),
+        source_of_truth: asBoolean(item.source_of_truth, false),
+        trust_level: asNumber(item.trust_level, 60),
+        updated_at: updatedAt,
+        text,
+        signature: hashText(`chunk|${checksum}|${updatedAt}|${hashText(text)}`)
+      };
+    })
+    .filter((value): value is ChunkEntity => value !== null);
+}
+
 function parseExistingEmbeddings(raw: JsonObject[], modelId: string): Map<string, EmbeddingRecord> {
   const index = new Map<string, EmbeddingRecord>();
 
@@ -312,7 +407,16 @@ async function main(): Promise<void> {
   const documents = parseFileEntities(readJsonl(path.join(CACHE_DIR, "documents.jsonl")), maxTextChars);
   const rules = parseRuleEntities(readJsonl(path.join(CACHE_DIR, "entities.rule.jsonl")), maxTextChars);
   const adrs = parseAdrEntities(readJsonl(path.join(CACHE_DIR, "entities.adr.jsonl")), maxTextChars);
-  const entities: SearchEntity[] = [...documents, ...rules, ...adrs].sort((a, b) => a.id.localeCompare(b.id));
+  const modules = parseModuleEntities(readJsonl(path.join(CACHE_DIR, "entities.module.jsonl")), maxTextChars);
+
+  // Build file path lookup for chunk embedding text (reuse already-parsed documents)
+  const filePathById = new Map<string, string>();
+  for (const doc of documents) {
+    filePathById.set(doc.id, doc.path);
+  }
+  const chunks = parseChunkEntities(readJsonl(path.join(CACHE_DIR, "entities.chunk.jsonl")), filePathById, maxTextChars);
+
+  const entities: SearchEntity[] = [...documents, ...rules, ...adrs, ...modules, ...chunks].sort((a, b) => a.id.localeCompare(b.id));
 
   const existing = parseExistingEmbeddings(readJsonl(EMBEDDINGS_PATH), modelId);
 

--- a/mcp/src/embed.ts
+++ b/mcp/src/embed.ts
@@ -62,6 +62,8 @@ type AdrEntity = {
   signature: string;
 };
 
+// Embedding-specific entity types — intentionally different from types.ts records
+// because they carry `text` and `signature` fields used for embedding generation.
 type ModuleEntity = {
   id: string;
   type: "Module";

--- a/mcp/src/graph.ts
+++ b/mcp/src/graph.ts
@@ -9,6 +9,7 @@ import type {
   DocumentRecord,
   JsonObject,
   JsonValue,
+  ModuleRecord,
   RankingWeights,
   RelationRecord,
   RuleRecord,
@@ -164,9 +165,11 @@ function parseChunkEntities(raw: JsonObject[]): ChunkRecord[] {
         kind: asString(item.kind, "chunk"),
         signature: asString(item.signature),
         body: asString(item.body),
+        description: asString(item.description),
         start_line: asNumber(item.start_line),
         end_line: asNumber(item.end_line),
         language: asString(item.language),
+        exported: asBoolean(item.exported, false),
         updated_at: asString(item.updated_at),
         source_of_truth: asBoolean(item.source_of_truth, false),
         trust_level: asNumber(item.trust_level, 60),
@@ -174,6 +177,30 @@ function parseChunkEntities(raw: JsonObject[]): ChunkRecord[] {
       };
     })
     .filter((item): item is ChunkRecord => item !== null);
+}
+
+function parseModuleEntities(raw: JsonObject[]): ModuleRecord[] {
+  return raw
+    .map((item) => {
+      const id = asString(item.id);
+      if (!id) {
+        return null;
+      }
+
+      return {
+        id,
+        path: asString(item.path),
+        name: asString(item.name),
+        summary: asString(item.summary),
+        file_count: asNumber(item.file_count, 0),
+        exported_symbols: asString(item.exported_symbols),
+        updated_at: asString(item.updated_at),
+        source_of_truth: asBoolean(item.source_of_truth, false),
+        trust_level: asNumber(item.trust_level, 75),
+        status: asString(item.status, "active")
+      };
+    })
+    .filter((item): item is ModuleRecord => item !== null);
 }
 
 function parseRuleEntities(raw: JsonObject[]): RuleRecord[] {
@@ -539,9 +566,11 @@ function parseRyuGraphChunks(rows: UnknownRow[]): ChunkRecord[] {
         kind: asStringUnknown(row.kind, "chunk"),
         signature: asStringUnknown(row.signature),
         body: asStringUnknown(row.body),
+        description: asStringUnknown(row.description),
         start_line: asNumberUnknown(row.start_line),
         end_line: asNumberUnknown(row.end_line),
         language: asStringUnknown(row.language),
+        exported: asBooleanUnknown(row.exported, false),
         updated_at: asStringUnknown(row.updated_at),
         source_of_truth: asBooleanUnknown(row.source_of_truth, false),
         trust_level: asNumberUnknown(row.trust_level, 60),
@@ -549,6 +578,30 @@ function parseRyuGraphChunks(rows: UnknownRow[]): ChunkRecord[] {
       };
     })
     .filter((value): value is ChunkRecord => value !== null);
+}
+
+function parseRyuGraphModules(rows: UnknownRow[]): ModuleRecord[] {
+  return rows
+    .map((row) => {
+      const id = asStringUnknown(row.id);
+      if (!id) {
+        return null;
+      }
+
+      return {
+        id,
+        path: asStringUnknown(row.path),
+        name: asStringUnknown(row.name),
+        summary: asStringUnknown(row.summary),
+        file_count: asNumberUnknown(row.file_count, 0),
+        exported_symbols: asStringUnknown(row.exported_symbols),
+        updated_at: asStringUnknown(row.updated_at),
+        source_of_truth: asBooleanUnknown(row.source_of_truth, false),
+        trust_level: asNumberUnknown(row.trust_level, 75),
+        status: asStringUnknown(row.status, "active")
+      };
+    })
+    .filter((value): value is ModuleRecord => value !== null);
 }
 
 function parseRyuGraphRelations(
@@ -578,15 +631,23 @@ export async function loadContextData(): Promise<ContextData> {
   const cachedDocuments = parseDocuments(readJsonl(PATHS.documents));
   const cachedAdrs = parseAdrs(readJsonl(PATHS.adrEntities));
   const cachedChunks = parseChunkEntities(readJsonl(PATHS.chunkEntities));
+  const cachedModules = parseModuleEntities(readJsonl(PATHS.moduleEntities));
   const cachedChunkRelations = [
+    ...parseRelations(readJsonl(PATHS.definesRelations), "DEFINES"),
     ...parseRelations(readJsonl(PATHS.callsRelations), "CALLS", ["call_type"]),
     ...parseRelations(readJsonl(PATHS.importsRelations), "IMPORTS", ["import_name"])
+  ];
+  const cachedModuleRelations = [
+    ...parseRelations(readJsonl(PATHS.containsRelations), "CONTAINS"),
+    ...parseRelations(readJsonl(PATHS.containsModuleRelations), "CONTAINS_MODULE"),
+    ...parseRelations(readJsonl(PATHS.exportsRelations), "EXPORTS")
   ];
   const cachedRelations = [
     ...parseRelations(readJsonl(PATHS.constrainsRelations), "CONSTRAINS"),
     ...parseRelations(readJsonl(PATHS.implementsRelations), "IMPLEMENTS"),
     ...parseRelations(readJsonl(PATHS.supersedesRelations), "SUPERSEDES"),
-    ...cachedChunkRelations
+    ...cachedChunkRelations,
+    ...cachedModuleRelations
   ];
 
   const yamlRules = parseRulesYaml(readFileIfExists(PATHS.rulesYaml));
@@ -600,6 +661,7 @@ export async function loadContextData(): Promise<ContextData> {
       adrs: cachedAdrs,
       rules: cachedRules,
       chunks: cachedChunks,
+      modules: cachedModules,
       relations: cachedRelations,
       ranking,
       source: "cache",
@@ -608,7 +670,7 @@ export async function loadContextData(): Promise<ContextData> {
   }
 
   try {
-    const [fileRows, ruleRows, adrRows, chunkRows, constrainsRows, implementsRows, supersedesRows] =
+    const [fileRows, ruleRows, adrRows, chunkRows, moduleRows, constrainsRows, implementsRows, supersedesRows, definesRows, callsRows, importsRows, containsRows, containsModuleRows, exportsRows] =
       await Promise.all([
         queryRows(
           connection,
@@ -668,13 +730,32 @@ export async function loadContextData(): Promise<ContextData> {
             c.kind AS kind,
             c.signature AS signature,
             c.body AS body,
+            c.description AS description,
             c.start_line AS start_line,
             c.end_line AS end_line,
             c.language AS language,
+            c.exported AS exported,
             c.updated_at AS updated_at,
             c.source_of_truth AS source_of_truth,
             c.trust_level AS trust_level,
             c.status AS status;
+        `
+        ),
+        queryRows(
+          connection,
+          `
+          MATCH (m:Module)
+          RETURN
+            m.id AS id,
+            m.path AS path,
+            m.name AS name,
+            m.summary AS summary,
+            m.file_count AS file_count,
+            m.exported_symbols AS exported_symbols,
+            m.updated_at AS updated_at,
+            m.source_of_truth AS source_of_truth,
+            m.trust_level AS trust_level,
+            m.status AS status;
         `
         ),
         queryRows(
@@ -697,6 +778,48 @@ export async function loadContextData(): Promise<ContextData> {
           MATCH (a1:ADR)-[s:SUPERSEDES]->(a2:ADR)
           RETURN a1.id AS from, a2.id AS to, s.reason AS note;
         `
+        ),
+        queryRows(
+          connection,
+          `
+          MATCH (f:File)-[:DEFINES]->(c:Chunk)
+          RETURN f.id AS from, c.id AS to;
+        `
+        ),
+        queryRows(
+          connection,
+          `
+          MATCH (c1:Chunk)-[ca:CALLS]->(c2:Chunk)
+          RETURN c1.id AS from, c2.id AS to, ca.call_type AS call_type;
+        `
+        ),
+        queryRows(
+          connection,
+          `
+          MATCH (c:Chunk)-[im:IMPORTS]->(f:File)
+          RETURN c.id AS from, f.id AS to, im.import_name AS import_name;
+        `
+        ),
+        queryRows(
+          connection,
+          `
+          MATCH (m:Module)-[:CONTAINS]->(f:File)
+          RETURN m.id AS from, f.id AS to;
+        `
+        ),
+        queryRows(
+          connection,
+          `
+          MATCH (m1:Module)-[:CONTAINS_MODULE]->(m2:Module)
+          RETURN m1.id AS from, m2.id AS to;
+        `
+        ),
+        queryRows(
+          connection,
+          `
+          MATCH (m:Module)-[:EXPORTS]->(c:Chunk)
+          RETURN m.id AS from, c.id AS to;
+        `
         )
       ]);
 
@@ -706,10 +829,17 @@ export async function loadContextData(): Promise<ContextData> {
     const ryuRules = parseRyuGraphRules(ruleRows);
     const ryuAdrs = parseRyuGraphAdrs(adrRows);
     const ryuChunks = parseRyuGraphChunks(chunkRows);
+    const ryuModules = parseRyuGraphModules(moduleRows);
     const ryuRelations = [
       ...parseRyuGraphRelations(constrainsRows, "CONSTRAINS", "note"),
       ...parseRyuGraphRelations(implementsRows, "IMPLEMENTS", "note"),
-      ...parseRyuGraphRelations(supersedesRows, "SUPERSEDES", "note")
+      ...parseRyuGraphRelations(supersedesRows, "SUPERSEDES", "note"),
+      ...parseRyuGraphRelations(definesRows, "DEFINES", "note"),
+      ...parseRyuGraphRelations(callsRows, "CALLS", "call_type"),
+      ...parseRyuGraphRelations(importsRows, "IMPORTS", "import_name"),
+      ...parseRyuGraphRelations(containsRows, "CONTAINS", "note"),
+      ...parseRyuGraphRelations(containsModuleRows, "CONTAINS_MODULE", "note"),
+      ...parseRyuGraphRelations(exportsRows, "EXPORTS", "note")
     ];
 
     return {
@@ -717,7 +847,8 @@ export async function loadContextData(): Promise<ContextData> {
       adrs: ryuAdrs.length > 0 ? ryuAdrs : cachedAdrs,
       rules: ryuRules.length > 0 ? ryuRules : cachedRules,
       chunks: ryuChunks.length > 0 ? ryuChunks : cachedChunks,
-      relations: ryuRelations.length > 0 ? [...ryuRelations, ...cachedChunkRelations] : cachedRelations,
+      modules: ryuModules.length > 0 ? ryuModules : cachedModules,
+      relations: ryuRelations.length > 0 ? ryuRelations : cachedRelations,
       ranking,
       source: "ryu"
     };
@@ -732,6 +863,7 @@ export async function loadContextData(): Promise<ContextData> {
       adrs: cachedAdrs,
       rules: cachedRules,
       chunks: cachedChunks,
+      modules: cachedModules,
       relations: cachedRelations,
       ranking,
       source: "cache",

--- a/mcp/src/graph.ts
+++ b/mcp/src/graph.ts
@@ -670,158 +670,30 @@ export async function loadContextData(): Promise<ContextData> {
   }
 
   try {
-    const [fileRows, ruleRows, adrRows, chunkRows, moduleRows, constrainsRows, implementsRows, supersedesRows, definesRows, callsRows, importsRows, containsRows, containsModuleRows, exportsRows] =
-      await Promise.all([
-        queryRows(
-          connection,
-          `
-          MATCH (f:File)
-          RETURN
-            f.id AS id,
-            f.path AS path,
-            f.kind AS kind,
-            f.excerpt AS excerpt,
-            f.updated_at AS updated_at,
-            f.source_of_truth AS source_of_truth,
-            f.trust_level AS trust_level,
-            f.status AS status;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (r:Rule)
-          RETURN
-            r.id AS id,
-            r.title AS title,
-            r.body AS body,
-            r.scope AS scope,
-            r.priority AS priority,
-            r.updated_at AS updated_at,
-            r.source_of_truth AS source_of_truth,
-            r.trust_level AS trust_level,
-            r.status AS status;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (a:ADR)
-          RETURN
-            a.id AS id,
-            a.path AS path,
-            a.title AS title,
-            a.body AS body,
-            a.decision_date AS decision_date,
-            a.supersedes_id AS supersedes_id,
-            a.source_of_truth AS source_of_truth,
-            a.trust_level AS trust_level,
-            a.status AS status;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (c:Chunk)
-          RETURN
-            c.id AS id,
-            c.file_id AS file_id,
-            c.name AS name,
-            c.kind AS kind,
-            c.signature AS signature,
-            c.body AS body,
-            c.description AS description,
-            c.start_line AS start_line,
-            c.end_line AS end_line,
-            c.language AS language,
-            c.exported AS exported,
-            c.updated_at AS updated_at,
-            c.source_of_truth AS source_of_truth,
-            c.trust_level AS trust_level,
-            c.status AS status;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (m:Module)
-          RETURN
-            m.id AS id,
-            m.path AS path,
-            m.name AS name,
-            m.summary AS summary,
-            m.file_count AS file_count,
-            m.exported_symbols AS exported_symbols,
-            m.updated_at AS updated_at,
-            m.source_of_truth AS source_of_truth,
-            m.trust_level AS trust_level,
-            m.status AS status;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (r:Rule)-[c:CONSTRAINS]->(f:File)
-          RETURN r.id AS from, f.id AS to, c.note AS note;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (f:File)-[i:IMPLEMENTS]->(r:Rule)
-          RETURN f.id AS from, r.id AS to, i.note AS note;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (a1:ADR)-[s:SUPERSEDES]->(a2:ADR)
-          RETURN a1.id AS from, a2.id AS to, s.reason AS note;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (f:File)-[:DEFINES]->(c:Chunk)
-          RETURN f.id AS from, c.id AS to;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (c1:Chunk)-[ca:CALLS]->(c2:Chunk)
-          RETURN c1.id AS from, c2.id AS to, ca.call_type AS call_type;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (c:Chunk)-[im:IMPORTS]->(f:File)
-          RETURN c.id AS from, f.id AS to, im.import_name AS import_name;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (m:Module)-[:CONTAINS]->(f:File)
-          RETURN m.id AS from, f.id AS to;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (m1:Module)-[:CONTAINS_MODULE]->(m2:Module)
-          RETURN m1.id AS from, m2.id AS to;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (m:Module)-[:EXPORTS]->(c:Chunk)
-          RETURN m.id AS from, c.id AS to;
-        `
-        )
-      ]);
+    const ryuQueries = await Promise.all([
+      queryRows(connection, `MATCH (f:File) RETURN f.id AS id, f.path AS path, f.kind AS kind, f.excerpt AS excerpt, f.updated_at AS updated_at, f.source_of_truth AS source_of_truth, f.trust_level AS trust_level, f.status AS status;`),
+      queryRows(connection, `MATCH (r:Rule) RETURN r.id AS id, r.title AS title, r.body AS body, r.scope AS scope, r.priority AS priority, r.updated_at AS updated_at, r.source_of_truth AS source_of_truth, r.trust_level AS trust_level, r.status AS status;`),
+      queryRows(connection, `MATCH (a:ADR) RETURN a.id AS id, a.path AS path, a.title AS title, a.body AS body, a.decision_date AS decision_date, a.supersedes_id AS supersedes_id, a.source_of_truth AS source_of_truth, a.trust_level AS trust_level, a.status AS status;`),
+      queryRows(connection, `MATCH (c:Chunk) RETURN c.id AS id, c.file_id AS file_id, c.name AS name, c.kind AS kind, c.signature AS signature, c.body AS body, c.description AS description, c.start_line AS start_line, c.end_line AS end_line, c.language AS language, c.exported AS exported, c.updated_at AS updated_at, c.source_of_truth AS source_of_truth, c.trust_level AS trust_level, c.status AS status;`),
+      queryRows(connection, `MATCH (m:Module) RETURN m.id AS id, m.path AS path, m.name AS name, m.summary AS summary, m.file_count AS file_count, m.exported_symbols AS exported_symbols, m.updated_at AS updated_at, m.source_of_truth AS source_of_truth, m.trust_level AS trust_level, m.status AS status;`),
+      queryRows(connection, `MATCH (r:Rule)-[c:CONSTRAINS]->(f:File) RETURN r.id AS from, f.id AS to, c.note AS note;`),
+      queryRows(connection, `MATCH (f:File)-[i:IMPLEMENTS]->(r:Rule) RETURN f.id AS from, r.id AS to, i.note AS note;`),
+      queryRows(connection, `MATCH (a1:ADR)-[s:SUPERSEDES]->(a2:ADR) RETURN a1.id AS from, a2.id AS to, s.reason AS note;`),
+      queryRows(connection, `MATCH (f:File)-[:DEFINES]->(c:Chunk) RETURN f.id AS from, c.id AS to;`),
+      queryRows(connection, `MATCH (c1:Chunk)-[ca:CALLS]->(c2:Chunk) RETURN c1.id AS from, c2.id AS to, ca.call_type AS call_type;`),
+      queryRows(connection, `MATCH (c:Chunk)-[im:IMPORTS]->(f:File) RETURN c.id AS from, f.id AS to, im.import_name AS import_name;`),
+      queryRows(connection, `MATCH (m:Module)-[:CONTAINS]->(f:File) RETURN m.id AS from, f.id AS to;`),
+      queryRows(connection, `MATCH (m1:Module)-[:CONTAINS_MODULE]->(m2:Module) RETURN m1.id AS from, m2.id AS to;`),
+      queryRows(connection, `MATCH (m:Module)-[:EXPORTS]->(c:Chunk) RETURN m.id AS from, c.id AS to;`)
+    ]);
+
+    // Named destructuring to avoid positional misalignment with 14 parallel queries
+    const [
+      fileRows, ruleRows, adrRows, chunkRows, moduleRows,          // entities
+      constrainsRows, implementsRows, supersedesRows,               // core relations
+      definesRows, callsRows, importsRows,                          // chunk relations
+      containsRows, containsModuleRows, exportsRows                 // module relations
+    ] = ryuQueries;
 
     const contentById = new Map(cachedDocuments.map((doc) => [doc.id, doc.content]));
 
@@ -848,6 +720,8 @@ export async function loadContextData(): Promise<ContextData> {
       rules: ryuRules.length > 0 ? ryuRules : cachedRules,
       chunks: ryuChunks.length > 0 ? ryuChunks : cachedChunks,
       modules: ryuModules.length > 0 ? ryuModules : cachedModules,
+      // Ryu now queries all relation types (core + chunk + module), so no need
+      // to merge cached chunk/module relations separately.
       relations: ryuRelations.length > 0 ? ryuRelations : cachedRelations,
       ranking,
       source: "ryu"

--- a/mcp/src/graph.ts
+++ b/mcp/src/graph.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import ryugraph, { type Connection, type Database, type QueryResult } from "ryugraph";
+import { readJsonl, asString, asNumber, asBoolean } from "./jsonl.js";
 import { DB_PATH, DEFAULT_RANKING, PATHS } from "./paths.js";
 import type {
   AdrRecord,
@@ -8,10 +9,10 @@ import type {
   ContextData,
   DocumentRecord,
   JsonObject,
-  JsonValue,
   ModuleRecord,
   RankingWeights,
   RelationRecord,
+  RelationType,
   RuleRecord,
   UnknownRow
 } from "./types.js";
@@ -38,38 +39,6 @@ function readFileIfExists(filePath: string): string | null {
     return null;
   }
   return fs.readFileSync(filePath, "utf8");
-}
-
-function readJsonl(filePath: string): JsonObject[] {
-  const raw = readFileIfExists(filePath);
-  if (!raw) {
-    return [];
-  }
-
-  return raw
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      try {
-        return JSON.parse(line) as JsonObject;
-      } catch {
-        return null;
-      }
-    })
-    .filter((value): value is JsonObject => value !== null);
-}
-
-function asString(value: JsonValue | undefined, fallback = ""): string {
-  return typeof value === "string" ? value : fallback;
-}
-
-function asNumber(value: JsonValue | undefined, fallback = 0): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
-}
-
-function asBoolean(value: JsonValue | undefined, fallback = false): boolean {
-  return typeof value === "boolean" ? value : fallback;
 }
 
 function asStringUnknown(value: unknown, fallback = ""): string {
@@ -300,7 +269,7 @@ function parseRulesYaml(yamlText: string | null): RuleRecord[] {
 
 function parseRelations(
   raw: JsonObject[],
-  relation: RelationRecord["relation"],
+  relation: RelationType,
   noteFields: string[] = ["note", "reason"]
 ): RelationRecord[] {
   return raw
@@ -606,7 +575,7 @@ function parseRyuGraphModules(rows: UnknownRow[]): ModuleRecord[] {
 
 function parseRyuGraphRelations(
   rows: UnknownRow[],
-  relation: RelationRecord["relation"],
+  relation: RelationType,
   noteField: string
 ): RelationRecord[] {
   return rows

--- a/mcp/src/jsonl.ts
+++ b/mcp/src/jsonl.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import type { JsonObject, JsonValue } from "./types.js";
+
+export function readJsonl(filePath: string): JsonObject[] {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+
+  return fs
+    .readFileSync(filePath, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as JsonObject;
+      } catch {
+        return null;
+      }
+    })
+    .filter((value): value is JsonObject => value !== null);
+}
+
+export function asString(value: JsonValue | undefined, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+export function asNumber(value: JsonValue | undefined, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export function asBoolean(value: JsonValue | undefined, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}

--- a/mcp/src/loadGraph.ts
+++ b/mcp/src/loadGraph.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import ryugraph, { type Connection, type QueryResult } from "ryugraph";
+import ryugraph, { type Connection, type PreparedStatement, type QueryResult, type RyuValue } from "ryugraph";
+import { readJsonl, asString, asNumber, asBoolean } from "./jsonl.js";
+import type { JsonObject } from "./types.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10,9 +12,19 @@ const CONTEXT_DIR = path.join(REPO_ROOT, ".context");
 const CACHE_DIR = path.join(CONTEXT_DIR, "cache");
 const DB_PATH = path.join(CONTEXT_DIR, "db", "graph.ryu");
 const ONTOLOGY_PATH = path.join(CONTEXT_DIR, "ontology.cypher");
+const BATCH_SIZE = 50;
 
-type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
-type JsonObject = { [key: string]: JsonValue };
+async function executeBatch(
+  conn: Connection,
+  statement: PreparedStatement,
+  items: Record<string, RyuValue>[],
+  batchSize = BATCH_SIZE
+): Promise<void> {
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    await Promise.all(batch.map((item) => conn.execute(statement, item)));
+  }
+}
 
 type FileEntity = {
   id: string;
@@ -99,38 +111,6 @@ type ImportRelation = {
   to: string;
   import_name: string;
 };
-
-function asString(value: JsonValue | undefined, fallback = ""): string {
-  return typeof value === "string" ? value : fallback;
-}
-
-function asNumber(value: JsonValue | undefined, fallback = 0): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
-}
-
-function asBoolean(value: JsonValue | undefined, fallback = false): boolean {
-  return typeof value === "boolean" ? value : fallback;
-}
-
-function readJsonl(filePath: string): JsonObject[] {
-  if (!fs.existsSync(filePath)) {
-    return [];
-  }
-
-  return fs
-    .readFileSync(filePath, "utf8")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      try {
-        return JSON.parse(line) as JsonObject;
-      } catch {
-        return null;
-      }
-    })
-    .filter((value): value is JsonObject => value !== null);
-}
 
 function readEntityFile(fileName: string): JsonObject[] {
   return readJsonl(path.join(CACHE_DIR, fileName));
@@ -576,71 +556,27 @@ async function main(): Promise<void> {
     CREATE (m)-[:EXPORTS]->(c);
   `);
 
-  for (const entity of fileEntities) {
-    await conn.execute(insertFile, entity);
-  }
+  // Insert all nodes first (batched for performance)
+  await executeBatch(conn, insertFile, fileEntities);
+  await executeBatch(conn, insertRule, ruleEntities.map((e) => ({
+    id: e.id, title: e.title, body: e.body, scope: e.scope,
+    priority: e.priority, updated_at: e.updated_at,
+    source_of_truth: e.source_of_truth, trust_level: e.trust_level, status: e.status
+  })));
+  await executeBatch(conn, insertAdr, adrEntities);
+  await executeBatch(conn, insertChunk, chunkEntities);
+  await executeBatch(conn, insertModule, moduleEntities);
 
-  for (const entity of ruleEntities) {
-    await conn.execute(insertRule, {
-      id: entity.id,
-      title: entity.title,
-      body: entity.body,
-      scope: entity.scope,
-      priority: entity.priority,
-      updated_at: entity.updated_at,
-      source_of_truth: entity.source_of_truth,
-      trust_level: entity.trust_level,
-      status: entity.status
-    });
-  }
-
-  for (const entity of adrEntities) {
-    await conn.execute(insertAdr, entity);
-  }
-
-  for (const entity of chunkEntities) {
-    await conn.execute(insertChunk, entity);
-  }
-
-  for (const edge of defines) {
-    await conn.execute(insertDefines, edge);
-  }
-
-  for (const edge of calls) {
-    await conn.execute(insertCalls, edge);
-  }
-
-  for (const edge of imports) {
-    await conn.execute(insertImports, edge);
-  }
-
-  for (const edge of constrains) {
-    await conn.execute(insertConstrains, edge);
-  }
-
-  for (const edge of implementsEdges) {
-    await conn.execute(insertImplements, edge);
-  }
-
-  for (const edge of supersedes) {
-    await conn.execute(insertSupersedes, edge);
-  }
-
-  for (const entity of moduleEntities) {
-    await conn.execute(insertModule, entity);
-  }
-
-  for (const edge of contains) {
-    await conn.execute(insertContains, edge);
-  }
-
-  for (const edge of containsModule) {
-    await conn.execute(insertContainsModule, edge);
-  }
-
-  for (const edge of exports) {
-    await conn.execute(insertExports, edge);
-  }
+  // Insert all edges (nodes must exist first)
+  await executeBatch(conn, insertDefines, defines);
+  await executeBatch(conn, insertCalls, calls);
+  await executeBatch(conn, insertImports, imports);
+  await executeBatch(conn, insertConstrains, constrains);
+  await executeBatch(conn, insertImplements, implementsEdges);
+  await executeBatch(conn, insertSupersedes, supersedes);
+  await executeBatch(conn, insertContains, contains);
+  await executeBatch(conn, insertContainsModule, containsModule);
+  await executeBatch(conn, insertExports, exports);
 
   const fileCount = await rows(await conn.query("MATCH (f:File) RETURN count(*) AS count;"));
   const ruleCount = await rows(await conn.query("MATCH (r:Rule) RETURN count(*) AS count;"));

--- a/mcp/src/loadGraph.ts
+++ b/mcp/src/loadGraph.ts
@@ -57,10 +57,25 @@ type ChunkEntity = {
   kind: string;
   signature: string;
   body: string;
+  description: string;
   start_line: number;
   end_line: number;
   language: string;
+  exported: boolean;
   checksum: string;
+  updated_at: string;
+  source_of_truth: boolean;
+  trust_level: number;
+  status: string;
+};
+
+type ModuleEntity = {
+  id: string;
+  path: string;
+  name: string;
+  summary: string;
+  file_count: number;
+  exported_symbols: string;
   updated_at: string;
   source_of_truth: boolean;
   trust_level: number;
@@ -208,9 +223,11 @@ function parseChunks(raw: JsonObject[]): ChunkEntity[] {
         kind: asString(item.kind, "function"),
         signature: asString(item.signature),
         body: asString(item.body),
+        description: asString(item.description),
         start_line: asNumber(item.start_line, 0),
         end_line: asNumber(item.end_line, 0),
         language: asString(item.language, "javascript"),
+        exported: asBoolean(item.exported, false),
         checksum: asString(item.checksum),
         updated_at: asString(item.updated_at),
         source_of_truth: asBoolean(item.source_of_truth, true),
@@ -219,6 +236,30 @@ function parseChunks(raw: JsonObject[]): ChunkEntity[] {
       };
     })
     .filter((value): value is ChunkEntity => value !== null);
+}
+
+function parseModules(raw: JsonObject[]): ModuleEntity[] {
+  return raw
+    .map((item) => {
+      const id = asString(item.id);
+      if (!id) {
+        return null;
+      }
+
+      return {
+        id,
+        path: asString(item.path),
+        name: asString(item.name),
+        summary: asString(item.summary),
+        file_count: asNumber(item.file_count, 0),
+        exported_symbols: asString(item.exported_symbols),
+        updated_at: asString(item.updated_at),
+        source_of_truth: asBoolean(item.source_of_truth, false),
+        trust_level: asNumber(item.trust_level, 75),
+        status: asString(item.status, "active")
+      };
+    })
+    .filter((value): value is ModuleEntity => value !== null);
 }
 
 function parseRelations(fileName: string, noteField: string): Relation[] {
@@ -339,21 +380,25 @@ async function ensureRequiredFiles(): Promise<void> {
   }
 }
 
-function warnIfOptionalChunkFilesMissing(): void {
-  const optionalChunkFiles = [
+function warnIfOptionalFilesMissing(): void {
+  const optionalFiles = [
     "entities.chunk.jsonl",
     "relations.defines.jsonl",
     "relations.calls.jsonl",
-    "relations.imports.jsonl"
+    "relations.imports.jsonl",
+    "entities.module.jsonl",
+    "relations.contains.jsonl",
+    "relations.contains_module.jsonl",
+    "relations.exports.jsonl"
   ];
 
-  const missing = optionalChunkFiles.filter((fileName) => !fs.existsSync(path.join(CACHE_DIR, fileName)));
+  const missing = optionalFiles.filter((fileName) => !fs.existsSync(path.join(CACHE_DIR, fileName)));
   if (missing.length === 0) {
     return;
   }
 
   console.warn(
-    `[graph-load] warning: missing optional chunk files (${missing.join(", ")}); continuing without chunk nodes/relations`
+    `[graph-load] warning: missing optional files (${missing.join(", ")}); continuing without those nodes/relations`
   );
 }
 
@@ -362,7 +407,7 @@ async function main(): Promise<void> {
   const reset = !args.has("--no-reset");
 
   await ensureRequiredFiles();
-  warnIfOptionalChunkFilesMissing();
+  warnIfOptionalFilesMissing();
 
   if (reset) {
     fs.rmSync(DB_PATH, { recursive: true, force: true });
@@ -381,9 +426,13 @@ async function main(): Promise<void> {
   await conn.query("MATCH (f:File)-[d:DEFINES]->(c:Chunk) DELETE d;");
   await conn.query("MATCH (c1:Chunk)-[ca:CALLS]->(c2:Chunk) DELETE ca;");
   await conn.query("MATCH (c:Chunk)-[im:IMPORTS]->(f:File) DELETE im;");
+  await conn.query("MATCH (m:Module)-[co:CONTAINS]->(f:File) DELETE co;");
+  await conn.query("MATCH (m1:Module)-[cm:CONTAINS_MODULE]->(m2:Module) DELETE cm;");
+  await conn.query("MATCH (m:Module)-[ex:EXPORTS]->(c:Chunk) DELETE ex;");
   await conn.query("MATCH (n:ADR) DELETE n;");
   await conn.query("MATCH (n:Rule) DELETE n;");
   await conn.query("MATCH (n:Chunk) DELETE n;");
+  await conn.query("MATCH (n:Module) DELETE n;");
   await conn.query("MATCH (n:File) DELETE n;");
 
   const fileEntities = parseFiles(readEntityFile("entities.file.jsonl"));
@@ -396,6 +445,10 @@ async function main(): Promise<void> {
   const defines = parseSimpleRelations("relations.defines.jsonl");
   const calls = parseCallRelations("relations.calls.jsonl");
   const imports = parseImportRelations("relations.imports.jsonl");
+  const moduleEntities = parseModules(readEntityFile("entities.module.jsonl"));
+  const contains = parseSimpleRelations("relations.contains.jsonl");
+  const containsModule = parseSimpleRelations("relations.contains_module.jsonl");
+  const exports = parseSimpleRelations("relations.exports.jsonl");
 
   const insertFile = await conn.prepare(`
     CREATE (f:File {
@@ -447,9 +500,11 @@ async function main(): Promise<void> {
       kind: $kind,
       signature: $signature,
       body: $body,
+      description: $description,
       start_line: $start_line,
       end_line: $end_line,
       language: $language,
+      exported: $exported,
       checksum: $checksum,
       updated_at: $updated_at,
       source_of_truth: $source_of_truth,
@@ -486,6 +541,36 @@ async function main(): Promise<void> {
   const insertImports = await conn.prepare(`
     MATCH (c:Chunk {id: $from}), (f:File {id: $to})
     CREATE (c)-[:IMPORTS {import_name: $import_name}]->(f);
+  `);
+
+  const insertModule = await conn.prepare(`
+    CREATE (m:Module {
+      id: $id,
+      path: $path,
+      name: $name,
+      summary: $summary,
+      file_count: $file_count,
+      exported_symbols: $exported_symbols,
+      updated_at: $updated_at,
+      source_of_truth: $source_of_truth,
+      trust_level: $trust_level,
+      status: $status
+    });
+  `);
+
+  const insertContains = await conn.prepare(`
+    MATCH (m:Module {id: $from}), (f:File {id: $to})
+    CREATE (m)-[:CONTAINS]->(f);
+  `);
+
+  const insertContainsModule = await conn.prepare(`
+    MATCH (m1:Module {id: $from}), (m2:Module {id: $to})
+    CREATE (m1)-[:CONTAINS_MODULE]->(m2);
+  `);
+
+  const insertExports = await conn.prepare(`
+    MATCH (m:Module {id: $from}), (c:Chunk {id: $to})
+    CREATE (m)-[:EXPORTS]->(c);
   `);
 
   for (const entity of fileEntities) {
@@ -538,6 +623,22 @@ async function main(): Promise<void> {
     await conn.execute(insertSupersedes, edge);
   }
 
+  for (const entity of moduleEntities) {
+    await conn.execute(insertModule, entity);
+  }
+
+  for (const edge of contains) {
+    await conn.execute(insertContains, edge);
+  }
+
+  for (const edge of containsModule) {
+    await conn.execute(insertContainsModule, edge);
+  }
+
+  for (const edge of exports) {
+    await conn.execute(insertExports, edge);
+  }
+
   const fileCount = await rows(await conn.query("MATCH (f:File) RETURN count(*) AS count;"));
   const ruleCount = await rows(await conn.query("MATCH (r:Rule) RETURN count(*) AS count;"));
   const adrCount = await rows(await conn.query("MATCH (a:ADR) RETURN count(*) AS count;"));
@@ -560,6 +661,16 @@ async function main(): Promise<void> {
   const importsCount = await rows(
     await conn.query("MATCH (:Chunk)-[im:IMPORTS]->(:File) RETURN count(im) AS count;")
   );
+  const moduleCount = await rows(await conn.query("MATCH (m:Module) RETURN count(*) AS count;"));
+  const containsCount = await rows(
+    await conn.query("MATCH (:Module)-[co:CONTAINS]->(:File) RETURN count(co) AS count;")
+  );
+  const containsModuleCount = await rows(
+    await conn.query("MATCH (:Module)-[cm:CONTAINS_MODULE]->(:Module) RETURN count(cm) AS count;")
+  );
+  const exportsCount = await rows(
+    await conn.query("MATCH (:Module)-[ex:EXPORTS]->(:Chunk) RETURN count(ex) AS count;")
+  );
 
   const summary = {
     generated_at: new Date().toISOString(),
@@ -574,7 +685,11 @@ async function main(): Promise<void> {
       supersedes: Number(supersedesCount[0]?.count ?? 0),
       defines: Number(definesCount[0]?.count ?? 0),
       calls: Number(callsCount[0]?.count ?? 0),
-      imports: Number(importsCount[0]?.count ?? 0)
+      imports: Number(importsCount[0]?.count ?? 0),
+      modules: Number(moduleCount[0]?.count ?? 0),
+      contains: Number(containsCount[0]?.count ?? 0),
+      contains_module: Number(containsModuleCount[0]?.count ?? 0),
+      exports: Number(exportsCount[0]?.count ?? 0)
     }
   };
 
@@ -583,13 +698,16 @@ async function main(): Promise<void> {
 
   console.log(`[graph-load] db_path=${DB_PATH}`);
   console.log(
-    `[graph-load] files=${summary.counts.files} rules=${summary.counts.rules} adrs=${summary.counts.adrs} chunks=${summary.counts.chunks}`
+    `[graph-load] files=${summary.counts.files} rules=${summary.counts.rules} adrs=${summary.counts.adrs} chunks=${summary.counts.chunks} modules=${summary.counts.modules}`
   );
   console.log(
     `[graph-load] rels constrains=${summary.counts.constrains} implements=${summary.counts.implements} supersedes=${summary.counts.supersedes}`
   );
   console.log(
     `[graph-load] rels defines=${summary.counts.defines} calls=${summary.counts.calls} imports=${summary.counts.imports}`
+  );
+  console.log(
+    `[graph-load] rels contains=${summary.counts.contains} contains_module=${summary.counts.contains_module} exports=${summary.counts.exports}`
   );
   console.log(`[graph-load] manifest=${summaryPath}`);
 

--- a/mcp/src/loadGraph.ts
+++ b/mcp/src/loadGraph.ts
@@ -420,6 +420,7 @@ async function main(): Promise<void> {
   const ontologyStatements = parseOntologyStatements(fs.readFileSync(ONTOLOGY_PATH, "utf8"));
   await executeStatements(conn, ontologyStatements);
 
+  // Delete all relations first, then all nodes, to avoid orphaned edges
   await conn.query("MATCH (a:ADR)-[r:SUPERSEDES]->(b:ADR) DELETE r;");
   await conn.query("MATCH (f:File)-[i:IMPLEMENTS]->(r:Rule) DELETE i;");
   await conn.query("MATCH (r:Rule)-[c:CONSTRAINS]->(f:File) DELETE c;");
@@ -429,6 +430,8 @@ async function main(): Promise<void> {
   await conn.query("MATCH (m:Module)-[co:CONTAINS]->(f:File) DELETE co;");
   await conn.query("MATCH (m1:Module)-[cm:CONTAINS_MODULE]->(m2:Module) DELETE cm;");
   await conn.query("MATCH (m:Module)-[ex:EXPORTS]->(c:Chunk) DELETE ex;");
+
+  // Now delete all nodes
   await conn.query("MATCH (n:ADR) DELETE n;");
   await conn.query("MATCH (n:Rule) DELETE n;");
   await conn.query("MATCH (n:Chunk) DELETE n;");

--- a/mcp/src/paths.ts
+++ b/mcp/src/paths.ts
@@ -28,7 +28,12 @@ export const PATHS = {
   implementsRelations: path.join(CACHE_DIR, "relations.implements.jsonl"),
   supersedesRelations: path.join(CACHE_DIR, "relations.supersedes.jsonl"),
   callsRelations: path.join(CACHE_DIR, "relations.calls.jsonl"),
-  importsRelations: path.join(CACHE_DIR, "relations.imports.jsonl")
+  definesRelations: path.join(CACHE_DIR, "relations.defines.jsonl"),
+  importsRelations: path.join(CACHE_DIR, "relations.imports.jsonl"),
+  moduleEntities: path.join(CACHE_DIR, "entities.module.jsonl"),
+  containsRelations: path.join(CACHE_DIR, "relations.contains.jsonl"),
+  containsModuleRelations: path.join(CACHE_DIR, "relations.contains_module.jsonl"),
+  exportsRelations: path.join(CACHE_DIR, "relations.exports.jsonl")
 };
 
 export const DEFAULT_RANKING: RankingWeights = {

--- a/mcp/src/search.ts
+++ b/mcp/src/search.ts
@@ -217,14 +217,32 @@ function buildSearchEntities(data: ContextData, includeContent: boolean): Search
       kind: chunk.kind || "chunk",
       label: chunk.name || chunk.id,
       path: filePath,
-      text: `${filePath}\n${chunk.name}\n${chunk.signature}\n${chunk.body}`,
+      text: `${filePath}\n${chunk.name}\n${chunk.signature}\n${chunk.description}\n${chunk.body}`,
       status: chunk.status,
       source_of_truth: chunk.source_of_truth,
       trust_level: chunk.trust_level,
       updated_at: chunk.updated_at,
-      snippet: chunk.body.slice(0, 500),
+      snippet: chunk.description || chunk.body.slice(0, 500),
       matched_rules: fileRuleLinks.get(chunk.file_id) ?? [],
       content: includeContent ? chunk.body : undefined
+    });
+  }
+
+  for (const module of data.modules) {
+    entities.push({
+      id: module.id,
+      entity_type: "Module",
+      kind: "MODULE",
+      label: module.name,
+      path: module.path,
+      text: `${module.path}\n${module.name}\n${module.summary}\n${module.exported_symbols}`,
+      status: module.status,
+      source_of_truth: module.source_of_truth,
+      trust_level: module.trust_level,
+      updated_at: module.updated_at,
+      snippet: module.summary.slice(0, 500),
+      matched_rules: [],
+      content: includeContent ? module.summary : undefined
     });
   }
 
@@ -329,6 +347,17 @@ function entityCatalog(data: ContextData): Map<string, JsonObject> {
       chunkEntity.path = filePath;
     }
     catalog.set(chunk.id, chunkEntity);
+  }
+
+  for (const module of data.modules) {
+    catalog.set(module.id, {
+      id: module.id,
+      type: "Module",
+      label: module.name,
+      status: module.status,
+      source_of_truth: module.source_of_truth,
+      path: module.path
+    });
   }
 
   return catalog;

--- a/mcp/src/search.ts
+++ b/mcp/src/search.ts
@@ -240,7 +240,7 @@ function buildSearchEntities(data: ContextData, includeContent: boolean): Search
       source_of_truth: module.source_of_truth,
       trust_level: module.trust_level,
       updated_at: module.updated_at,
-      snippet: module.summary.slice(0, 500),
+      snippet: (module.summary || "").slice(0, 500),
       matched_rules: [],
       content: includeContent ? module.summary : undefined
     });

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -38,10 +38,22 @@ export type AdrRecord = {
   status: string;
 };
 
+export type RelationType =
+  | "CONSTRAINS"
+  | "IMPLEMENTS"
+  | "SUPERSEDES"
+  | "DEFINES"
+  | "CALLS"
+  | "IMPORTS"
+  | "PART_OF"
+  | "CONTAINS"
+  | "CONTAINS_MODULE"
+  | "EXPORTS";
+
 export type RelationRecord = {
   from: string;
   to: string;
-  relation: "CONSTRAINS" | "IMPLEMENTS" | "SUPERSEDES" | "DEFINES" | "CALLS" | "IMPORTS" | "PART_OF" | "CONTAINS" | "CONTAINS_MODULE" | "EXPORTS";
+  relation: RelationType;
   note: string;
 };
 

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -41,7 +41,7 @@ export type AdrRecord = {
 export type RelationRecord = {
   from: string;
   to: string;
-  relation: "CONSTRAINS" | "IMPLEMENTS" | "SUPERSEDES" | "CALLS" | "IMPORTS" | "PART_OF";
+  relation: "CONSTRAINS" | "IMPLEMENTS" | "SUPERSEDES" | "DEFINES" | "CALLS" | "IMPORTS" | "PART_OF" | "CONTAINS" | "CONTAINS_MODULE" | "EXPORTS";
   note: string;
 };
 
@@ -52,9 +52,24 @@ export type ChunkRecord = {
   kind: string;
   signature: string;
   body: string;
+  description: string;
   start_line: number;
   end_line: number;
   language: string;
+  exported: boolean;
+  updated_at: string;
+  source_of_truth: boolean;
+  trust_level: number;
+  status: string;
+};
+
+export type ModuleRecord = {
+  id: string;
+  path: string;
+  name: string;
+  summary: string;
+  file_count: number;
+  exported_symbols: string;
   updated_at: string;
   source_of_truth: boolean;
   trust_level: number;
@@ -73,6 +88,7 @@ export type ContextData = {
   adrs: AdrRecord[];
   rules: RuleRecord[];
   chunks: ChunkRecord[];
+  modules: ModuleRecord[];
   relations: RelationRecord[];
   ranking: RankingWeights;
   source: "cache" | "ryu";
@@ -81,7 +97,7 @@ export type ContextData = {
 
 export type SearchEntity = {
   id: string;
-  entity_type: "File" | "Rule" | "ADR" | "Chunk";
+  entity_type: "File" | "Rule" | "ADR" | "Chunk" | "Module";
   kind: string;
   label: string;
   path: string;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "docs/MCP_MARKETPLACE.md"
   ],
   "scripts": {
-    "test": "node tests/plan-state.test.mjs",
+    "test": "node tests/plan-state.test.mjs && node --test tests/ingest-units.test.mjs tests/javascript-parser.test.mjs tests/multi-level.test.mjs",
     "release:sync-version": "node scripts/sync-release-version.mjs",
     "release:check-version-sync": "node scripts/sync-release-version.mjs --check",
     "prepublishOnly": "echo 'Ready to publish to npm'"

--- a/scaffold/mcp/src/embed.ts
+++ b/scaffold/mcp/src/embed.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { env, pipeline } from "@xenova/transformers";
+import { readJsonl, asString, asNumber, asBoolean } from "./jsonl.js";
+import type { JsonObject, JsonValue } from "./types.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -16,9 +18,7 @@ const MODEL_CACHE_DIR = path.join(EMBEDDINGS_DIR, "models");
 
 const DEFAULT_MODEL_ID = "Xenova/all-MiniLM-L6-v2";
 const DEFAULT_MAX_TEXT_CHARS = 7000;
-
-type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
-type JsonObject = { [key: string]: JsonValue };
+const CHUNK_BODY_PREVIEW_CHARS = 2000;
 
 type FileEntity = {
   id: string;
@@ -62,7 +62,37 @@ type AdrEntity = {
   signature: string;
 };
 
-type SearchEntity = FileEntity | RuleEntity | AdrEntity;
+// Embedding-specific entity types — intentionally different from types.ts records
+// because they carry `text` and `signature` fields used for embedding generation.
+type ModuleEntity = {
+  id: string;
+  type: "Module";
+  kind: "MODULE";
+  label: string;
+  path: string;
+  status: string;
+  source_of_truth: boolean;
+  trust_level: number;
+  updated_at: string;
+  text: string;
+  signature: string;
+};
+
+type ChunkEntity = {
+  id: string;
+  type: "Chunk";
+  kind: string;
+  label: string;
+  path: string;
+  status: string;
+  source_of_truth: boolean;
+  trust_level: number;
+  updated_at: string;
+  text: string;
+  signature: string;
+};
+
+type SearchEntity = FileEntity | RuleEntity | AdrEntity | ModuleEntity | ChunkEntity;
 
 type EmbeddingRecord = {
   id: string;
@@ -87,18 +117,6 @@ function parseArgs(argv: string[]): { mode: "full" | "changed" } {
   };
 }
 
-function asString(value: JsonValue | undefined, fallback = ""): string {
-  return typeof value === "string" ? value : fallback;
-}
-
-function asNumber(value: JsonValue | undefined, fallback = 0): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
-}
-
-function asBoolean(value: JsonValue | undefined, fallback = false): boolean {
-  return typeof value === "boolean" ? value : fallback;
-}
-
 function hashText(value: string): string {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
@@ -109,26 +127,6 @@ function normalizeText(value: string): string {
 
 function clampText(value: string, maxChars: number): string {
   return value.slice(0, maxChars);
-}
-
-function readJsonl(filePath: string): JsonObject[] {
-  if (!fs.existsSync(filePath)) {
-    return [];
-  }
-
-  return fs
-    .readFileSync(filePath, "utf8")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      try {
-        return JSON.parse(line) as JsonObject;
-      } catch {
-        return null;
-      }
-    })
-    .filter((value): value is JsonObject => value !== null);
 }
 
 function writeJsonl(filePath: string, records: EmbeddingRecord[]): void {
@@ -243,6 +241,73 @@ function parseAdrEntities(raw: JsonObject[], maxChars: number): AdrEntity[] {
     .filter((value): value is AdrEntity => value !== null);
 }
 
+function parseModuleEntities(raw: JsonObject[], maxChars: number): ModuleEntity[] {
+  return raw
+    .map((item) => {
+      const id = asString(item.id);
+      if (!id) {
+        return null;
+      }
+
+      const modulePath = asString(item.path);
+      const name = asString(item.name);
+      const summary = asString(item.summary);
+      const exportedSymbols = asString(item.exported_symbols);
+      const updatedAt = asString(item.updated_at);
+      const text = clampText(`${modulePath}\n${name}\n${summary}\n${exportedSymbols}`, maxChars);
+
+      return {
+        id,
+        type: "Module" as const,
+        kind: "MODULE" as const,
+        label: name || modulePath,
+        path: modulePath,
+        status: asString(item.status, "active"),
+        source_of_truth: asBoolean(item.source_of_truth, false),
+        trust_level: asNumber(item.trust_level, 75),
+        updated_at: updatedAt,
+        text,
+        signature: hashText(`module|${id}|${updatedAt}|${hashText(text)}`)
+      };
+    })
+    .filter((value): value is ModuleEntity => value !== null);
+}
+
+function parseChunkEntities(raw: JsonObject[], filePathById: Map<string, string>, maxChars: number): ChunkEntity[] {
+  return raw
+    .map((item) => {
+      const id = asString(item.id);
+      if (!id) {
+        return null;
+      }
+
+      const fileId = asString(item.file_id);
+      const filePath = filePathById.get(fileId) ?? "";
+      const name = asString(item.name);
+      const sig = asString(item.signature);
+      const description = asString(item.description);
+      const body = asString(item.body);
+      const updatedAt = asString(item.updated_at);
+      const checksum = asString(item.checksum, hashText(body));
+      const text = clampText(`${filePath}\n${name}\n${sig}\n${description}\n${body.slice(0, CHUNK_BODY_PREVIEW_CHARS)}`, maxChars);
+
+      return {
+        id,
+        type: "Chunk" as const,
+        kind: asString(item.kind, "chunk"),
+        label: name || id,
+        path: filePath,
+        status: asString(item.status, "active"),
+        source_of_truth: asBoolean(item.source_of_truth, false),
+        trust_level: asNumber(item.trust_level, 60),
+        updated_at: updatedAt,
+        text,
+        signature: hashText(`chunk|${checksum}|${updatedAt}|${hashText(text)}`)
+      };
+    })
+    .filter((value): value is ChunkEntity => value !== null);
+}
+
 function parseExistingEmbeddings(raw: JsonObject[], modelId: string): Map<string, EmbeddingRecord> {
   const index = new Map<string, EmbeddingRecord>();
 
@@ -312,7 +377,16 @@ async function main(): Promise<void> {
   const documents = parseFileEntities(readJsonl(path.join(CACHE_DIR, "documents.jsonl")), maxTextChars);
   const rules = parseRuleEntities(readJsonl(path.join(CACHE_DIR, "entities.rule.jsonl")), maxTextChars);
   const adrs = parseAdrEntities(readJsonl(path.join(CACHE_DIR, "entities.adr.jsonl")), maxTextChars);
-  const entities: SearchEntity[] = [...documents, ...rules, ...adrs].sort((a, b) => a.id.localeCompare(b.id));
+  const modules = parseModuleEntities(readJsonl(path.join(CACHE_DIR, "entities.module.jsonl")), maxTextChars);
+
+  // Build file path lookup for chunk embedding text (reuse already-parsed documents)
+  const filePathById = new Map<string, string>();
+  for (const doc of documents) {
+    filePathById.set(doc.id, doc.path);
+  }
+  const chunks = parseChunkEntities(readJsonl(path.join(CACHE_DIR, "entities.chunk.jsonl")), filePathById, maxTextChars);
+
+  const entities: SearchEntity[] = [...documents, ...rules, ...adrs, ...modules, ...chunks].sort((a, b) => a.id.localeCompare(b.id));
 
   const existing = parseExistingEmbeddings(readJsonl(EMBEDDINGS_PATH), modelId);
 

--- a/scaffold/mcp/src/graph.ts
+++ b/scaffold/mcp/src/graph.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import ryugraph, { type Connection, type Database, type QueryResult } from "ryugraph";
+import { readJsonl, asString, asNumber, asBoolean } from "./jsonl.js";
 import { DB_PATH, DEFAULT_RANKING, PATHS } from "./paths.js";
 import type {
   AdrRecord,
@@ -8,9 +9,10 @@ import type {
   ContextData,
   DocumentRecord,
   JsonObject,
-  JsonValue,
+  ModuleRecord,
   RankingWeights,
   RelationRecord,
+  RelationType,
   RuleRecord,
   UnknownRow
 } from "./types.js";
@@ -37,38 +39,6 @@ function readFileIfExists(filePath: string): string | null {
     return null;
   }
   return fs.readFileSync(filePath, "utf8");
-}
-
-function readJsonl(filePath: string): JsonObject[] {
-  const raw = readFileIfExists(filePath);
-  if (!raw) {
-    return [];
-  }
-
-  return raw
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      try {
-        return JSON.parse(line) as JsonObject;
-      } catch {
-        return null;
-      }
-    })
-    .filter((value): value is JsonObject => value !== null);
-}
-
-function asString(value: JsonValue | undefined, fallback = ""): string {
-  return typeof value === "string" ? value : fallback;
-}
-
-function asNumber(value: JsonValue | undefined, fallback = 0): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
-}
-
-function asBoolean(value: JsonValue | undefined, fallback = false): boolean {
-  return typeof value === "boolean" ? value : fallback;
 }
 
 function asStringUnknown(value: unknown, fallback = ""): string {
@@ -164,9 +134,11 @@ function parseChunkEntities(raw: JsonObject[]): ChunkRecord[] {
         kind: asString(item.kind, "chunk"),
         signature: asString(item.signature),
         body: asString(item.body),
+        description: asString(item.description),
         start_line: asNumber(item.start_line),
         end_line: asNumber(item.end_line),
         language: asString(item.language),
+        exported: asBoolean(item.exported, false),
         updated_at: asString(item.updated_at),
         source_of_truth: asBoolean(item.source_of_truth, false),
         trust_level: asNumber(item.trust_level, 60),
@@ -174,6 +146,30 @@ function parseChunkEntities(raw: JsonObject[]): ChunkRecord[] {
       };
     })
     .filter((item): item is ChunkRecord => item !== null);
+}
+
+function parseModuleEntities(raw: JsonObject[]): ModuleRecord[] {
+  return raw
+    .map((item) => {
+      const id = asString(item.id);
+      if (!id) {
+        return null;
+      }
+
+      return {
+        id,
+        path: asString(item.path),
+        name: asString(item.name),
+        summary: asString(item.summary),
+        file_count: asNumber(item.file_count, 0),
+        exported_symbols: asString(item.exported_symbols),
+        updated_at: asString(item.updated_at),
+        source_of_truth: asBoolean(item.source_of_truth, false),
+        trust_level: asNumber(item.trust_level, 75),
+        status: asString(item.status, "active")
+      };
+    })
+    .filter((item): item is ModuleRecord => item !== null);
 }
 
 function parseRuleEntities(raw: JsonObject[]): RuleRecord[] {
@@ -273,7 +269,7 @@ function parseRulesYaml(yamlText: string | null): RuleRecord[] {
 
 function parseRelations(
   raw: JsonObject[],
-  relation: RelationRecord["relation"],
+  relation: RelationType,
   noteFields: string[] = ["note", "reason"]
 ): RelationRecord[] {
   return raw
@@ -539,9 +535,11 @@ function parseRyuGraphChunks(rows: UnknownRow[]): ChunkRecord[] {
         kind: asStringUnknown(row.kind, "chunk"),
         signature: asStringUnknown(row.signature),
         body: asStringUnknown(row.body),
+        description: asStringUnknown(row.description),
         start_line: asNumberUnknown(row.start_line),
         end_line: asNumberUnknown(row.end_line),
         language: asStringUnknown(row.language),
+        exported: asBooleanUnknown(row.exported, false),
         updated_at: asStringUnknown(row.updated_at),
         source_of_truth: asBooleanUnknown(row.source_of_truth, false),
         trust_level: asNumberUnknown(row.trust_level, 60),
@@ -551,9 +549,33 @@ function parseRyuGraphChunks(rows: UnknownRow[]): ChunkRecord[] {
     .filter((value): value is ChunkRecord => value !== null);
 }
 
+function parseRyuGraphModules(rows: UnknownRow[]): ModuleRecord[] {
+  return rows
+    .map((row) => {
+      const id = asStringUnknown(row.id);
+      if (!id) {
+        return null;
+      }
+
+      return {
+        id,
+        path: asStringUnknown(row.path),
+        name: asStringUnknown(row.name),
+        summary: asStringUnknown(row.summary),
+        file_count: asNumberUnknown(row.file_count, 0),
+        exported_symbols: asStringUnknown(row.exported_symbols),
+        updated_at: asStringUnknown(row.updated_at),
+        source_of_truth: asBooleanUnknown(row.source_of_truth, false),
+        trust_level: asNumberUnknown(row.trust_level, 75),
+        status: asStringUnknown(row.status, "active")
+      };
+    })
+    .filter((value): value is ModuleRecord => value !== null);
+}
+
 function parseRyuGraphRelations(
   rows: UnknownRow[],
-  relation: RelationRecord["relation"],
+  relation: RelationType,
   noteField: string
 ): RelationRecord[] {
   return rows
@@ -578,15 +600,23 @@ export async function loadContextData(): Promise<ContextData> {
   const cachedDocuments = parseDocuments(readJsonl(PATHS.documents));
   const cachedAdrs = parseAdrs(readJsonl(PATHS.adrEntities));
   const cachedChunks = parseChunkEntities(readJsonl(PATHS.chunkEntities));
+  const cachedModules = parseModuleEntities(readJsonl(PATHS.moduleEntities));
   const cachedChunkRelations = [
+    ...parseRelations(readJsonl(PATHS.definesRelations), "DEFINES"),
     ...parseRelations(readJsonl(PATHS.callsRelations), "CALLS", ["call_type"]),
     ...parseRelations(readJsonl(PATHS.importsRelations), "IMPORTS", ["import_name"])
+  ];
+  const cachedModuleRelations = [
+    ...parseRelations(readJsonl(PATHS.containsRelations), "CONTAINS"),
+    ...parseRelations(readJsonl(PATHS.containsModuleRelations), "CONTAINS_MODULE"),
+    ...parseRelations(readJsonl(PATHS.exportsRelations), "EXPORTS")
   ];
   const cachedRelations = [
     ...parseRelations(readJsonl(PATHS.constrainsRelations), "CONSTRAINS"),
     ...parseRelations(readJsonl(PATHS.implementsRelations), "IMPLEMENTS"),
     ...parseRelations(readJsonl(PATHS.supersedesRelations), "SUPERSEDES"),
-    ...cachedChunkRelations
+    ...cachedChunkRelations,
+    ...cachedModuleRelations
   ];
 
   const yamlRules = parseRulesYaml(readFileIfExists(PATHS.rulesYaml));
@@ -600,6 +630,7 @@ export async function loadContextData(): Promise<ContextData> {
       adrs: cachedAdrs,
       rules: cachedRules,
       chunks: cachedChunks,
+      modules: cachedModules,
       relations: cachedRelations,
       ranking,
       source: "cache",
@@ -608,97 +639,30 @@ export async function loadContextData(): Promise<ContextData> {
   }
 
   try {
-    const [fileRows, ruleRows, adrRows, chunkRows, constrainsRows, implementsRows, supersedesRows] =
-      await Promise.all([
-        queryRows(
-          connection,
-          `
-          MATCH (f:File)
-          RETURN
-            f.id AS id,
-            f.path AS path,
-            f.kind AS kind,
-            f.excerpt AS excerpt,
-            f.updated_at AS updated_at,
-            f.source_of_truth AS source_of_truth,
-            f.trust_level AS trust_level,
-            f.status AS status;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (r:Rule)
-          RETURN
-            r.id AS id,
-            r.title AS title,
-            r.body AS body,
-            r.scope AS scope,
-            r.priority AS priority,
-            r.updated_at AS updated_at,
-            r.source_of_truth AS source_of_truth,
-            r.trust_level AS trust_level,
-            r.status AS status;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (a:ADR)
-          RETURN
-            a.id AS id,
-            a.path AS path,
-            a.title AS title,
-            a.body AS body,
-            a.decision_date AS decision_date,
-            a.supersedes_id AS supersedes_id,
-            a.source_of_truth AS source_of_truth,
-            a.trust_level AS trust_level,
-            a.status AS status;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (c:Chunk)
-          RETURN
-            c.id AS id,
-            c.file_id AS file_id,
-            c.name AS name,
-            c.kind AS kind,
-            c.signature AS signature,
-            c.body AS body,
-            c.start_line AS start_line,
-            c.end_line AS end_line,
-            c.language AS language,
-            c.updated_at AS updated_at,
-            c.source_of_truth AS source_of_truth,
-            c.trust_level AS trust_level,
-            c.status AS status;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (r:Rule)-[c:CONSTRAINS]->(f:File)
-          RETURN r.id AS from, f.id AS to, c.note AS note;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (f:File)-[i:IMPLEMENTS]->(r:Rule)
-          RETURN f.id AS from, r.id AS to, i.note AS note;
-        `
-        ),
-        queryRows(
-          connection,
-          `
-          MATCH (a1:ADR)-[s:SUPERSEDES]->(a2:ADR)
-          RETURN a1.id AS from, a2.id AS to, s.reason AS note;
-        `
-        )
-      ]);
+    const ryuQueries = await Promise.all([
+      queryRows(connection, `MATCH (f:File) RETURN f.id AS id, f.path AS path, f.kind AS kind, f.excerpt AS excerpt, f.updated_at AS updated_at, f.source_of_truth AS source_of_truth, f.trust_level AS trust_level, f.status AS status;`),
+      queryRows(connection, `MATCH (r:Rule) RETURN r.id AS id, r.title AS title, r.body AS body, r.scope AS scope, r.priority AS priority, r.updated_at AS updated_at, r.source_of_truth AS source_of_truth, r.trust_level AS trust_level, r.status AS status;`),
+      queryRows(connection, `MATCH (a:ADR) RETURN a.id AS id, a.path AS path, a.title AS title, a.body AS body, a.decision_date AS decision_date, a.supersedes_id AS supersedes_id, a.source_of_truth AS source_of_truth, a.trust_level AS trust_level, a.status AS status;`),
+      queryRows(connection, `MATCH (c:Chunk) RETURN c.id AS id, c.file_id AS file_id, c.name AS name, c.kind AS kind, c.signature AS signature, c.body AS body, c.description AS description, c.start_line AS start_line, c.end_line AS end_line, c.language AS language, c.exported AS exported, c.updated_at AS updated_at, c.source_of_truth AS source_of_truth, c.trust_level AS trust_level, c.status AS status;`),
+      queryRows(connection, `MATCH (m:Module) RETURN m.id AS id, m.path AS path, m.name AS name, m.summary AS summary, m.file_count AS file_count, m.exported_symbols AS exported_symbols, m.updated_at AS updated_at, m.source_of_truth AS source_of_truth, m.trust_level AS trust_level, m.status AS status;`),
+      queryRows(connection, `MATCH (r:Rule)-[c:CONSTRAINS]->(f:File) RETURN r.id AS from, f.id AS to, c.note AS note;`),
+      queryRows(connection, `MATCH (f:File)-[i:IMPLEMENTS]->(r:Rule) RETURN f.id AS from, r.id AS to, i.note AS note;`),
+      queryRows(connection, `MATCH (a1:ADR)-[s:SUPERSEDES]->(a2:ADR) RETURN a1.id AS from, a2.id AS to, s.reason AS note;`),
+      queryRows(connection, `MATCH (f:File)-[:DEFINES]->(c:Chunk) RETURN f.id AS from, c.id AS to;`),
+      queryRows(connection, `MATCH (c1:Chunk)-[ca:CALLS]->(c2:Chunk) RETURN c1.id AS from, c2.id AS to, ca.call_type AS call_type;`),
+      queryRows(connection, `MATCH (c:Chunk)-[im:IMPORTS]->(f:File) RETURN c.id AS from, f.id AS to, im.import_name AS import_name;`),
+      queryRows(connection, `MATCH (m:Module)-[:CONTAINS]->(f:File) RETURN m.id AS from, f.id AS to;`),
+      queryRows(connection, `MATCH (m1:Module)-[:CONTAINS_MODULE]->(m2:Module) RETURN m1.id AS from, m2.id AS to;`),
+      queryRows(connection, `MATCH (m:Module)-[:EXPORTS]->(c:Chunk) RETURN m.id AS from, c.id AS to;`)
+    ]);
+
+    // Named destructuring to avoid positional misalignment with 14 parallel queries
+    const [
+      fileRows, ruleRows, adrRows, chunkRows, moduleRows,          // entities
+      constrainsRows, implementsRows, supersedesRows,               // core relations
+      definesRows, callsRows, importsRows,                          // chunk relations
+      containsRows, containsModuleRows, exportsRows                 // module relations
+    ] = ryuQueries;
 
     const contentById = new Map(cachedDocuments.map((doc) => [doc.id, doc.content]));
 
@@ -706,10 +670,17 @@ export async function loadContextData(): Promise<ContextData> {
     const ryuRules = parseRyuGraphRules(ruleRows);
     const ryuAdrs = parseRyuGraphAdrs(adrRows);
     const ryuChunks = parseRyuGraphChunks(chunkRows);
+    const ryuModules = parseRyuGraphModules(moduleRows);
     const ryuRelations = [
       ...parseRyuGraphRelations(constrainsRows, "CONSTRAINS", "note"),
       ...parseRyuGraphRelations(implementsRows, "IMPLEMENTS", "note"),
-      ...parseRyuGraphRelations(supersedesRows, "SUPERSEDES", "note")
+      ...parseRyuGraphRelations(supersedesRows, "SUPERSEDES", "note"),
+      ...parseRyuGraphRelations(definesRows, "DEFINES", "note"),
+      ...parseRyuGraphRelations(callsRows, "CALLS", "call_type"),
+      ...parseRyuGraphRelations(importsRows, "IMPORTS", "import_name"),
+      ...parseRyuGraphRelations(containsRows, "CONTAINS", "note"),
+      ...parseRyuGraphRelations(containsModuleRows, "CONTAINS_MODULE", "note"),
+      ...parseRyuGraphRelations(exportsRows, "EXPORTS", "note")
     ];
 
     return {
@@ -717,7 +688,10 @@ export async function loadContextData(): Promise<ContextData> {
       adrs: ryuAdrs.length > 0 ? ryuAdrs : cachedAdrs,
       rules: ryuRules.length > 0 ? ryuRules : cachedRules,
       chunks: ryuChunks.length > 0 ? ryuChunks : cachedChunks,
-      relations: ryuRelations.length > 0 ? [...ryuRelations, ...cachedChunkRelations] : cachedRelations,
+      modules: ryuModules.length > 0 ? ryuModules : cachedModules,
+      // Ryu now queries all relation types (core + chunk + module), so no need
+      // to merge cached chunk/module relations separately.
+      relations: ryuRelations.length > 0 ? ryuRelations : cachedRelations,
       ranking,
       source: "ryu"
     };
@@ -732,6 +706,7 @@ export async function loadContextData(): Promise<ContextData> {
       adrs: cachedAdrs,
       rules: cachedRules,
       chunks: cachedChunks,
+      modules: cachedModules,
       relations: cachedRelations,
       ranking,
       source: "cache",

--- a/scaffold/mcp/src/jsonl.ts
+++ b/scaffold/mcp/src/jsonl.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import type { JsonObject, JsonValue } from "./types.js";
+
+export function readJsonl(filePath: string): JsonObject[] {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+
+  return fs
+    .readFileSync(filePath, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as JsonObject;
+      } catch {
+        return null;
+      }
+    })
+    .filter((value): value is JsonObject => value !== null);
+}
+
+export function asString(value: JsonValue | undefined, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+export function asNumber(value: JsonValue | undefined, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+export function asBoolean(value: JsonValue | undefined, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}

--- a/scaffold/mcp/src/loadGraph.ts
+++ b/scaffold/mcp/src/loadGraph.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import ryugraph, { type Connection, type QueryResult } from "ryugraph";
+import ryugraph, { type Connection, type PreparedStatement, type QueryResult, type RyuValue } from "ryugraph";
+import { readJsonl, asString, asNumber, asBoolean } from "./jsonl.js";
+import type { JsonObject } from "./types.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10,9 +12,19 @@ const CONTEXT_DIR = path.join(REPO_ROOT, ".context");
 const CACHE_DIR = path.join(CONTEXT_DIR, "cache");
 const DB_PATH = path.join(CONTEXT_DIR, "db", "graph.ryu");
 const ONTOLOGY_PATH = path.join(CONTEXT_DIR, "ontology.cypher");
+const BATCH_SIZE = 50;
 
-type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
-type JsonObject = { [key: string]: JsonValue };
+async function executeBatch(
+  conn: Connection,
+  statement: PreparedStatement,
+  items: Record<string, RyuValue>[],
+  batchSize = BATCH_SIZE
+): Promise<void> {
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    await Promise.all(batch.map((item) => conn.execute(statement, item)));
+  }
+}
 
 type FileEntity = {
   id: string;
@@ -57,10 +69,25 @@ type ChunkEntity = {
   kind: string;
   signature: string;
   body: string;
+  description: string;
   start_line: number;
   end_line: number;
   language: string;
+  exported: boolean;
   checksum: string;
+  updated_at: string;
+  source_of_truth: boolean;
+  trust_level: number;
+  status: string;
+};
+
+type ModuleEntity = {
+  id: string;
+  path: string;
+  name: string;
+  summary: string;
+  file_count: number;
+  exported_symbols: string;
   updated_at: string;
   source_of_truth: boolean;
   trust_level: number;
@@ -84,38 +111,6 @@ type ImportRelation = {
   to: string;
   import_name: string;
 };
-
-function asString(value: JsonValue | undefined, fallback = ""): string {
-  return typeof value === "string" ? value : fallback;
-}
-
-function asNumber(value: JsonValue | undefined, fallback = 0): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
-}
-
-function asBoolean(value: JsonValue | undefined, fallback = false): boolean {
-  return typeof value === "boolean" ? value : fallback;
-}
-
-function readJsonl(filePath: string): JsonObject[] {
-  if (!fs.existsSync(filePath)) {
-    return [];
-  }
-
-  return fs
-    .readFileSync(filePath, "utf8")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      try {
-        return JSON.parse(line) as JsonObject;
-      } catch {
-        return null;
-      }
-    })
-    .filter((value): value is JsonObject => value !== null);
-}
 
 function readEntityFile(fileName: string): JsonObject[] {
   return readJsonl(path.join(CACHE_DIR, fileName));
@@ -208,9 +203,11 @@ function parseChunks(raw: JsonObject[]): ChunkEntity[] {
         kind: asString(item.kind, "function"),
         signature: asString(item.signature),
         body: asString(item.body),
+        description: asString(item.description),
         start_line: asNumber(item.start_line, 0),
         end_line: asNumber(item.end_line, 0),
         language: asString(item.language, "javascript"),
+        exported: asBoolean(item.exported, false),
         checksum: asString(item.checksum),
         updated_at: asString(item.updated_at),
         source_of_truth: asBoolean(item.source_of_truth, true),
@@ -219,6 +216,30 @@ function parseChunks(raw: JsonObject[]): ChunkEntity[] {
       };
     })
     .filter((value): value is ChunkEntity => value !== null);
+}
+
+function parseModules(raw: JsonObject[]): ModuleEntity[] {
+  return raw
+    .map((item) => {
+      const id = asString(item.id);
+      if (!id) {
+        return null;
+      }
+
+      return {
+        id,
+        path: asString(item.path),
+        name: asString(item.name),
+        summary: asString(item.summary),
+        file_count: asNumber(item.file_count, 0),
+        exported_symbols: asString(item.exported_symbols),
+        updated_at: asString(item.updated_at),
+        source_of_truth: asBoolean(item.source_of_truth, false),
+        trust_level: asNumber(item.trust_level, 75),
+        status: asString(item.status, "active")
+      };
+    })
+    .filter((value): value is ModuleEntity => value !== null);
 }
 
 function parseRelations(fileName: string, noteField: string): Relation[] {
@@ -339,21 +360,25 @@ async function ensureRequiredFiles(): Promise<void> {
   }
 }
 
-function warnIfOptionalChunkFilesMissing(): void {
-  const optionalChunkFiles = [
+function warnIfOptionalFilesMissing(): void {
+  const optionalFiles = [
     "entities.chunk.jsonl",
     "relations.defines.jsonl",
     "relations.calls.jsonl",
-    "relations.imports.jsonl"
+    "relations.imports.jsonl",
+    "entities.module.jsonl",
+    "relations.contains.jsonl",
+    "relations.contains_module.jsonl",
+    "relations.exports.jsonl"
   ];
 
-  const missing = optionalChunkFiles.filter((fileName) => !fs.existsSync(path.join(CACHE_DIR, fileName)));
+  const missing = optionalFiles.filter((fileName) => !fs.existsSync(path.join(CACHE_DIR, fileName)));
   if (missing.length === 0) {
     return;
   }
 
   console.warn(
-    `[graph-load] warning: missing optional chunk files (${missing.join(", ")}); continuing without chunk nodes/relations`
+    `[graph-load] warning: missing optional files (${missing.join(", ")}); continuing without those nodes/relations`
   );
 }
 
@@ -362,7 +387,7 @@ async function main(): Promise<void> {
   const reset = !args.has("--no-reset");
 
   await ensureRequiredFiles();
-  warnIfOptionalChunkFilesMissing();
+  warnIfOptionalFilesMissing();
 
   if (reset) {
     fs.rmSync(DB_PATH, { recursive: true, force: true });
@@ -375,15 +400,22 @@ async function main(): Promise<void> {
   const ontologyStatements = parseOntologyStatements(fs.readFileSync(ONTOLOGY_PATH, "utf8"));
   await executeStatements(conn, ontologyStatements);
 
+  // Delete all relations first, then all nodes, to avoid orphaned edges
   await conn.query("MATCH (a:ADR)-[r:SUPERSEDES]->(b:ADR) DELETE r;");
   await conn.query("MATCH (f:File)-[i:IMPLEMENTS]->(r:Rule) DELETE i;");
   await conn.query("MATCH (r:Rule)-[c:CONSTRAINS]->(f:File) DELETE c;");
   await conn.query("MATCH (f:File)-[d:DEFINES]->(c:Chunk) DELETE d;");
   await conn.query("MATCH (c1:Chunk)-[ca:CALLS]->(c2:Chunk) DELETE ca;");
   await conn.query("MATCH (c:Chunk)-[im:IMPORTS]->(f:File) DELETE im;");
+  await conn.query("MATCH (m:Module)-[co:CONTAINS]->(f:File) DELETE co;");
+  await conn.query("MATCH (m1:Module)-[cm:CONTAINS_MODULE]->(m2:Module) DELETE cm;");
+  await conn.query("MATCH (m:Module)-[ex:EXPORTS]->(c:Chunk) DELETE ex;");
+
+  // Now delete all nodes
   await conn.query("MATCH (n:ADR) DELETE n;");
   await conn.query("MATCH (n:Rule) DELETE n;");
   await conn.query("MATCH (n:Chunk) DELETE n;");
+  await conn.query("MATCH (n:Module) DELETE n;");
   await conn.query("MATCH (n:File) DELETE n;");
 
   const fileEntities = parseFiles(readEntityFile("entities.file.jsonl"));
@@ -396,6 +428,10 @@ async function main(): Promise<void> {
   const defines = parseSimpleRelations("relations.defines.jsonl");
   const calls = parseCallRelations("relations.calls.jsonl");
   const imports = parseImportRelations("relations.imports.jsonl");
+  const moduleEntities = parseModules(readEntityFile("entities.module.jsonl"));
+  const contains = parseSimpleRelations("relations.contains.jsonl");
+  const containsModule = parseSimpleRelations("relations.contains_module.jsonl");
+  const exports = parseSimpleRelations("relations.exports.jsonl");
 
   const insertFile = await conn.prepare(`
     CREATE (f:File {
@@ -447,9 +483,11 @@ async function main(): Promise<void> {
       kind: $kind,
       signature: $signature,
       body: $body,
+      description: $description,
       start_line: $start_line,
       end_line: $end_line,
       language: $language,
+      exported: $exported,
       checksum: $checksum,
       updated_at: $updated_at,
       source_of_truth: $source_of_truth,
@@ -488,55 +526,57 @@ async function main(): Promise<void> {
     CREATE (c)-[:IMPORTS {import_name: $import_name}]->(f);
   `);
 
-  for (const entity of fileEntities) {
-    await conn.execute(insertFile, entity);
-  }
-
-  for (const entity of ruleEntities) {
-    await conn.execute(insertRule, {
-      id: entity.id,
-      title: entity.title,
-      body: entity.body,
-      scope: entity.scope,
-      priority: entity.priority,
-      updated_at: entity.updated_at,
-      source_of_truth: entity.source_of_truth,
-      trust_level: entity.trust_level,
-      status: entity.status
+  const insertModule = await conn.prepare(`
+    CREATE (m:Module {
+      id: $id,
+      path: $path,
+      name: $name,
+      summary: $summary,
+      file_count: $file_count,
+      exported_symbols: $exported_symbols,
+      updated_at: $updated_at,
+      source_of_truth: $source_of_truth,
+      trust_level: $trust_level,
+      status: $status
     });
-  }
+  `);
 
-  for (const entity of adrEntities) {
-    await conn.execute(insertAdr, entity);
-  }
+  const insertContains = await conn.prepare(`
+    MATCH (m:Module {id: $from}), (f:File {id: $to})
+    CREATE (m)-[:CONTAINS]->(f);
+  `);
 
-  for (const entity of chunkEntities) {
-    await conn.execute(insertChunk, entity);
-  }
+  const insertContainsModule = await conn.prepare(`
+    MATCH (m1:Module {id: $from}), (m2:Module {id: $to})
+    CREATE (m1)-[:CONTAINS_MODULE]->(m2);
+  `);
 
-  for (const edge of defines) {
-    await conn.execute(insertDefines, edge);
-  }
+  const insertExports = await conn.prepare(`
+    MATCH (m:Module {id: $from}), (c:Chunk {id: $to})
+    CREATE (m)-[:EXPORTS]->(c);
+  `);
 
-  for (const edge of calls) {
-    await conn.execute(insertCalls, edge);
-  }
+  // Insert all nodes first (batched for performance)
+  await executeBatch(conn, insertFile, fileEntities);
+  await executeBatch(conn, insertRule, ruleEntities.map((e) => ({
+    id: e.id, title: e.title, body: e.body, scope: e.scope,
+    priority: e.priority, updated_at: e.updated_at,
+    source_of_truth: e.source_of_truth, trust_level: e.trust_level, status: e.status
+  })));
+  await executeBatch(conn, insertAdr, adrEntities);
+  await executeBatch(conn, insertChunk, chunkEntities);
+  await executeBatch(conn, insertModule, moduleEntities);
 
-  for (const edge of imports) {
-    await conn.execute(insertImports, edge);
-  }
-
-  for (const edge of constrains) {
-    await conn.execute(insertConstrains, edge);
-  }
-
-  for (const edge of implementsEdges) {
-    await conn.execute(insertImplements, edge);
-  }
-
-  for (const edge of supersedes) {
-    await conn.execute(insertSupersedes, edge);
-  }
+  // Insert all edges (nodes must exist first)
+  await executeBatch(conn, insertDefines, defines);
+  await executeBatch(conn, insertCalls, calls);
+  await executeBatch(conn, insertImports, imports);
+  await executeBatch(conn, insertConstrains, constrains);
+  await executeBatch(conn, insertImplements, implementsEdges);
+  await executeBatch(conn, insertSupersedes, supersedes);
+  await executeBatch(conn, insertContains, contains);
+  await executeBatch(conn, insertContainsModule, containsModule);
+  await executeBatch(conn, insertExports, exports);
 
   const fileCount = await rows(await conn.query("MATCH (f:File) RETURN count(*) AS count;"));
   const ruleCount = await rows(await conn.query("MATCH (r:Rule) RETURN count(*) AS count;"));
@@ -560,6 +600,16 @@ async function main(): Promise<void> {
   const importsCount = await rows(
     await conn.query("MATCH (:Chunk)-[im:IMPORTS]->(:File) RETURN count(im) AS count;")
   );
+  const moduleCount = await rows(await conn.query("MATCH (m:Module) RETURN count(*) AS count;"));
+  const containsCount = await rows(
+    await conn.query("MATCH (:Module)-[co:CONTAINS]->(:File) RETURN count(co) AS count;")
+  );
+  const containsModuleCount = await rows(
+    await conn.query("MATCH (:Module)-[cm:CONTAINS_MODULE]->(:Module) RETURN count(cm) AS count;")
+  );
+  const exportsCount = await rows(
+    await conn.query("MATCH (:Module)-[ex:EXPORTS]->(:Chunk) RETURN count(ex) AS count;")
+  );
 
   const summary = {
     generated_at: new Date().toISOString(),
@@ -574,7 +624,11 @@ async function main(): Promise<void> {
       supersedes: Number(supersedesCount[0]?.count ?? 0),
       defines: Number(definesCount[0]?.count ?? 0),
       calls: Number(callsCount[0]?.count ?? 0),
-      imports: Number(importsCount[0]?.count ?? 0)
+      imports: Number(importsCount[0]?.count ?? 0),
+      modules: Number(moduleCount[0]?.count ?? 0),
+      contains: Number(containsCount[0]?.count ?? 0),
+      contains_module: Number(containsModuleCount[0]?.count ?? 0),
+      exports: Number(exportsCount[0]?.count ?? 0)
     }
   };
 
@@ -583,13 +637,16 @@ async function main(): Promise<void> {
 
   console.log(`[graph-load] db_path=${DB_PATH}`);
   console.log(
-    `[graph-load] files=${summary.counts.files} rules=${summary.counts.rules} adrs=${summary.counts.adrs} chunks=${summary.counts.chunks}`
+    `[graph-load] files=${summary.counts.files} rules=${summary.counts.rules} adrs=${summary.counts.adrs} chunks=${summary.counts.chunks} modules=${summary.counts.modules}`
   );
   console.log(
     `[graph-load] rels constrains=${summary.counts.constrains} implements=${summary.counts.implements} supersedes=${summary.counts.supersedes}`
   );
   console.log(
     `[graph-load] rels defines=${summary.counts.defines} calls=${summary.counts.calls} imports=${summary.counts.imports}`
+  );
+  console.log(
+    `[graph-load] rels contains=${summary.counts.contains} contains_module=${summary.counts.contains_module} exports=${summary.counts.exports}`
   );
   console.log(`[graph-load] manifest=${summaryPath}`);
 

--- a/scaffold/mcp/src/paths.ts
+++ b/scaffold/mcp/src/paths.ts
@@ -28,7 +28,12 @@ export const PATHS = {
   implementsRelations: path.join(CACHE_DIR, "relations.implements.jsonl"),
   supersedesRelations: path.join(CACHE_DIR, "relations.supersedes.jsonl"),
   callsRelations: path.join(CACHE_DIR, "relations.calls.jsonl"),
-  importsRelations: path.join(CACHE_DIR, "relations.imports.jsonl")
+  definesRelations: path.join(CACHE_DIR, "relations.defines.jsonl"),
+  importsRelations: path.join(CACHE_DIR, "relations.imports.jsonl"),
+  moduleEntities: path.join(CACHE_DIR, "entities.module.jsonl"),
+  containsRelations: path.join(CACHE_DIR, "relations.contains.jsonl"),
+  containsModuleRelations: path.join(CACHE_DIR, "relations.contains_module.jsonl"),
+  exportsRelations: path.join(CACHE_DIR, "relations.exports.jsonl")
 };
 
 export const DEFAULT_RANKING: RankingWeights = {

--- a/scaffold/mcp/src/search.ts
+++ b/scaffold/mcp/src/search.ts
@@ -217,14 +217,32 @@ function buildSearchEntities(data: ContextData, includeContent: boolean): Search
       kind: chunk.kind || "chunk",
       label: chunk.name || chunk.id,
       path: filePath,
-      text: `${filePath}\n${chunk.name}\n${chunk.signature}\n${chunk.body}`,
+      text: `${filePath}\n${chunk.name}\n${chunk.signature}\n${chunk.description}\n${chunk.body}`,
       status: chunk.status,
       source_of_truth: chunk.source_of_truth,
       trust_level: chunk.trust_level,
       updated_at: chunk.updated_at,
-      snippet: chunk.body.slice(0, 500),
+      snippet: chunk.description || chunk.body.slice(0, 500),
       matched_rules: fileRuleLinks.get(chunk.file_id) ?? [],
       content: includeContent ? chunk.body : undefined
+    });
+  }
+
+  for (const module of data.modules) {
+    entities.push({
+      id: module.id,
+      entity_type: "Module",
+      kind: "MODULE",
+      label: module.name,
+      path: module.path,
+      text: `${module.path}\n${module.name}\n${module.summary}\n${module.exported_symbols}`,
+      status: module.status,
+      source_of_truth: module.source_of_truth,
+      trust_level: module.trust_level,
+      updated_at: module.updated_at,
+      snippet: (module.summary || "").slice(0, 500),
+      matched_rules: [],
+      content: includeContent ? module.summary : undefined
     });
   }
 
@@ -329,6 +347,17 @@ function entityCatalog(data: ContextData): Map<string, JsonObject> {
       chunkEntity.path = filePath;
     }
     catalog.set(chunk.id, chunkEntity);
+  }
+
+  for (const module of data.modules) {
+    catalog.set(module.id, {
+      id: module.id,
+      type: "Module",
+      label: module.name,
+      status: module.status,
+      source_of_truth: module.source_of_truth,
+      path: module.path
+    });
   }
 
   return catalog;

--- a/scaffold/mcp/src/types.ts
+++ b/scaffold/mcp/src/types.ts
@@ -38,10 +38,22 @@ export type AdrRecord = {
   status: string;
 };
 
+export type RelationType =
+  | "CONSTRAINS"
+  | "IMPLEMENTS"
+  | "SUPERSEDES"
+  | "DEFINES"
+  | "CALLS"
+  | "IMPORTS"
+  | "PART_OF"
+  | "CONTAINS"
+  | "CONTAINS_MODULE"
+  | "EXPORTS";
+
 export type RelationRecord = {
   from: string;
   to: string;
-  relation: "CONSTRAINS" | "IMPLEMENTS" | "SUPERSEDES" | "CALLS" | "IMPORTS" | "PART_OF";
+  relation: RelationType;
   note: string;
 };
 
@@ -52,9 +64,24 @@ export type ChunkRecord = {
   kind: string;
   signature: string;
   body: string;
+  description: string;
   start_line: number;
   end_line: number;
   language: string;
+  exported: boolean;
+  updated_at: string;
+  source_of_truth: boolean;
+  trust_level: number;
+  status: string;
+};
+
+export type ModuleRecord = {
+  id: string;
+  path: string;
+  name: string;
+  summary: string;
+  file_count: number;
+  exported_symbols: string;
   updated_at: string;
   source_of_truth: boolean;
   trust_level: number;
@@ -73,6 +100,7 @@ export type ContextData = {
   adrs: AdrRecord[];
   rules: RuleRecord[];
   chunks: ChunkRecord[];
+  modules: ModuleRecord[];
   relations: RelationRecord[];
   ranking: RankingWeights;
   source: "cache" | "ryu";
@@ -81,7 +109,7 @@ export type ContextData = {
 
 export type SearchEntity = {
   id: string;
-  entity_type: "File" | "Rule" | "ADR" | "Chunk";
+  entity_type: "File" | "Rule" | "ADR" | "Chunk" | "Module";
   kind: string;
   label: string;
   path: string;

--- a/scaffold/scripts/ingest.mjs
+++ b/scaffold/scripts/ingest.mjs
@@ -610,6 +610,114 @@ function readJsonlSafe(filePath) {
     .filter((record) => record !== null);
 }
 
+function relationKey(...parts) {
+  return parts.map((part) => String(part ?? "")).join("|");
+}
+
+function removeChunkStateForFile(fileId, chunkRecordMap, definesRelationMap, callsRelationMap, importsRelationMap) {
+  const removedChunkIds = new Set();
+
+  for (const [chunkId, chunkRecord] of chunkRecordMap.entries()) {
+    if (chunkRecord.file_id === fileId) {
+      removedChunkIds.add(chunkId);
+      chunkRecordMap.delete(chunkId);
+    }
+  }
+
+  if (removedChunkIds.size === 0) {
+    return;
+  }
+
+  for (const [key, relation] of definesRelationMap.entries()) {
+    if (relation.from === fileId || removedChunkIds.has(relation.to)) {
+      definesRelationMap.delete(key);
+    }
+  }
+
+  for (const [key, relation] of callsRelationMap.entries()) {
+    if (removedChunkIds.has(relation.from) || removedChunkIds.has(relation.to)) {
+      callsRelationMap.delete(key);
+    }
+  }
+
+  for (const [key, relation] of importsRelationMap.entries()) {
+    if (removedChunkIds.has(relation.from)) {
+      importsRelationMap.delete(key);
+    }
+  }
+}
+
+function hydrateIncrementalChunkState(fileRecords) {
+  const fileIdSet = new Set(fileRecords.map((record) => record.id));
+  const chunkRecordMap = new Map();
+  const definesRelationMap = new Map();
+  const callsRelationMap = new Map();
+  const importsRelationMap = new Map();
+
+  for (const record of readJsonlSafe(path.join(CACHE_DIR, "entities.chunk.jsonl"))) {
+    if (!record || typeof record !== "object") continue;
+    const chunkId = String(record.id ?? "");
+    const fileId = String(record.file_id ?? "");
+    if (!chunkId || !fileIdSet.has(fileId)) {
+      continue;
+    }
+    chunkRecordMap.set(chunkId, {
+      ...record,
+      id: chunkId,
+      file_id: fileId
+    });
+  }
+
+  const chunkIdSet = new Set(chunkRecordMap.keys());
+
+  for (const record of readJsonlSafe(path.join(CACHE_DIR, "relations.defines.jsonl"))) {
+    if (!record || typeof record !== "object") continue;
+    const from = String(record.from ?? "");
+    const to = String(record.to ?? "");
+    if (!fileIdSet.has(from) || !chunkIdSet.has(to)) {
+      continue;
+    }
+    definesRelationMap.set(relationKey(from, to), { from, to });
+  }
+
+  for (const record of readJsonlSafe(path.join(CACHE_DIR, "relations.calls.jsonl"))) {
+    if (!record || typeof record !== "object") continue;
+    const from = String(record.from ?? "");
+    const to = String(record.to ?? "");
+    const callType = String(record.call_type ?? "direct");
+    if (!chunkIdSet.has(from) || !chunkIdSet.has(to)) {
+      continue;
+    }
+    callsRelationMap.set(relationKey(from, to, callType), {
+      from,
+      to,
+      call_type: callType
+    });
+  }
+
+  for (const record of readJsonlSafe(path.join(CACHE_DIR, "relations.imports.jsonl"))) {
+    if (!record || typeof record !== "object") continue;
+    const from = String(record.from ?? "");
+    const to = String(record.to ?? "");
+    const importName = String(record.import_name ?? "");
+    if (!chunkIdSet.has(from) || !fileIdSet.has(to)) {
+      continue;
+    }
+    importsRelationMap.set(relationKey(from, to, importName), {
+      from,
+      to,
+      import_name: importName
+    });
+  }
+
+  return {
+    chunkRecordMap,
+    definesRelationMap,
+    callsRelationMap,
+    importsRelationMap
+  };
+}
+
 function normalizeRuleTokens(ruleRecord) {
   const idParts = ruleRecord.id.split(/[._-]+/g);
   const descriptionTokens = tokenizeKeywords(ruleRecord.body);
@@ -630,6 +738,143 @@ function chunkIdFor(filePath, chunk) {
   const startLine = Number.isFinite(chunk.startLine) ? chunk.startLine : 0;
   const endLine = Number.isFinite(chunk.endLine) ? chunk.endLine : startLine;
   return `chunk:${filePath}:${chunk.name}:${startLine}-${endLine}`;
+}
+
+function generateChunkDescription(chunk) {
+  const parts = [chunk.kind];
+  if (chunk.exported) parts.push("exported");
+  if (chunk.async) parts.push("async");
+  parts.push(chunk.signature);
+
+  // Extract leading JSDoc/comment from body
+  // Match leading JSDoc (/** */), block (/* */) and line (//) comments
+  const commentMatch = chunk.body.match(/^(?:\s*(?:\/\*[\s\S]*?\*\/|\/\/[^\n]*)[\s\n]*)+/);
+  if (commentMatch) {
+    const cleaned = commentMatch[0]
+      .replace(/\/\*\*|\*\/|\*|\/\//g, "")
+      .replace(/\s+/g, " ").trim()
+      .slice(0, 200);
+    if (cleaned.length > 10) parts.push(cleaned);
+  }
+
+  return parts.join(". ") + ".";
+}
+
+function generateModuleSummary(dir, files, exportNames, repoRoot = REPO_ROOT) {
+  // Check for README.md in directory
+  const readmePath = path.join(repoRoot, dir, "README.md");
+  if (fs.existsSync(readmePath)) {
+    try {
+      const content = fs.readFileSync(readmePath, "utf8");
+      // Skip first heading line, take first 300 chars
+      const lines = content.split(/\r?\n/);
+      const startIdx = lines.findIndex(l => !l.startsWith("#") && l.trim().length > 0);
+      if (startIdx >= 0) {
+        const excerpt = lines.slice(startIdx).join(" ").trim().slice(0, 300);
+        if (excerpt.length > 20) return excerpt;
+      }
+    } catch {
+      // fall through to auto-generated summary
+    }
+  }
+
+  const name = path.basename(dir);
+  const codeFiles = files.filter(f => f.kind === "CODE");
+  const docFiles = files.filter(f => f.kind !== "CODE");
+
+  const parts = [`Module ${name}`];
+  parts.push(`Contains ${files.length} files (${codeFiles.length} code, ${docFiles.length} docs)`);
+
+  // Detect common file extension pattern
+  const exts = new Set(codeFiles.map(f => path.extname(f.path).toLowerCase()));
+  if (exts.size === 1) {
+    const ext = [...exts][0];
+    const extNames = { ".ts": "TypeScript", ".js": "JavaScript", ".mjs": "JavaScript (ESM)", ".tsx": "TypeScript React" };
+    if (extNames[ext]) parts.push(`${extNames[ext]} source files`);
+  }
+
+  if (exportNames.length > 0) {
+    parts.push(`Key exports: ${exportNames.slice(0, 5).join(", ")}`);
+  }
+
+  return parts.join(". ") + ".";
+}
+
+function generateModules(fileRecords, chunkRecords) {
+  const dirFiles = new Map();
+  const dirChunks = new Map();
+  const fileById = new Map(fileRecords.map(f => [f.id, f]));
+
+  for (const file of fileRecords) {
+    const dir = path.dirname(file.path);
+    if (!dirFiles.has(dir)) dirFiles.set(dir, []);
+    dirFiles.get(dir).push(file);
+  }
+
+  for (const chunk of chunkRecords) {
+    if (!chunk.exported || isWindowChunkId(chunk.id)) continue;
+    const file = fileById.get(chunk.file_id);
+    if (!file) continue;
+    const dir = path.dirname(file.path);
+    if (!dirChunks.has(dir)) dirChunks.set(dir, []);
+    dirChunks.get(dir).push(chunk);
+  }
+
+  const modules = [];
+  const containsRelations = [];
+  const containsModuleRelations = [];
+  const exportsRelations = [];
+
+  const MIN_MODULE_FILES = 2;
+
+  for (const [dir, files] of dirFiles) {
+    if (files.length < MIN_MODULE_FILES) continue;
+
+    const exports = dirChunks.get(dir) || [];
+    const exportNames = [...new Set(exports.slice(0, 20).map(c => c.name))];
+    const moduleId = `module:${dir}`;
+
+    modules.push({
+      id: moduleId,
+      path: dir,
+      name: path.basename(dir),
+      summary: generateModuleSummary(dir, files, exportNames),
+      file_count: files.length,
+      exported_symbols: exportNames.join(", "),
+      updated_at: files.reduce((latest, f) => f.updated_at > latest ? f.updated_at : latest, ""),
+      source_of_truth: false,
+      trust_level: 75,
+      status: "active"
+    });
+
+    // CONTAINS: Module -> File
+    for (const file of files) {
+      containsRelations.push({ from: moduleId, to: file.id });
+    }
+
+    // EXPORTS: Module -> Chunk
+    for (const chunk of exports) {
+      exportsRelations.push({ from: moduleId, to: chunk.id });
+    }
+  }
+
+  // CONTAINS_MODULE: parent Module -> child Module
+  const moduleDirs = new Set(modules.map(m => m.path));
+  for (const dir of moduleDirs) {
+    const parent = path.dirname(dir);
+    if (parent !== dir && moduleDirs.has(parent)) {
+      containsModuleRelations.push({
+        from: `module:${parent}`,
+        to: `module:${dir}`
+      });
+    }
+  }
+
+  return { modules, containsRelations, containsModuleRelations, exportsRelations };
+}
+
+function isWindowChunkId(chunkId) {
+  return typeof chunkId === "string" && chunkId.includes(":window:");
 }
 
 function splitChunkIntoWindows(chunkRecord, options) {
@@ -660,9 +905,11 @@ function splitChunkIntoWindows(chunkRecord, options) {
       kind: chunkRecord.kind,
       signature: `${chunkRecord.signature} [window ${windowIndex}]`,
       body: persistedBody,
+      description: chunkRecord.description || "",
       start_line: windowStartLine,
       end_line: windowEndLine,
       language: chunkRecord.language,
+      exported: chunkRecord.exported || false,
       checksum: checksum(Buffer.from(windowBody)),
       updated_at: chunkRecord.updated_at,
       trust_level: chunkRecord.trust_level,
@@ -857,12 +1104,29 @@ function main() {
   const fileRecords = [...fileRecordMap.values()].sort((a, b) => a.path.localeCompare(b.path));
   const adrRecords = [...adrRecordMap.values()].sort((a, b) => a.path.localeCompare(b.path));
   const indexedFileIds = new Set(fileRecords.map((record) => record.id));
+  const changedFileIds = new Set(
+    [...candidates].map((absolutePath) => `file:${toPosixPath(path.relative(REPO_ROOT, absolutePath))}`)
+  );
 
-  // Extract chunks from code files
-  const chunkRecords = [];
-  const definesRelations = [];
-  const callsRelations = [];
-  const importsRelations = [];
+  const {
+    chunkRecordMap,
+    definesRelationMap,
+    callsRelationMap,
+    importsRelationMap
+  } = incrementalMode
+    ? hydrateIncrementalChunkState(fileRecords)
+    : {
+        chunkRecordMap: new Map(),
+        definesRelationMap: new Map(),
+        callsRelationMap: new Map(),
+        importsRelationMap: new Map()
+      };
+
+  const cachedChunkFileIds = new Set(
+    [...chunkRecordMap.values()].map((record) => String(record.file_id ?? "")).filter(Boolean)
+  );
+
+  // Extract chunks from changed or uncached code files
   let windowedChunkCount = 0;
 
   for (const fileRecord of fileRecords) {
@@ -871,6 +1135,20 @@ function main() {
     const ext = path.extname(fileRecord.path).toLowerCase();
     const supportedForChunking = [".js", ".mjs", ".cjs", ".ts"].includes(ext);
     if (!supportedForChunking) continue;
+
+    const shouldParseFile =
+      !incrementalMode || changedFileIds.has(fileRecord.id) || !cachedChunkFileIds.has(fileRecord.id);
+    if (!shouldParseFile) {
+      continue;
+    }
+
+    removeChunkStateForFile(
+      fileRecord.id,
+      chunkRecordMap,
+      definesRelationMap,
+      callsRelationMap,
+      importsRelationMap
+    );
 
     try {
       const language = ext === ".ts" ? "typescript" : "javascript";
@@ -898,9 +1176,11 @@ function main() {
           kind: chunk.kind,
           signature: chunk.signature,
           body: chunk.body.slice(0, MAX_BODY_CHARS), // Limit chunk body size
+          description: generateChunkDescription(chunk),
           start_line: chunk.startLine,
           end_line: chunk.endLine,
           language: chunk.language,
+          exported: Boolean(chunk.exported),
           checksum: checksum(Buffer.from(chunk.body)),
           updated_at: fileRecord.updated_at,
           trust_level: fileRecord.trust_level,
@@ -910,10 +1190,10 @@ function main() {
               : "active",
           source_of_truth: Boolean(fileRecord.source_of_truth)
         };
-        chunkRecords.push(chunkRecord);
+        chunkRecordMap.set(chunkId, chunkRecord);
 
         // DEFINES relation: File -> Chunk
-        definesRelations.push({
+        definesRelationMap.set(relationKey(fileRecord.id, chunkId), {
           from: fileRecord.id,
           to: chunkId
         });
@@ -928,8 +1208,8 @@ function main() {
         if (windows.length > 0) {
           windowedChunkCount += windows.length;
           for (const windowChunk of windows) {
-            chunkRecords.push(windowChunk);
-            definesRelations.push({
+            chunkRecordMap.set(windowChunk.id, windowChunk);
+            definesRelationMap.set(relationKey(fileRecord.id, windowChunk.id), {
               from: fileRecord.id,
               to: windowChunk.id
             });
@@ -943,7 +1223,7 @@ function main() {
             continue;
           }
 
-          importsRelations.push({
+          importsRelationMap.set(relationKey(chunkId, targetFileId, importPath), {
             from: chunkId,
             to: targetFileId,
             import_name: importPath
@@ -962,7 +1242,7 @@ function main() {
               continue;
             }
             seenCallEdges.add(callKey);
-            callsRelations.push({
+            callsRelationMap.set(relationKey(chunkId, targetChunkId, "direct"), {
               from: chunkId,
               to: targetChunkId,
               call_type: "direct"
@@ -977,9 +1257,20 @@ function main() {
     }
   }
 
+  const chunkRecords = [...chunkRecordMap.values()].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
   // Filter CALLS relations to only valid targets (chunks that actually exist)
   const chunkIdSet = new Set(chunkRecords.map(c => c.id));
-  const validCallsRelations = callsRelations.filter(rel => chunkIdSet.has(rel.to));
+  const validDefinesRelations = [...definesRelationMap.values()].filter(
+    (rel) => indexedFileIds.has(rel.from) && chunkIdSet.has(rel.to)
+  );
+  const totalCallsRelations = callsRelationMap.size;
+  const validCallsRelations = [...callsRelationMap.values()].filter(
+    (rel) => chunkIdSet.has(rel.from) && chunkIdSet.has(rel.to)
+  );
+  const validImportsRelations = [...importsRelationMap.values()].filter(
+    (rel) => chunkIdSet.has(rel.from) && indexedFileIds.has(rel.to)
+  );
 
   if (verbose && chunkRecords.length > 0) {
     console.log(`[ingest] extracted ${chunkRecords.length} chunks from ${fileRecords.filter(f => f.kind === "CODE").length} code files`);
@@ -988,7 +1279,18 @@ function main() {
         `[ingest] overlap windows added=${windowedChunkCount} (window_lines=${chunkWindowLines}, overlap_lines=${chunkOverlapLines}, max_windows=${chunkMaxWindows})`
       );
     }
-    console.log(`[ingest] ${validCallsRelations.length} call relations (${callsRelations.length - validCallsRelations.length} filtered)`);
+    console.log(`[ingest] ${validCallsRelations.length} call relations (${totalCallsRelations - validCallsRelations.length} filtered)`);
+  }
+
+  // Generate Module entities and relations
+  const moduleResult = generateModules(fileRecords, chunkRecords);
+  const moduleRecords = moduleResult.modules;
+  const moduleContainsRelations = moduleResult.containsRelations;
+  const moduleContainsModuleRelations = moduleResult.containsModuleRelations;
+  const moduleExportsRelations = moduleResult.exportsRelations;
+
+  if (verbose && moduleRecords.length > 0) {
+    console.log(`[ingest] modules=${moduleRecords.length} contains=${moduleContainsRelations.length} contains_module=${moduleContainsModuleRelations.length} exports=${moduleExportsRelations.length}`);
   }
 
   const ruleRecords = rules.map((rule) => ({
@@ -1090,9 +1392,13 @@ function main() {
   writeJsonl(path.join(CACHE_DIR, "relations.supersedes.jsonl"), supersedesRelations);
   writeJsonl(path.join(CACHE_DIR, "relations.constrains.jsonl"), constrainsRelations);
   writeJsonl(path.join(CACHE_DIR, "relations.implements.jsonl"), implementsRelations);
-  writeJsonl(path.join(CACHE_DIR, "relations.defines.jsonl"), definesRelations);
+  writeJsonl(path.join(CACHE_DIR, "relations.defines.jsonl"), validDefinesRelations);
   writeJsonl(path.join(CACHE_DIR, "relations.calls.jsonl"), validCallsRelations);
-  writeJsonl(path.join(CACHE_DIR, "relations.imports.jsonl"), importsRelations);
+  writeJsonl(path.join(CACHE_DIR, "relations.imports.jsonl"), validImportsRelations);
+  writeJsonl(path.join(CACHE_DIR, "entities.module.jsonl"), moduleRecords);
+  writeJsonl(path.join(CACHE_DIR, "relations.contains.jsonl"), moduleContainsRelations);
+  writeJsonl(path.join(CACHE_DIR, "relations.contains_module.jsonl"), moduleContainsModuleRelations);
+  writeJsonl(path.join(CACHE_DIR, "relations.exports.jsonl"), moduleExportsRelations);
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "file_nodes.tsv"),
@@ -1225,7 +1531,7 @@ function main() {
   writeTsv(
     path.join(DB_IMPORT_DIR, "defines_rel.tsv"),
     ["from", "to"],
-    definesRelations.map((record) => [record.from, record.to])
+    validDefinesRelations.map((record) => [record.from, record.to])
   );
 
   writeTsv(
@@ -1237,7 +1543,7 @@ function main() {
   writeTsv(
     path.join(DB_IMPORT_DIR, "imports_rel.tsv"),
     ["from", "to", "import_name"],
-    importsRelations.map((record) => [record.from, record.to, record.import_name])
+    validImportsRelations.map((record) => [record.from, record.to, record.import_name])
   );
 
   const manifest = {
@@ -1252,9 +1558,13 @@ function main() {
       relations_constrains: constrainsRelations.length,
       relations_implements: implementsRelations.length,
       relations_supersedes: supersedesRelations.length,
-      relations_defines: definesRelations.length,
+      relations_defines: validDefinesRelations.length,
       relations_calls: validCallsRelations.length,
-      relations_imports: importsRelations.length
+      relations_imports: validImportsRelations.length,
+      modules: moduleRecords.length,
+      relations_contains: moduleContainsRelations.length,
+      relations_contains_module: moduleContainsModuleRelations.length,
+      relations_exports: moduleExportsRelations.length
     },
     skipped,
     incremental_mode: incrementalMode,
@@ -1285,4 +1595,9 @@ function main() {
   console.log(`[ingest] wrote cache + db import files under .context/`);
 }
 
-main();
+const isMainModule = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename);
+if (isMainModule) {
+  main();
+}
+
+export { generateChunkDescription, generateModuleSummary, generateModules };

--- a/scaffold/scripts/parsers/javascript/chunks.mjs
+++ b/scaffold/scripts/parsers/javascript/chunks.mjs
@@ -144,12 +144,13 @@ function extractFunctionChunk(node, kind, code, nameOverride = null) {
   }
 
   const params = (node.params || []).map(formatParameterName);
+  const bodyStart = findLeadingCommentStart(code, node);
 
   return {
     name,
     kind,
     signature: `${name}(${params.join(", ")})`,
-    body: code.slice(node.start, node.end),
+    body: code.slice(bodyStart, node.end),
     startLine: node.loc.start.line,
     endLine: node.loc.end.line,
     callNode: node.body || node,
@@ -166,12 +167,13 @@ function extractClassChunk(node, code) {
   }
 
   const superClass = node.superClass?.name || null;
+  const bodyStart = findLeadingCommentStart(code, node);
 
   return {
     name,
     kind: "class",
     signature: superClass ? `class ${name} extends ${superClass}` : `class ${name}`,
-    body: code.slice(node.start, node.end),
+    body: code.slice(bodyStart, node.end),
     startLine: node.loc.start.line,
     endLine: node.loc.end.line,
     callNode: node.body,
@@ -192,12 +194,13 @@ function extractClassMethods(classNode, code, language) {
     const params = (member.value.params || []).map(formatParameterName);
     const isStatic = member.static === true;
     const prefix = isStatic ? "static " : "";
+    const bodyStart = findLeadingCommentStart(code, member);
 
     methods.push({
       name: `${className}.${member.key.name}`,
       kind: "method",
       signature: `${prefix}${member.key.name}(${params.join(", ")})`,
-      body: code.slice(member.start, member.end),
+      body: code.slice(bodyStart, member.end),
       startLine: member.loc.start.line,
       endLine: member.loc.end.line,
       callNode: member.value.body,
@@ -210,6 +213,61 @@ function extractClassMethods(classNode, code, language) {
   }
 
   return methods;
+}
+
+function findLeadingCommentStart(code, node) {
+  let bodyStart = node.start;
+  let lineStart = code.lastIndexOf("\n", node.start - 1) + 1;
+
+  while (lineStart > 0) {
+    const previousLineEnd = lineStart - 1;
+    const previousLineStart = code.lastIndexOf("\n", previousLineEnd - 1) + 1;
+    const previousLine = code.slice(previousLineStart, previousLineEnd).replace(/\r$/, "");
+    const trimmed = previousLine.trim();
+
+    if (!trimmed) {
+      break;
+    }
+
+    if (trimmed.startsWith("//")) {
+      bodyStart = previousLineStart;
+      lineStart = previousLineStart;
+      continue;
+    }
+
+    if (trimmed.endsWith("*/")) {
+      let blockStart = previousLineStart;
+      let searchStart = previousLineStart;
+      let foundBlockStart = trimmed.startsWith("/*");
+
+      while (!foundBlockStart && searchStart > 0) {
+        const blockLineEnd = searchStart - 1;
+        const blockLineStart = code.lastIndexOf("\n", blockLineEnd - 1) + 1;
+        const blockLine = code.slice(blockLineStart, blockLineEnd).replace(/\r$/, "");
+        const blockTrimmed = blockLine.trim();
+
+        if (!blockTrimmed) {
+          return bodyStart;
+        }
+
+        blockStart = blockLineStart;
+        searchStart = blockLineStart;
+        foundBlockStart = blockTrimmed.startsWith("/*");
+      }
+
+      if (!foundBlockStart) {
+        break;
+      }
+
+      bodyStart = blockStart;
+      lineStart = blockStart;
+      continue;
+    }
+
+    break;
+  }
+
+  return bodyStart;
 }
 
 function formatParameterName(param) {

--- a/scaffold/scripts/parsers/javascript/chunks.mjs
+++ b/scaffold/scripts/parsers/javascript/chunks.mjs
@@ -1,9 +1,22 @@
-import { simple as walkSimple } from "acorn-walk";
+import { ancestor as walkAncestor, simple as walkSimple } from "acorn-walk";
 
 import { WALK_BASE } from "./ast.mjs";
 
 export function discoverChunks(ast, code, language = "javascript") {
   const chunks = [];
+  const exportedNames = collectExportedNames(ast);
+
+  function pushChunk(chunk) {
+    if (!chunk) {
+      return;
+    }
+
+    chunk.language = language;
+    if (exportedNames.has(chunk.name)) {
+      chunk.exported = true;
+    }
+    chunks.push(chunk);
+  }
 
   walkSimple(
     ast,
@@ -13,11 +26,7 @@ export function discoverChunks(ast, code, language = "javascript") {
           return;
         }
 
-        const chunk = extractFunctionChunk(node, "function", code);
-        if (chunk) {
-          chunk.language = language;
-          chunks.push(chunk);
-        }
+        pushChunk(extractFunctionChunk(node, "function", code));
       },
 
       ClassDeclaration(node) {
@@ -27,8 +36,7 @@ export function discoverChunks(ast, code, language = "javascript") {
 
         const chunk = extractClassChunk(node, code);
         if (chunk) {
-          chunk.language = language;
-          chunks.push(chunk);
+          pushChunk(chunk);
 
           for (const method of extractClassMethods(node, code, language)) {
             method.parentChunk = chunk.name;
@@ -52,68 +60,7 @@ export function discoverChunks(ast, code, language = "javascript") {
           }
 
           const chunk = extractFunctionChunk(declarator.init, "const", code, declarator.id.name);
-          if (chunk) {
-            chunk.language = language;
-            chunks.push(chunk);
-          }
-        }
-      },
-
-      ExportNamedDeclaration(node) {
-        if (!node.declaration) {
-          return;
-        }
-
-        if (node.declaration.type === "FunctionDeclaration") {
-          const chunk = extractFunctionChunk(node.declaration, "function", code);
-          if (chunk) {
-            chunk.exported = true;
-            chunk.language = language;
-            chunks.push(chunk);
-          }
-          return;
-        }
-
-        if (node.declaration.type === "ClassDeclaration") {
-          const chunk = extractClassChunk(node.declaration, code);
-          if (chunk) {
-            chunk.exported = true;
-            chunk.language = language;
-            chunks.push(chunk);
-
-            for (const method of extractClassMethods(node.declaration, code, language)) {
-              method.parentChunk = chunk.name;
-              chunks.push(method);
-            }
-          }
-        }
-      },
-
-      ExportDefaultDeclaration(node) {
-        if (node.declaration.type === "FunctionDeclaration") {
-          const chunk = extractFunctionChunk(node.declaration, "function", code);
-          if (chunk) {
-            chunk.exported = true;
-            chunk.default = true;
-            chunk.language = language;
-            chunks.push(chunk);
-          }
-          return;
-        }
-
-        if (node.declaration.type === "ClassDeclaration") {
-          const chunk = extractClassChunk(node.declaration, code);
-          if (chunk) {
-            chunk.exported = true;
-            chunk.default = true;
-            chunk.language = language;
-            chunks.push(chunk);
-
-            for (const method of extractClassMethods(node.declaration, code, language)) {
-              method.parentChunk = chunk.name;
-              chunks.push(method);
-            }
-          }
+          pushChunk(chunk);
         }
       }
     },
@@ -135,6 +82,164 @@ function dedupeChunks(chunks) {
   }
 
   return [...seenChunks.values()];
+}
+
+function collectExportedNames(ast) {
+  const exportedNames = new Set();
+
+  walkSimple(
+    ast,
+    {
+      ExportNamedDeclaration(node) {
+        if (node.declaration) {
+          if (
+            (node.declaration.type === "FunctionDeclaration" ||
+              node.declaration.type === "ClassDeclaration") &&
+            node.declaration.id?.name
+          ) {
+            exportedNames.add(node.declaration.id.name);
+          }
+
+          if (node.declaration.type === "VariableDeclaration") {
+            for (const declarator of node.declaration.declarations || []) {
+              if (declarator.id?.type === "Identifier") {
+                exportedNames.add(declarator.id.name);
+              }
+            }
+          }
+        }
+
+        if (!node.source) {
+          for (const specifier of node.specifiers || []) {
+            if (specifier.local?.type === "Identifier") {
+              exportedNames.add(specifier.local.name);
+            }
+          }
+        }
+      },
+
+      ExportDefaultDeclaration(node) {
+        const declaration = node.declaration;
+        if (
+          (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration") &&
+          declaration.id?.name
+        ) {
+          exportedNames.add(declaration.id.name);
+          return;
+        }
+
+        if (declaration.type === "Identifier") {
+          exportedNames.add(declaration.name);
+        }
+      }
+    },
+    WALK_BASE
+  );
+
+  walkAncestor(
+    ast,
+    {
+      AssignmentExpression(node, ancestors) {
+        if (isNestedInFunctionScope(ancestors)) {
+          return;
+        }
+
+        addCommonJsExportedNames(exportedNames, node);
+      }
+    },
+    WALK_BASE
+  );
+
+  return exportedNames;
+}
+
+function isNestedInFunctionScope(ancestors) {
+  return ancestors.slice(0, -1).some((node) =>
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  );
+}
+
+function addCommonJsExportedNames(exportedNames, assignment) {
+  const exportPath = getCommonJsExportPath(assignment.left);
+  if (!exportPath) {
+    return;
+  }
+
+  addExportedNamesFromValue(exportedNames, assignment.right);
+}
+
+function getCommonJsExportPath(node) {
+  if (!node || node.type !== "MemberExpression") {
+    return null;
+  }
+
+  const propertyName = getStaticPropertyName(node);
+  if (!propertyName) {
+    return null;
+  }
+
+  if (node.object.type === "Identifier") {
+    if (node.object.name === "exports") {
+      return ["exports", propertyName];
+    }
+
+    if (node.object.name === "module" && propertyName === "exports") {
+      return ["module", "exports"];
+    }
+  }
+
+  const objectPath = getCommonJsExportPath(node.object);
+  if (!objectPath) {
+    return null;
+  }
+
+  if (objectPath.length >= 2 && objectPath[0] === "module" && objectPath[1] === "exports") {
+    return [...objectPath, propertyName];
+  }
+
+  return null;
+}
+
+function getStaticPropertyName(node) {
+  if (!node.computed && node.property.type === "Identifier") {
+    return node.property.name;
+  }
+
+  if (node.computed && node.property.type === "Literal" && typeof node.property.value === "string") {
+    return node.property.value;
+  }
+
+  return null;
+}
+
+function addExportedNamesFromValue(exportedNames, value) {
+  if (!value) {
+    return;
+  }
+
+  if (value.type === "Identifier") {
+    exportedNames.add(value.name);
+    return;
+  }
+
+  if (value.type === "AssignmentExpression") {
+    addExportedNamesFromValue(exportedNames, value.right);
+    return;
+  }
+
+  if (value.type !== "ObjectExpression") {
+    return;
+  }
+
+  for (const property of value.properties || []) {
+    if (property.type !== "Property" || property.kind !== "init") {
+      continue;
+    }
+
+    addExportedNamesFromValue(exportedNames, property.value);
+  }
 }
 
 function extractFunctionChunk(node, kind, code, nameOverride = null) {

--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -639,7 +639,8 @@ function generateChunkDescription(chunk) {
   parts.push(chunk.signature);
 
   // Extract leading JSDoc/comment from body
-  const commentMatch = chunk.body.match(/^(?:\s*(?:\/\*\*[\s\S]*?\*\/|\/\/[^\n]*)[\s\n]*)+/);
+  // Match leading JSDoc (/** */), block (/* */) and line (//) comments
+  const commentMatch = chunk.body.match(/^(?:\s*(?:\/\*[\s\S]*?\*\/|\/\/[^\n]*)[\s\n]*)+/);
   if (commentMatch) {
     const cleaned = commentMatch[0]
       .replace(/\/\*\*|\*\/|\*|\/\//g, "")

--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -632,6 +632,138 @@ function chunkIdFor(filePath, chunk) {
   return `chunk:${filePath}:${chunk.name}:${startLine}-${endLine}`;
 }
 
+function generateChunkDescription(chunk) {
+  const parts = [chunk.kind];
+  if (chunk.exported) parts.push("exported");
+  if (chunk.async) parts.push("async");
+  parts.push(chunk.signature);
+
+  // Extract leading JSDoc/comment from body
+  const commentMatch = chunk.body.match(/^(?:\s*(?:\/\*\*[\s\S]*?\*\/|\/\/[^\n]*)[\s\n]*)+/);
+  if (commentMatch) {
+    const cleaned = commentMatch[0]
+      .replace(/\/\*\*|\*\/|\*|\/\//g, "")
+      .replace(/\s+/g, " ").trim()
+      .slice(0, 200);
+    if (cleaned.length > 10) parts.push(cleaned);
+  }
+
+  return parts.join(". ") + ".";
+}
+
+function generateModuleSummary(dir, files, exportNames) {
+  // Check for README.md in directory
+  const readmePath = path.join(REPO_ROOT, dir, "README.md");
+  if (fs.existsSync(readmePath)) {
+    try {
+      const content = fs.readFileSync(readmePath, "utf8");
+      // Skip first heading line, take first 300 chars
+      const lines = content.split(/\r?\n/);
+      const startIdx = lines.findIndex(l => !l.startsWith("#") && l.trim().length > 0);
+      if (startIdx >= 0) {
+        const excerpt = lines.slice(startIdx).join(" ").trim().slice(0, 300);
+        if (excerpt.length > 20) return excerpt;
+      }
+    } catch {
+      // fall through to auto-generated summary
+    }
+  }
+
+  const name = path.basename(dir);
+  const codeFiles = files.filter(f => f.kind === "CODE");
+  const docFiles = files.filter(f => f.kind !== "CODE");
+
+  const parts = [`Module ${name}`];
+  parts.push(`Contains ${files.length} files (${codeFiles.length} code, ${docFiles.length} docs)`);
+
+  // Detect common file extension pattern
+  const exts = new Set(codeFiles.map(f => path.extname(f.path).toLowerCase()));
+  if (exts.size === 1) {
+    const ext = [...exts][0];
+    const extNames = { ".ts": "TypeScript", ".js": "JavaScript", ".mjs": "JavaScript (ESM)", ".tsx": "TypeScript React" };
+    if (extNames[ext]) parts.push(`${extNames[ext]} source files`);
+  }
+
+  if (exportNames.length > 0) {
+    parts.push(`Key exports: ${exportNames.slice(0, 5).join(", ")}`);
+  }
+
+  return parts.join(". ") + ".";
+}
+
+function generateModules(fileRecords, chunkRecords) {
+  const dirFiles = new Map();
+  const dirChunks = new Map();
+  const fileById = new Map(fileRecords.map(f => [f.id, f]));
+
+  for (const file of fileRecords) {
+    const dir = path.dirname(file.path);
+    if (!dirFiles.has(dir)) dirFiles.set(dir, []);
+    dirFiles.get(dir).push(file);
+  }
+
+  for (const chunk of chunkRecords) {
+    if (!chunk.exported) continue;
+    const file = fileById.get(chunk.file_id);
+    if (!file) continue;
+    const dir = path.dirname(file.path);
+    if (!dirChunks.has(dir)) dirChunks.set(dir, []);
+    dirChunks.get(dir).push(chunk);
+  }
+
+  const modules = [];
+  const containsRelations = [];
+  const containsModuleRelations = [];
+  const exportsRelations = [];
+
+  const MIN_MODULE_FILES = 2;
+
+  for (const [dir, files] of dirFiles) {
+    if (files.length < MIN_MODULE_FILES) continue;
+
+    const exports = dirChunks.get(dir) || [];
+    const exportNames = exports.slice(0, 20).map(c => c.name);
+    const moduleId = `module:${dir}`;
+
+    modules.push({
+      id: moduleId,
+      path: dir,
+      name: path.basename(dir),
+      summary: generateModuleSummary(dir, files, exportNames),
+      file_count: files.length,
+      exported_symbols: exportNames.join(", "),
+      updated_at: files.reduce((latest, f) => f.updated_at > latest ? f.updated_at : latest, ""),
+      source_of_truth: false,
+      trust_level: 75,
+      status: "active"
+    });
+
+    // CONTAINS: Module -> File
+    for (const file of files) {
+      containsRelations.push({ from: moduleId, to: file.id });
+    }
+
+    // EXPORTS: Module -> Chunk
+    for (const chunk of exports) {
+      exportsRelations.push({ from: moduleId, to: chunk.id });
+    }
+  }
+
+  // CONTAINS_MODULE: parent Module -> child Module
+  const moduleDirs = new Set(modules.map(m => m.path));
+  for (const dir of moduleDirs) {
+    const parent = path.dirname(dir);
+    if (parent !== dir && moduleDirs.has(parent)) {
+      containsModuleRelations.push({
+        from: `module:${parent}`,
+        to: `module:${dir}`
+      });
+    }
+  }
+
+  return { modules, containsRelations, containsModuleRelations, exportsRelations };
+}
+
 function splitChunkIntoWindows(chunkRecord, options) {
   const { windowLines, overlapLines, splitMinLines, maxWindows, chunkBody } = options;
   const sourceBody = typeof chunkBody === "string" ? chunkBody : chunkRecord.body;
@@ -660,9 +792,11 @@ function splitChunkIntoWindows(chunkRecord, options) {
       kind: chunkRecord.kind,
       signature: `${chunkRecord.signature} [window ${windowIndex}]`,
       body: persistedBody,
+      description: chunkRecord.description || "",
       start_line: windowStartLine,
       end_line: windowEndLine,
       language: chunkRecord.language,
+      exported: chunkRecord.exported || false,
       checksum: checksum(Buffer.from(windowBody)),
       updated_at: chunkRecord.updated_at,
       trust_level: chunkRecord.trust_level,
@@ -898,9 +1032,11 @@ function main() {
           kind: chunk.kind,
           signature: chunk.signature,
           body: chunk.body.slice(0, MAX_BODY_CHARS), // Limit chunk body size
+          description: generateChunkDescription(chunk),
           start_line: chunk.startLine,
           end_line: chunk.endLine,
           language: chunk.language,
+          exported: Boolean(chunk.exported),
           checksum: checksum(Buffer.from(chunk.body)),
           updated_at: fileRecord.updated_at,
           trust_level: fileRecord.trust_level,
@@ -989,6 +1125,17 @@ function main() {
       );
     }
     console.log(`[ingest] ${validCallsRelations.length} call relations (${callsRelations.length - validCallsRelations.length} filtered)`);
+  }
+
+  // Generate Module entities and relations
+  const moduleResult = generateModules(fileRecords, chunkRecords);
+  const moduleRecords = moduleResult.modules;
+  const moduleContainsRelations = moduleResult.containsRelations;
+  const moduleContainsModuleRelations = moduleResult.containsModuleRelations;
+  const moduleExportsRelations = moduleResult.exportsRelations;
+
+  if (verbose && moduleRecords.length > 0) {
+    console.log(`[ingest] modules=${moduleRecords.length} contains=${moduleContainsRelations.length} contains_module=${moduleContainsModuleRelations.length} exports=${moduleExportsRelations.length}`);
   }
 
   const ruleRecords = rules.map((rule) => ({
@@ -1093,6 +1240,10 @@ function main() {
   writeJsonl(path.join(CACHE_DIR, "relations.defines.jsonl"), definesRelations);
   writeJsonl(path.join(CACHE_DIR, "relations.calls.jsonl"), validCallsRelations);
   writeJsonl(path.join(CACHE_DIR, "relations.imports.jsonl"), importsRelations);
+  writeJsonl(path.join(CACHE_DIR, "entities.module.jsonl"), moduleRecords);
+  writeJsonl(path.join(CACHE_DIR, "relations.contains.jsonl"), moduleContainsRelations);
+  writeJsonl(path.join(CACHE_DIR, "relations.contains_module.jsonl"), moduleContainsModuleRelations);
+  writeJsonl(path.join(CACHE_DIR, "relations.exports.jsonl"), moduleExportsRelations);
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "file_nodes.tsv"),
@@ -1254,7 +1405,11 @@ function main() {
       relations_supersedes: supersedesRelations.length,
       relations_defines: definesRelations.length,
       relations_calls: validCallsRelations.length,
-      relations_imports: importsRelations.length
+      relations_imports: importsRelations.length,
+      modules: moduleRecords.length,
+      relations_contains: moduleContainsRelations.length,
+      relations_contains_module: moduleContainsModuleRelations.length,
+      relations_exports: moduleExportsRelations.length
     },
     skipped,
     incremental_mode: incrementalMode,

--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -704,7 +704,7 @@ function generateModules(fileRecords, chunkRecords) {
   }
 
   for (const chunk of chunkRecords) {
-    if (!chunk.exported) continue;
+    if (!chunk.exported || isWindowChunkId(chunk.id)) continue;
     const file = fileById.get(chunk.file_id);
     if (!file) continue;
     const dir = path.dirname(file.path);
@@ -723,7 +723,7 @@ function generateModules(fileRecords, chunkRecords) {
     if (files.length < MIN_MODULE_FILES) continue;
 
     const exports = dirChunks.get(dir) || [];
-    const exportNames = exports.slice(0, 20).map(c => c.name);
+    const exportNames = [...new Set(exports.slice(0, 20).map(c => c.name))];
     const moduleId = `module:${dir}`;
 
     modules.push({
@@ -763,6 +763,10 @@ function generateModules(fileRecords, chunkRecords) {
   }
 
   return { modules, containsRelations, containsModuleRelations, exportsRelations };
+}
+
+function isWindowChunkId(chunkId) {
+  return typeof chunkId === "string" && chunkId.includes(":window:");
 }
 
 function splitChunkIntoWindows(chunkRecord, options) {

--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -610,6 +610,114 @@ function readJsonlSafe(filePath) {
     .filter((record) => record !== null);
 }
 
+function relationKey(...parts) {
+  return parts.map((part) => String(part ?? "")).join("|");
+}
+
+function removeChunkStateForFile(fileId, chunkRecordMap, definesRelationMap, callsRelationMap, importsRelationMap) {
+  const removedChunkIds = new Set();
+
+  for (const [chunkId, chunkRecord] of chunkRecordMap.entries()) {
+    if (chunkRecord.file_id === fileId) {
+      removedChunkIds.add(chunkId);
+      chunkRecordMap.delete(chunkId);
+    }
+  }
+
+  if (removedChunkIds.size === 0) {
+    return;
+  }
+
+  for (const [key, relation] of definesRelationMap.entries()) {
+    if (relation.from === fileId || removedChunkIds.has(relation.to)) {
+      definesRelationMap.delete(key);
+    }
+  }
+
+  for (const [key, relation] of callsRelationMap.entries()) {
+    if (removedChunkIds.has(relation.from) || removedChunkIds.has(relation.to)) {
+      callsRelationMap.delete(key);
+    }
+  }
+
+  for (const [key, relation] of importsRelationMap.entries()) {
+    if (removedChunkIds.has(relation.from)) {
+      importsRelationMap.delete(key);
+    }
+  }
+}
+
+function hydrateIncrementalChunkState(fileRecords) {
+  const fileIdSet = new Set(fileRecords.map((record) => record.id));
+  const chunkRecordMap = new Map();
+  const definesRelationMap = new Map();
+  const callsRelationMap = new Map();
+  const importsRelationMap = new Map();
+
+  for (const record of readJsonlSafe(path.join(CACHE_DIR, "entities.chunk.jsonl"))) {
+    if (!record || typeof record !== "object") continue;
+    const chunkId = String(record.id ?? "");
+    const fileId = String(record.file_id ?? "");
+    if (!chunkId || !fileIdSet.has(fileId)) {
+      continue;
+    }
+    chunkRecordMap.set(chunkId, {
+      ...record,
+      id: chunkId,
+      file_id: fileId
+    });
+  }
+
+  const chunkIdSet = new Set(chunkRecordMap.keys());
+
+  for (const record of readJsonlSafe(path.join(CACHE_DIR, "relations.defines.jsonl"))) {
+    if (!record || typeof record !== "object") continue;
+    const from = String(record.from ?? "");
+    const to = String(record.to ?? "");
+    if (!fileIdSet.has(from) || !chunkIdSet.has(to)) {
+      continue;
+    }
+    definesRelationMap.set(relationKey(from, to), { from, to });
+  }
+
+  for (const record of readJsonlSafe(path.join(CACHE_DIR, "relations.calls.jsonl"))) {
+    if (!record || typeof record !== "object") continue;
+    const from = String(record.from ?? "");
+    const to = String(record.to ?? "");
+    const callType = String(record.call_type ?? "direct");
+    if (!chunkIdSet.has(from) || !chunkIdSet.has(to)) {
+      continue;
+    }
+    callsRelationMap.set(relationKey(from, to, callType), {
+      from,
+      to,
+      call_type: callType
+    });
+  }
+
+  for (const record of readJsonlSafe(path.join(CACHE_DIR, "relations.imports.jsonl"))) {
+    if (!record || typeof record !== "object") continue;
+    const from = String(record.from ?? "");
+    const to = String(record.to ?? "");
+    const importName = String(record.import_name ?? "");
+    if (!chunkIdSet.has(from) || !fileIdSet.has(to)) {
+      continue;
+    }
+    importsRelationMap.set(relationKey(from, to, importName), {
+      from,
+      to,
+      import_name: importName
+    });
+  }
+
+  return {
+    chunkRecordMap,
+    definesRelationMap,
+    callsRelationMap,
+    importsRelationMap
+  };
+}
+
 function normalizeRuleTokens(ruleRecord) {
   const idParts = ruleRecord.id.split(/[._-]+/g);
   const descriptionTokens = tokenizeKeywords(ruleRecord.body);
@@ -996,12 +1104,29 @@ function main() {
   const fileRecords = [...fileRecordMap.values()].sort((a, b) => a.path.localeCompare(b.path));
   const adrRecords = [...adrRecordMap.values()].sort((a, b) => a.path.localeCompare(b.path));
   const indexedFileIds = new Set(fileRecords.map((record) => record.id));
+  const changedFileIds = new Set(
+    [...candidates].map((absolutePath) => `file:${toPosixPath(path.relative(REPO_ROOT, absolutePath))}`)
+  );
 
-  // Extract chunks from code files
-  const chunkRecords = [];
-  const definesRelations = [];
-  const callsRelations = [];
-  const importsRelations = [];
+  const {
+    chunkRecordMap,
+    definesRelationMap,
+    callsRelationMap,
+    importsRelationMap
+  } = incrementalMode
+    ? hydrateIncrementalChunkState(fileRecords)
+    : {
+        chunkRecordMap: new Map(),
+        definesRelationMap: new Map(),
+        callsRelationMap: new Map(),
+        importsRelationMap: new Map()
+      };
+
+  const cachedChunkFileIds = new Set(
+    [...chunkRecordMap.values()].map((record) => String(record.file_id ?? "")).filter(Boolean)
+  );
+
+  // Extract chunks from changed or uncached code files
   let windowedChunkCount = 0;
 
   for (const fileRecord of fileRecords) {
@@ -1010,6 +1135,20 @@ function main() {
     const ext = path.extname(fileRecord.path).toLowerCase();
     const supportedForChunking = [".js", ".mjs", ".cjs", ".ts"].includes(ext);
     if (!supportedForChunking) continue;
+
+    const shouldParseFile =
+      !incrementalMode || changedFileIds.has(fileRecord.id) || !cachedChunkFileIds.has(fileRecord.id);
+    if (!shouldParseFile) {
+      continue;
+    }
+
+    removeChunkStateForFile(
+      fileRecord.id,
+      chunkRecordMap,
+      definesRelationMap,
+      callsRelationMap,
+      importsRelationMap
+    );
 
     try {
       const language = ext === ".ts" ? "typescript" : "javascript";
@@ -1051,10 +1190,10 @@ function main() {
               : "active",
           source_of_truth: Boolean(fileRecord.source_of_truth)
         };
-        chunkRecords.push(chunkRecord);
+        chunkRecordMap.set(chunkId, chunkRecord);
 
         // DEFINES relation: File -> Chunk
-        definesRelations.push({
+        definesRelationMap.set(relationKey(fileRecord.id, chunkId), {
           from: fileRecord.id,
           to: chunkId
         });
@@ -1069,8 +1208,8 @@ function main() {
         if (windows.length > 0) {
           windowedChunkCount += windows.length;
           for (const windowChunk of windows) {
-            chunkRecords.push(windowChunk);
-            definesRelations.push({
+            chunkRecordMap.set(windowChunk.id, windowChunk);
+            definesRelationMap.set(relationKey(fileRecord.id, windowChunk.id), {
               from: fileRecord.id,
               to: windowChunk.id
             });
@@ -1084,7 +1223,7 @@ function main() {
             continue;
           }
 
-          importsRelations.push({
+          importsRelationMap.set(relationKey(chunkId, targetFileId, importPath), {
             from: chunkId,
             to: targetFileId,
             import_name: importPath
@@ -1103,7 +1242,7 @@ function main() {
               continue;
             }
             seenCallEdges.add(callKey);
-            callsRelations.push({
+            callsRelationMap.set(relationKey(chunkId, targetChunkId, "direct"), {
               from: chunkId,
               to: targetChunkId,
               call_type: "direct"
@@ -1118,9 +1257,20 @@ function main() {
     }
   }
 
+  const chunkRecords = [...chunkRecordMap.values()].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
   // Filter CALLS relations to only valid targets (chunks that actually exist)
   const chunkIdSet = new Set(chunkRecords.map(c => c.id));
-  const validCallsRelations = callsRelations.filter(rel => chunkIdSet.has(rel.to));
+  const validDefinesRelations = [...definesRelationMap.values()].filter(
+    (rel) => indexedFileIds.has(rel.from) && chunkIdSet.has(rel.to)
+  );
+  const totalCallsRelations = callsRelationMap.size;
+  const validCallsRelations = [...callsRelationMap.values()].filter(
+    (rel) => chunkIdSet.has(rel.from) && chunkIdSet.has(rel.to)
+  );
+  const validImportsRelations = [...importsRelationMap.values()].filter(
+    (rel) => chunkIdSet.has(rel.from) && indexedFileIds.has(rel.to)
+  );
 
   if (verbose && chunkRecords.length > 0) {
     console.log(`[ingest] extracted ${chunkRecords.length} chunks from ${fileRecords.filter(f => f.kind === "CODE").length} code files`);
@@ -1129,7 +1279,7 @@ function main() {
         `[ingest] overlap windows added=${windowedChunkCount} (window_lines=${chunkWindowLines}, overlap_lines=${chunkOverlapLines}, max_windows=${chunkMaxWindows})`
       );
     }
-    console.log(`[ingest] ${validCallsRelations.length} call relations (${callsRelations.length - validCallsRelations.length} filtered)`);
+    console.log(`[ingest] ${validCallsRelations.length} call relations (${totalCallsRelations - validCallsRelations.length} filtered)`);
   }
 
   // Generate Module entities and relations
@@ -1242,9 +1392,9 @@ function main() {
   writeJsonl(path.join(CACHE_DIR, "relations.supersedes.jsonl"), supersedesRelations);
   writeJsonl(path.join(CACHE_DIR, "relations.constrains.jsonl"), constrainsRelations);
   writeJsonl(path.join(CACHE_DIR, "relations.implements.jsonl"), implementsRelations);
-  writeJsonl(path.join(CACHE_DIR, "relations.defines.jsonl"), definesRelations);
+  writeJsonl(path.join(CACHE_DIR, "relations.defines.jsonl"), validDefinesRelations);
   writeJsonl(path.join(CACHE_DIR, "relations.calls.jsonl"), validCallsRelations);
-  writeJsonl(path.join(CACHE_DIR, "relations.imports.jsonl"), importsRelations);
+  writeJsonl(path.join(CACHE_DIR, "relations.imports.jsonl"), validImportsRelations);
   writeJsonl(path.join(CACHE_DIR, "entities.module.jsonl"), moduleRecords);
   writeJsonl(path.join(CACHE_DIR, "relations.contains.jsonl"), moduleContainsRelations);
   writeJsonl(path.join(CACHE_DIR, "relations.contains_module.jsonl"), moduleContainsModuleRelations);
@@ -1381,7 +1531,7 @@ function main() {
   writeTsv(
     path.join(DB_IMPORT_DIR, "defines_rel.tsv"),
     ["from", "to"],
-    definesRelations.map((record) => [record.from, record.to])
+    validDefinesRelations.map((record) => [record.from, record.to])
   );
 
   writeTsv(
@@ -1393,7 +1543,7 @@ function main() {
   writeTsv(
     path.join(DB_IMPORT_DIR, "imports_rel.tsv"),
     ["from", "to", "import_name"],
-    importsRelations.map((record) => [record.from, record.to, record.import_name])
+    validImportsRelations.map((record) => [record.from, record.to, record.import_name])
   );
 
   const manifest = {
@@ -1408,9 +1558,9 @@ function main() {
       relations_constrains: constrainsRelations.length,
       relations_implements: implementsRelations.length,
       relations_supersedes: supersedesRelations.length,
-      relations_defines: definesRelations.length,
+      relations_defines: validDefinesRelations.length,
       relations_calls: validCallsRelations.length,
-      relations_imports: importsRelations.length,
+      relations_imports: validImportsRelations.length,
       modules: moduleRecords.length,
       relations_contains: moduleContainsRelations.length,
       relations_contains_module: moduleContainsModuleRelations.length,

--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -652,9 +652,9 @@ function generateChunkDescription(chunk) {
   return parts.join(". ") + ".";
 }
 
-function generateModuleSummary(dir, files, exportNames) {
+function generateModuleSummary(dir, files, exportNames, repoRoot = REPO_ROOT) {
   // Check for README.md in directory
-  const readmePath = path.join(REPO_ROOT, dir, "README.md");
+  const readmePath = path.join(repoRoot, dir, "README.md");
   if (fs.existsSync(readmePath)) {
     try {
       const content = fs.readFileSync(readmePath, "utf8");
@@ -1441,4 +1441,9 @@ function main() {
   console.log(`[ingest] wrote cache + db import files under .context/`);
 }
 
-main();
+const isMainModule = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename);
+if (isMainModule) {
+  main();
+}
+
+export { generateChunkDescription, generateModuleSummary, generateModules };

--- a/scripts/parsers/javascript/chunks.mjs
+++ b/scripts/parsers/javascript/chunks.mjs
@@ -4,6 +4,19 @@ import { WALK_BASE } from "./ast.mjs";
 
 export function discoverChunks(ast, code, language = "javascript") {
   const chunks = [];
+  const exportedNames = collectExportedNames(ast);
+
+  function pushChunk(chunk) {
+    if (!chunk) {
+      return;
+    }
+
+    chunk.language = language;
+    if (exportedNames.has(chunk.name)) {
+      chunk.exported = true;
+    }
+    chunks.push(chunk);
+  }
 
   walkSimple(
     ast,
@@ -13,11 +26,7 @@ export function discoverChunks(ast, code, language = "javascript") {
           return;
         }
 
-        const chunk = extractFunctionChunk(node, "function", code);
-        if (chunk) {
-          chunk.language = language;
-          chunks.push(chunk);
-        }
+        pushChunk(extractFunctionChunk(node, "function", code));
       },
 
       ClassDeclaration(node) {
@@ -27,8 +36,7 @@ export function discoverChunks(ast, code, language = "javascript") {
 
         const chunk = extractClassChunk(node, code);
         if (chunk) {
-          chunk.language = language;
-          chunks.push(chunk);
+          pushChunk(chunk);
 
           for (const method of extractClassMethods(node, code, language)) {
             method.parentChunk = chunk.name;
@@ -52,68 +60,7 @@ export function discoverChunks(ast, code, language = "javascript") {
           }
 
           const chunk = extractFunctionChunk(declarator.init, "const", code, declarator.id.name);
-          if (chunk) {
-            chunk.language = language;
-            chunks.push(chunk);
-          }
-        }
-      },
-
-      ExportNamedDeclaration(node) {
-        if (!node.declaration) {
-          return;
-        }
-
-        if (node.declaration.type === "FunctionDeclaration") {
-          const chunk = extractFunctionChunk(node.declaration, "function", code);
-          if (chunk) {
-            chunk.exported = true;
-            chunk.language = language;
-            chunks.push(chunk);
-          }
-          return;
-        }
-
-        if (node.declaration.type === "ClassDeclaration") {
-          const chunk = extractClassChunk(node.declaration, code);
-          if (chunk) {
-            chunk.exported = true;
-            chunk.language = language;
-            chunks.push(chunk);
-
-            for (const method of extractClassMethods(node.declaration, code, language)) {
-              method.parentChunk = chunk.name;
-              chunks.push(method);
-            }
-          }
-        }
-      },
-
-      ExportDefaultDeclaration(node) {
-        if (node.declaration.type === "FunctionDeclaration") {
-          const chunk = extractFunctionChunk(node.declaration, "function", code);
-          if (chunk) {
-            chunk.exported = true;
-            chunk.default = true;
-            chunk.language = language;
-            chunks.push(chunk);
-          }
-          return;
-        }
-
-        if (node.declaration.type === "ClassDeclaration") {
-          const chunk = extractClassChunk(node.declaration, code);
-          if (chunk) {
-            chunk.exported = true;
-            chunk.default = true;
-            chunk.language = language;
-            chunks.push(chunk);
-
-            for (const method of extractClassMethods(node.declaration, code, language)) {
-              method.parentChunk = chunk.name;
-              chunks.push(method);
-            }
-          }
+          pushChunk(chunk);
         }
       }
     },
@@ -135,6 +82,61 @@ function dedupeChunks(chunks) {
   }
 
   return [...seenChunks.values()];
+}
+
+function collectExportedNames(ast) {
+  const exportedNames = new Set();
+
+  walkSimple(
+    ast,
+    {
+      ExportNamedDeclaration(node) {
+        if (node.declaration) {
+          if (
+            (node.declaration.type === "FunctionDeclaration" ||
+              node.declaration.type === "ClassDeclaration") &&
+            node.declaration.id?.name
+          ) {
+            exportedNames.add(node.declaration.id.name);
+          }
+
+          if (node.declaration.type === "VariableDeclaration") {
+            for (const declarator of node.declaration.declarations || []) {
+              if (declarator.id?.type === "Identifier") {
+                exportedNames.add(declarator.id.name);
+              }
+            }
+          }
+        }
+
+        if (!node.source) {
+          for (const specifier of node.specifiers || []) {
+            if (specifier.local?.type === "Identifier") {
+              exportedNames.add(specifier.local.name);
+            }
+          }
+        }
+      },
+
+      ExportDefaultDeclaration(node) {
+        const declaration = node.declaration;
+        if (
+          (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration") &&
+          declaration.id?.name
+        ) {
+          exportedNames.add(declaration.id.name);
+          return;
+        }
+
+        if (declaration.type === "Identifier") {
+          exportedNames.add(declaration.name);
+        }
+      }
+    },
+    WALK_BASE
+  );
+
+  return exportedNames;
 }
 
 function extractFunctionChunk(node, kind, code, nameOverride = null) {

--- a/scripts/parsers/javascript/chunks.mjs
+++ b/scripts/parsers/javascript/chunks.mjs
@@ -1,4 +1,4 @@
-import { simple as walkSimple } from "acorn-walk";
+import { ancestor as walkAncestor, simple as walkSimple } from "acorn-walk";
 
 import { WALK_BASE } from "./ast.mjs";
 
@@ -136,7 +136,110 @@ function collectExportedNames(ast) {
     WALK_BASE
   );
 
+  walkAncestor(
+    ast,
+    {
+      AssignmentExpression(node, ancestors) {
+        if (isNestedInFunctionScope(ancestors)) {
+          return;
+        }
+
+        addCommonJsExportedNames(exportedNames, node);
+      }
+    },
+    WALK_BASE
+  );
+
   return exportedNames;
+}
+
+function isNestedInFunctionScope(ancestors) {
+  return ancestors.slice(0, -1).some((node) =>
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  );
+}
+
+function addCommonJsExportedNames(exportedNames, assignment) {
+  const exportPath = getCommonJsExportPath(assignment.left);
+  if (!exportPath) {
+    return;
+  }
+
+  addExportedNamesFromValue(exportedNames, assignment.right);
+}
+
+function getCommonJsExportPath(node) {
+  if (!node || node.type !== "MemberExpression") {
+    return null;
+  }
+
+  const propertyName = getStaticPropertyName(node);
+  if (!propertyName) {
+    return null;
+  }
+
+  if (node.object.type === "Identifier") {
+    if (node.object.name === "exports") {
+      return ["exports", propertyName];
+    }
+
+    if (node.object.name === "module" && propertyName === "exports") {
+      return ["module", "exports"];
+    }
+  }
+
+  const objectPath = getCommonJsExportPath(node.object);
+  if (!objectPath) {
+    return null;
+  }
+
+  if (objectPath.length >= 2 && objectPath[0] === "module" && objectPath[1] === "exports") {
+    return [...objectPath, propertyName];
+  }
+
+  return null;
+}
+
+function getStaticPropertyName(node) {
+  if (!node.computed && node.property.type === "Identifier") {
+    return node.property.name;
+  }
+
+  if (node.computed && node.property.type === "Literal" && typeof node.property.value === "string") {
+    return node.property.value;
+  }
+
+  return null;
+}
+
+function addExportedNamesFromValue(exportedNames, value) {
+  if (!value) {
+    return;
+  }
+
+  if (value.type === "Identifier") {
+    exportedNames.add(value.name);
+    return;
+  }
+
+  if (value.type === "AssignmentExpression") {
+    addExportedNamesFromValue(exportedNames, value.right);
+    return;
+  }
+
+  if (value.type !== "ObjectExpression") {
+    return;
+  }
+
+  for (const property of value.properties || []) {
+    if (property.type !== "Property" || property.kind !== "init") {
+      continue;
+    }
+
+    addExportedNamesFromValue(exportedNames, property.value);
+  }
 }
 
 function extractFunctionChunk(node, kind, code, nameOverride = null) {

--- a/scripts/parsers/javascript/chunks.mjs
+++ b/scripts/parsers/javascript/chunks.mjs
@@ -146,12 +146,13 @@ function extractFunctionChunk(node, kind, code, nameOverride = null) {
   }
 
   const params = (node.params || []).map(formatParameterName);
+  const bodyStart = findLeadingCommentStart(code, node);
 
   return {
     name,
     kind,
     signature: `${name}(${params.join(", ")})`,
-    body: code.slice(node.start, node.end),
+    body: code.slice(bodyStart, node.end),
     startLine: node.loc.start.line,
     endLine: node.loc.end.line,
     callNode: node.body || node,
@@ -168,12 +169,13 @@ function extractClassChunk(node, code) {
   }
 
   const superClass = node.superClass?.name || null;
+  const bodyStart = findLeadingCommentStart(code, node);
 
   return {
     name,
     kind: "class",
     signature: superClass ? `class ${name} extends ${superClass}` : `class ${name}`,
-    body: code.slice(node.start, node.end),
+    body: code.slice(bodyStart, node.end),
     startLine: node.loc.start.line,
     endLine: node.loc.end.line,
     callNode: node.body,
@@ -194,12 +196,13 @@ function extractClassMethods(classNode, code, language) {
     const params = (member.value.params || []).map(formatParameterName);
     const isStatic = member.static === true;
     const prefix = isStatic ? "static " : "";
+    const bodyStart = findLeadingCommentStart(code, member);
 
     methods.push({
       name: `${className}.${member.key.name}`,
       kind: "method",
       signature: `${prefix}${member.key.name}(${params.join(", ")})`,
-      body: code.slice(member.start, member.end),
+      body: code.slice(bodyStart, member.end),
       startLine: member.loc.start.line,
       endLine: member.loc.end.line,
       callNode: member.value.body,
@@ -212,6 +215,61 @@ function extractClassMethods(classNode, code, language) {
   }
 
   return methods;
+}
+
+function findLeadingCommentStart(code, node) {
+  let bodyStart = node.start;
+  let lineStart = code.lastIndexOf("\n", node.start - 1) + 1;
+
+  while (lineStart > 0) {
+    const previousLineEnd = lineStart - 1;
+    const previousLineStart = code.lastIndexOf("\n", previousLineEnd - 1) + 1;
+    const previousLine = code.slice(previousLineStart, previousLineEnd).replace(/\r$/, "");
+    const trimmed = previousLine.trim();
+
+    if (!trimmed) {
+      break;
+    }
+
+    if (trimmed.startsWith("//")) {
+      bodyStart = previousLineStart;
+      lineStart = previousLineStart;
+      continue;
+    }
+
+    if (trimmed.endsWith("*/")) {
+      let blockStart = previousLineStart;
+      let searchStart = previousLineStart;
+      let foundBlockStart = trimmed.startsWith("/*");
+
+      while (!foundBlockStart && searchStart > 0) {
+        const blockLineEnd = searchStart - 1;
+        const blockLineStart = code.lastIndexOf("\n", blockLineEnd - 1) + 1;
+        const blockLine = code.slice(blockLineStart, blockLineEnd).replace(/\r$/, "");
+        const blockTrimmed = blockLine.trim();
+
+        if (!blockTrimmed) {
+          return bodyStart;
+        }
+
+        blockStart = blockLineStart;
+        searchStart = blockLineStart;
+        foundBlockStart = blockTrimmed.startsWith("/*");
+      }
+
+      if (!foundBlockStart) {
+        break;
+      }
+
+      bodyStart = blockStart;
+      lineStart = blockStart;
+      continue;
+    }
+
+    break;
+  }
+
+  return bodyStart;
 }
 
 function formatParameterName(param) {

--- a/tests/context-regressions.test.mjs
+++ b/tests/context-regressions.test.mjs
@@ -696,8 +696,146 @@ ranking:
   }
 }
 
+function testIngestIncrementalPreservesModuleExports() {
+  console.log("\n7. ingest incremental preserves module exports for unchanged sibling files");
+  const fixtureRoot = makeTempDir("cortex-ingest-module-exports-");
+  try {
+    fs.mkdirSync(path.join(fixtureRoot, ".context"), { recursive: true });
+    fs.mkdirSync(path.join(fixtureRoot, "scripts", "parsers"), { recursive: true });
+    fs.mkdirSync(path.join(fixtureRoot, "src", "lib"), { recursive: true });
+
+    const ingestSource = fs.readFileSync(INGEST_PATH, "utf8").replace(
+      'import { parseCode } from "./parsers/javascript.mjs";',
+      'import { parseCode } from "./parsers/mock-parser.mjs";'
+    );
+    fs.writeFileSync(path.join(fixtureRoot, "scripts", "ingest.mjs"), ingestSource, "utf8");
+
+    fs.writeFileSync(
+      path.join(fixtureRoot, "scripts", "parsers", "mock-parser.mjs"),
+      `export function parseCode(_content, filePath) {
+  if (filePath === "src/lib/a.ts") {
+    return {
+      errors: [],
+      chunks: [
+        {
+          name: "alpha",
+          kind: "function",
+          signature: "alpha()",
+          body: "export function alpha() { return 1; }",
+          startLine: 1,
+          endLine: 1,
+          calls: [],
+          imports: [],
+          language: "typescript",
+          exported: true
+        }
+      ]
+    };
+  }
+
+  if (filePath === "src/lib/b.ts") {
+    return {
+      errors: [],
+      chunks: [
+        {
+          name: "beta",
+          kind: "function",
+          signature: "beta()",
+          body: "export function beta() { return 2; }",
+          startLine: 1,
+          endLine: 1,
+          calls: [],
+          imports: [],
+          language: "typescript",
+          exported: true
+        }
+      ]
+    };
+  }
+
+  return { errors: [], chunks: [] };
+}
+`,
+      "utf8"
+    );
+
+    fs.writeFileSync(
+      path.join(fixtureRoot, ".context", "config.yaml"),
+      `repo_id: fixture
+source_paths:
+  - src
+truth_order:
+  - ADR
+  - RULE
+  - CODE
+  - WIKI
+ranking:
+  semantic: 0.40
+  graph: 0.25
+  trust: 0.20
+  recency: 0.15
+`,
+      "utf8"
+    );
+
+    fs.writeFileSync(
+      path.join(fixtureRoot, ".context", "rules.yaml"),
+      `rules:
+  - id: rule.test
+    description: "fixture rule"
+    priority: 1
+    enforce: true
+`,
+      "utf8"
+    );
+
+    fs.writeFileSync(path.join(fixtureRoot, "src", "lib", "a.ts"), "export const alpha = 1;\n", "utf8");
+    fs.writeFileSync(path.join(fixtureRoot, "src", "lib", "b.ts"), "export const beta = 2;\n", "utf8");
+
+    run("git", ["init"], { cwd: fixtureRoot });
+    run("git", ["checkout", "-b", "main"], { cwd: fixtureRoot });
+    run("git", ["config", "user.email", "tests@example.com"], { cwd: fixtureRoot });
+    run("git", ["config", "user.name", "Cortex Tests"], { cwd: fixtureRoot });
+    run("git", ["add", "."], { cwd: fixtureRoot });
+    run("git", ["commit", "-m", "initial fixture"], { cwd: fixtureRoot });
+
+    run("node", ["scripts/ingest.mjs"], { cwd: fixtureRoot });
+
+    let modules = parseJsonl(path.join(fixtureRoot, ".context", "cache", "entities.module.jsonl"));
+    let exports = parseJsonl(path.join(fixtureRoot, ".context", "cache", "relations.exports.jsonl"));
+    let libModule = modules.find((record) => record.id === "module:src/lib");
+
+    assert("full ingest creates src/lib module", Boolean(libModule));
+    assert(
+      "full ingest exports both alpha and beta",
+      exports.some((edge) => edge.from === "module:src/lib" && edge.to === "chunk:src/lib/a.ts:alpha:1-1") &&
+        exports.some((edge) => edge.from === "module:src/lib" && edge.to === "chunk:src/lib/b.ts:beta:1-1")
+    );
+
+    fs.writeFileSync(path.join(fixtureRoot, "src", "lib", "a.ts"), "export const alpha = 3;\n", "utf8");
+
+    run("node", ["scripts/ingest.mjs", "--changed"], { cwd: fixtureRoot });
+
+    modules = parseJsonl(path.join(fixtureRoot, ".context", "cache", "entities.module.jsonl"));
+    exports = parseJsonl(path.join(fixtureRoot, ".context", "cache", "relations.exports.jsonl"));
+    libModule = modules.find((record) => record.id === "module:src/lib");
+
+    assert("incremental ingest keeps src/lib module", Boolean(libModule));
+    assert(
+      "incremental ingest keeps unchanged sibling export relation",
+      exports.some((edge) => edge.from === "module:src/lib" && edge.to === "chunk:src/lib/b.ts:beta:1-1")
+    );
+    assert(
+      "incremental ingest keeps exported_symbols for both siblings",
+      libModule?.exported_symbols === "alpha, beta"
+    );
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
 function testIngestWindowChunksKeepRelationsOnBaseChunk() {
-  console.log("\n7. ingest keeps call/import relations on the base chunk only");
+  console.log("\n8. ingest keeps call/import relations on the base chunk only");
   const fixtureRoot = makeTempDir("cortex-ingest-window-relations-");
   try {
     fs.mkdirSync(path.join(fixtureRoot, ".context"), { recursive: true });
@@ -1620,6 +1758,7 @@ testIngestChunkOverlapWindows();
 testIngestChunkZeroOverlapConfig();
 testIngestChunkMaxWindowCap();
 testIngestChunkMetadataInheritanceInIncrementalMode();
+testIngestIncrementalPreservesModuleExports();
 testIngestWindowChunksKeepRelationsOnBaseChunk();
 testIngestAssignsImportEdgesOnlyToChunksThatUseImports();
 testParserPreservesSideEffectImportsForAllChunks();

--- a/tests/ingest-units.test.mjs
+++ b/tests/ingest-units.test.mjs
@@ -223,6 +223,30 @@ test("generateModules: exported chunks create EXPORTS relations", () => {
   assert.ok(result.exportsRelations.some(r => r.from === "module:lib" && r.to === "chunk:lib/b.ts:bar:1-5"));
 });
 
+test("generateModules: window chunks are excluded from module exports", () => {
+  const files = [
+    { id: "file:lib/a.ts", path: "lib/a.ts", kind: "CODE", updated_at: "2026-01-01" },
+    { id: "file:lib/b.ts", path: "lib/b.ts", kind: "CODE", updated_at: "2026-01-01" }
+  ];
+  const chunks = [
+    { id: "chunk:lib/a.ts:foo:1-120", file_id: "file:lib/a.ts", name: "foo", exported: true },
+    {
+      id: "chunk:lib/a.ts:foo:1-120:window:1:1-80",
+      file_id: "file:lib/a.ts",
+      name: "foo#window1",
+      exported: true
+    }
+  ];
+  const result = generateModules(files, chunks);
+
+  assert.equal(result.exportsRelations.length, 1);
+  assert.deepEqual(result.exportsRelations[0], {
+    from: "module:lib",
+    to: "chunk:lib/a.ts:foo:1-120"
+  });
+  assert.equal(result.modules[0].exported_symbols, "foo");
+});
+
 test("generateModules: no exported chunks means empty exports", () => {
   const files = [
     { id: "file:lib/a.ts", path: "lib/a.ts", kind: "CODE", updated_at: "2026-01-01" },

--- a/tests/ingest-units.test.mjs
+++ b/tests/ingest-units.test.mjs
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for ingest helper functions: generateChunkDescription,
+ * generateModuleSummary, and generateModules.
+ *
+ * Run with: node --test tests/ingest-units.test.mjs
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { generateChunkDescription, generateModuleSummary, generateModules } from "../scripts/ingest.mjs";
+
+// ─── generateChunkDescription ────────────────────────────────────────────────
+
+test("generateChunkDescription: basic function with signature", () => {
+  const chunk = { kind: "function", signature: "foo()", body: "", exported: false, async: false };
+  const result = generateChunkDescription(chunk);
+  assert.equal(result, "function. foo().");
+});
+
+test("generateChunkDescription: exported async function", () => {
+  const chunk = { kind: "function", signature: "bar(x)", body: "", exported: true, async: true };
+  const result = generateChunkDescription(chunk);
+  assert.equal(result, "function. exported. async. bar(x).");
+});
+
+test("generateChunkDescription: extracts JSDoc comment", () => {
+  const chunk = {
+    kind: "function",
+    signature: "process(data)",
+    body: "/** Processes input data and returns the result */\nfunction process(data) { return data; }",
+    exported: false,
+    async: false
+  };
+  const result = generateChunkDescription(chunk);
+  assert.ok(result.includes("Processes input data"), `Expected JSDoc content in: ${result}`);
+});
+
+test("generateChunkDescription: extracts line comment", () => {
+  const chunk = {
+    kind: "function",
+    signature: "helper()",
+    body: "// This is a helpful utility function\nfunction helper() {}",
+    exported: false,
+    async: false
+  };
+  const result = generateChunkDescription(chunk);
+  assert.ok(result.includes("This is a helpful utility function"), `Expected comment in: ${result}`);
+});
+
+test("generateChunkDescription: ignores short comments (<= 10 chars)", () => {
+  const chunk = {
+    kind: "function",
+    signature: "fn()",
+    body: "// hi\nfunction fn() {}",
+    exported: false,
+    async: false
+  };
+  const result = generateChunkDescription(chunk);
+  assert.equal(result, "function. fn().");
+});
+
+test("generateChunkDescription: body with no comments", () => {
+  const chunk = {
+    kind: "class",
+    signature: "class Foo",
+    body: "class Foo { constructor() {} }",
+    exported: false,
+    async: false
+  };
+  const result = generateChunkDescription(chunk);
+  assert.equal(result, "class. class Foo.");
+});
+
+test("generateChunkDescription: very long signature is preserved", () => {
+  const longSig = "a".repeat(500);
+  const chunk = { kind: "function", signature: longSig, body: "", exported: false, async: false };
+  const result = generateChunkDescription(chunk);
+  assert.ok(result.includes(longSig));
+});
+
+// ─── generateModuleSummary ───────────────────────────────────────────────────
+
+test("generateModuleSummary: auto-generated when no README", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ingest-test-"));
+  const files = [
+    { path: "src/foo.ts", kind: "CODE" },
+    { path: "src/bar.ts", kind: "CODE" }
+  ];
+  const result = generateModuleSummary("src", files, ["foo", "bar"], tmpDir);
+  assert.ok(result.startsWith("Module src"), `Expected auto summary, got: ${result}`);
+  assert.ok(result.includes("2 files"));
+  assert.ok(result.includes("2 code"));
+  assert.ok(result.includes("Key exports: foo, bar"));
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("generateModuleSummary: reads README.md when present", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ingest-test-"));
+  const srcDir = path.join(tmpDir, "src");
+  fs.mkdirSync(srcDir, { recursive: true });
+  fs.writeFileSync(path.join(srcDir, "README.md"), "# My Module\nThis module handles authentication and session management for the app.\n");
+
+  const files = [{ path: "src/auth.ts", kind: "CODE" }];
+  const result = generateModuleSummary("src", files, [], tmpDir);
+  assert.ok(result.includes("authentication"), `Expected README content, got: ${result}`);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("generateModuleSummary: falls back to auto if README too short", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ingest-test-"));
+  const srcDir = path.join(tmpDir, "src");
+  fs.mkdirSync(srcDir, { recursive: true });
+  fs.writeFileSync(path.join(srcDir, "README.md"), "# Title\nShort.\n");
+
+  const files = [
+    { path: "src/a.ts", kind: "CODE" },
+    { path: "src/b.ts", kind: "CODE" }
+  ];
+  const result = generateModuleSummary("src", files, [], tmpDir);
+  assert.ok(result.startsWith("Module src"), `Expected auto fallback, got: ${result}`);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("generateModuleSummary: mixed file types count correctly", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ingest-test-"));
+  const files = [
+    { path: "lib/index.ts", kind: "CODE" },
+    { path: "lib/README.md", kind: "DOC" },
+    { path: "lib/utils.ts", kind: "CODE" }
+  ];
+  const result = generateModuleSummary("lib", files, [], tmpDir);
+  assert.ok(result.includes("3 files"), `Expected 3 files, got: ${result}`);
+  assert.ok(result.includes("2 code"), `Expected 2 code, got: ${result}`);
+  assert.ok(result.includes("1 docs"), `Expected 1 docs, got: ${result}`);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("generateModuleSummary: single extension detected", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ingest-test-"));
+  const files = [
+    { path: "src/a.ts", kind: "CODE" },
+    { path: "src/b.ts", kind: "CODE" }
+  ];
+  const result = generateModuleSummary("src", files, [], tmpDir);
+  assert.ok(result.includes("TypeScript"), `Expected TypeScript mention, got: ${result}`);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("generateModuleSummary: multiple extensions — no extension text", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ingest-test-"));
+  const files = [
+    { path: "src/a.ts", kind: "CODE" },
+    { path: "src/b.js", kind: "CODE" }
+  ];
+  const result = generateModuleSummary("src", files, [], tmpDir);
+  assert.ok(!result.includes("TypeScript"), `Expected no extension text, got: ${result}`);
+  assert.ok(!result.includes("JavaScript"), `Expected no extension text, got: ${result}`);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── generateModules ─────────────────────────────────────────────────────────
+
+test("generateModules: skips directories with fewer than 2 files", () => {
+  const files = [{ id: "file:src/only.ts", path: "src/only.ts", kind: "CODE", updated_at: "2026-01-01" }];
+  const chunks = [];
+  const result = generateModules(files, chunks);
+  assert.equal(result.modules.length, 0);
+  assert.equal(result.containsRelations.length, 0);
+});
+
+test("generateModules: creates module for directory with 2+ files", () => {
+  const files = [
+    { id: "file:src/a.ts", path: "src/a.ts", kind: "CODE", updated_at: "2026-01-01" },
+    { id: "file:src/b.ts", path: "src/b.ts", kind: "CODE", updated_at: "2026-01-02" }
+  ];
+  const chunks = [];
+  const result = generateModules(files, chunks);
+  assert.equal(result.modules.length, 1);
+  assert.equal(result.modules[0].id, "module:src");
+  assert.equal(result.modules[0].name, "src");
+  assert.equal(result.modules[0].file_count, 2);
+  assert.equal(result.containsRelations.length, 2);
+});
+
+test("generateModules: CONTAINS_MODULE only creates direct parent-child links", () => {
+  const files = [
+    { id: "file:a/f1.ts", path: "a/f1.ts", kind: "CODE", updated_at: "2026-01-01" },
+    { id: "file:a/f2.ts", path: "a/f2.ts", kind: "CODE", updated_at: "2026-01-01" },
+    { id: "file:a/b/f1.ts", path: "a/b/f1.ts", kind: "CODE", updated_at: "2026-01-01" },
+    { id: "file:a/b/f2.ts", path: "a/b/f2.ts", kind: "CODE", updated_at: "2026-01-01" },
+    { id: "file:a/b/c/f1.ts", path: "a/b/c/f1.ts", kind: "CODE", updated_at: "2026-01-01" },
+    { id: "file:a/b/c/f2.ts", path: "a/b/c/f2.ts", kind: "CODE", updated_at: "2026-01-01" }
+  ];
+  const chunks = [];
+  const result = generateModules(files, chunks);
+
+  assert.equal(result.modules.length, 3);
+  assert.equal(result.containsModuleRelations.length, 2);
+
+  const cmRels = result.containsModuleRelations;
+  assert.ok(cmRels.some(r => r.from === "module:a" && r.to === "module:a/b"));
+  assert.ok(cmRels.some(r => r.from === "module:a/b" && r.to === "module:a/b/c"));
+  // No direct link from a to a/b/c
+  assert.ok(!cmRels.some(r => r.from === "module:a" && r.to === "module:a/b/c"));
+});
+
+test("generateModules: exported chunks create EXPORTS relations", () => {
+  const files = [
+    { id: "file:lib/a.ts", path: "lib/a.ts", kind: "CODE", updated_at: "2026-01-01" },
+    { id: "file:lib/b.ts", path: "lib/b.ts", kind: "CODE", updated_at: "2026-01-01" }
+  ];
+  const chunks = [
+    { id: "chunk:lib/a.ts:foo:1-5", file_id: "file:lib/a.ts", name: "foo", exported: true },
+    { id: "chunk:lib/b.ts:bar:1-5", file_id: "file:lib/b.ts", name: "bar", exported: true },
+    { id: "chunk:lib/b.ts:internal:6-10", file_id: "file:lib/b.ts", name: "internal", exported: false }
+  ];
+  const result = generateModules(files, chunks);
+
+  assert.equal(result.exportsRelations.length, 2);
+  assert.ok(result.exportsRelations.some(r => r.from === "module:lib" && r.to === "chunk:lib/a.ts:foo:1-5"));
+  assert.ok(result.exportsRelations.some(r => r.from === "module:lib" && r.to === "chunk:lib/b.ts:bar:1-5"));
+});
+
+test("generateModules: no exported chunks means empty exports", () => {
+  const files = [
+    { id: "file:lib/a.ts", path: "lib/a.ts", kind: "CODE", updated_at: "2026-01-01" },
+    { id: "file:lib/b.ts", path: "lib/b.ts", kind: "CODE", updated_at: "2026-01-01" }
+  ];
+  const chunks = [
+    { id: "chunk:lib/a.ts:fn:1-5", file_id: "file:lib/a.ts", name: "fn", exported: false }
+  ];
+  const result = generateModules(files, chunks);
+
+  assert.equal(result.modules.length, 1);
+  assert.equal(result.exportsRelations.length, 0);
+  assert.equal(result.modules[0].exported_symbols, "");
+});

--- a/tests/javascript-parser.test.mjs
+++ b/tests/javascript-parser.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { parseCode } from "../scripts/parsers/javascript.mjs";
+import { parseCode as parseScaffoldCode } from "../scaffold/scripts/parsers/javascript.mjs";
 
 test("parseCode marks exported variable declarations as exported", () => {
   const source = [
@@ -35,6 +36,46 @@ test("parseCode marks default identifier exports as exported", () => {
   const chunks = parseCode(source, "fixture.ts", "typescript").chunks;
   assert.equal(chunks.find((chunk) => chunk.name === "foo")?.exported, true);
 });
+
+test("scaffold parseCode marks common ESM export forms as exported", () => {
+  const source = [
+    "export const foo = () => {};",
+    "const bar = () => {};",
+    "function baz() { return 1; }",
+    "export { bar };",
+    "export default baz;"
+  ].join("\n");
+
+  const chunks = parseScaffoldCode(source, "fixture.ts", "typescript").chunks;
+  const chunkByName = new Map(chunks.map((chunk) => [chunk.name, chunk]));
+
+  assert.equal(chunkByName.get("foo")?.exported, true);
+  assert.equal(chunkByName.get("bar")?.exported, true);
+  assert.equal(chunkByName.get("baz")?.exported, true);
+});
+
+for (const [label, parser] of [
+  ["main", parseCode],
+  ["scaffold", parseScaffoldCode]
+]) {
+  test(`${label} parseCode marks CommonJS exports as exported`, () => {
+    const source = [
+      "function alpha() { return 1; }",
+      "const beta = () => 2;",
+      "class Gamma {}",
+      "module.exports = { alpha };",
+      "exports.beta = beta;",
+      "module.exports.Gamma = Gamma;"
+    ].join("\n");
+
+    const chunks = parser(source, "fixture.cjs", "javascript").chunks;
+    const chunkByName = new Map(chunks.map((chunk) => [chunk.name, chunk]));
+
+    assert.equal(chunkByName.get("alpha")?.exported, true);
+    assert.equal(chunkByName.get("beta")?.exported, true);
+    assert.equal(chunkByName.get("Gamma")?.exported, true);
+  });
+}
 
 test("parseCode includes leading JSDoc in function chunk bodies", () => {
   const source = [

--- a/tests/javascript-parser.test.mjs
+++ b/tests/javascript-parser.test.mjs
@@ -35,3 +35,31 @@ test("parseCode marks default identifier exports as exported", () => {
   const chunks = parseCode(source, "fixture.ts", "typescript").chunks;
   assert.equal(chunks.find((chunk) => chunk.name === "foo")?.exported, true);
 });
+
+test("parseCode includes leading JSDoc in function chunk bodies", () => {
+  const source = [
+    "/**",
+    " * Processes incoming records.",
+    " */",
+    "function processRecords(input) {",
+    "  return input;",
+    "}"
+  ].join("\n");
+
+  const chunks = parseCode(source, "fixture.js", "javascript").chunks;
+  const body = chunks.find((chunk) => chunk.name === "processRecords")?.body ?? "";
+
+  assert.match(body, /^\/\*\*[\s\S]*function processRecords/);
+});
+
+test("parseCode includes leading line comments for const function chunks", () => {
+  const source = [
+    "// Shared helper for retries",
+    "const retry = () => true;"
+  ].join("\n");
+
+  const chunks = parseCode(source, "fixture.js", "javascript").chunks;
+  const body = chunks.find((chunk) => chunk.name === "retry")?.body ?? "";
+
+  assert.match(body, /^\/\/ Shared helper for retries\nconst retry =/);
+});

--- a/tests/javascript-parser.test.mjs
+++ b/tests/javascript-parser.test.mjs
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseCode } from "../scripts/parsers/javascript.mjs";
+
+test("parseCode marks exported variable declarations as exported", () => {
+  const source = [
+    "export const foo = () => {};",
+    "const bar = () => {};",
+    "export { bar };"
+  ].join("\n");
+
+  const chunks = parseCode(source, "fixture.ts", "typescript").chunks;
+  const chunkByName = new Map(chunks.map((chunk) => [chunk.name, chunk]));
+
+  assert.equal(chunkByName.get("foo")?.exported, true);
+  assert.equal(chunkByName.get("bar")?.exported, true);
+});
+
+test("parseCode does not mark re-export specifiers as local exports", () => {
+  const source = [
+    "const foo = () => {};",
+    'export { bar } from "./dep";'
+  ].join("\n");
+
+  const chunks = parseCode(source, "fixture.ts", "typescript").chunks;
+  assert.equal(chunks.find((chunk) => chunk.name === "foo")?.exported, undefined);
+});
+
+test("parseCode marks default identifier exports as exported", () => {
+  const source = [
+    "const foo = () => {};",
+    "export default foo;"
+  ].join("\n");
+
+  const chunks = parseCode(source, "fixture.ts", "typescript").chunks;
+  assert.equal(chunks.find((chunk) => chunk.name === "foo")?.exported, true);
+});

--- a/tests/multi-level.test.mjs
+++ b/tests/multi-level.test.mjs
@@ -168,6 +168,16 @@ test("EXPORTS relations link modules to exported chunks", () => {
   }
 });
 
+test("EXPORTS relations exclude synthetic window chunks", () => {
+  ensureIngest();
+
+  const exports = readJsonl(path.join(CACHE_DIR, "relations.exports.jsonl"));
+  assert.ok(
+    exports.every((rel) => !String(rel.to).includes(":window:")),
+    "EXPORTS relations should not point to synthetic window chunks"
+  );
+});
+
 test("DEFINES relations exist", () => {
   ensureIngest();
 

--- a/tests/multi-level.test.mjs
+++ b/tests/multi-level.test.mjs
@@ -1,0 +1,187 @@
+/**
+ * Tests for multi-level representations: Module entities, Chunk descriptions,
+ * and their integration through the ingest pipeline.
+ *
+ * These tests run ingest against the real repo and validate JSONL outputs.
+ * Run with: node --test tests/multi-level.test.mjs
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, "..");
+const CACHE_DIR = path.join(REPO_ROOT, ".context", "cache");
+const INGEST_PATH = path.join(REPO_ROOT, "scripts", "ingest.mjs");
+
+function readJsonl(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  return fs
+    .readFileSync(filePath, "utf8")
+    .split(/\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+// Run ingest once before all tests
+let ingestRan = false;
+function ensureIngest() {
+  if (ingestRan) return;
+  execFileSync("node", [INGEST_PATH], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: 60000
+  });
+  ingestRan = true;
+}
+
+test("ingest produces chunk entities with description and exported fields", () => {
+  ensureIngest();
+
+  const chunks = readJsonl(path.join(CACHE_DIR, "entities.chunk.jsonl"));
+  assert.ok(chunks.length > 0, "should have chunk entities");
+
+  for (const chunk of chunks) {
+    assert.ok(typeof chunk.description === "string", `chunk ${chunk.id} missing description`);
+    assert.ok(typeof chunk.exported === "boolean", `chunk ${chunk.id} missing exported field`);
+  }
+
+  // At least some chunks should have non-empty descriptions
+  const withDescription = chunks.filter((c) => c.description.length > 0);
+  assert.ok(withDescription.length > 0, "some chunks should have descriptions");
+});
+
+test("chunk description includes kind and signature info", () => {
+  ensureIngest();
+
+  const chunks = readJsonl(path.join(CACHE_DIR, "entities.chunk.jsonl"));
+  const withDescription = chunks.filter((c) => c.description.length > 0);
+
+  for (const chunk of withDescription.slice(0, 10)) {
+    // Description should start with the kind
+    assert.ok(
+      chunk.description.includes(chunk.kind) || chunk.description.startsWith(chunk.kind),
+      `chunk ${chunk.id} description should reference its kind "${chunk.kind}"`
+    );
+  }
+});
+
+test("exported chunks are correctly identified", () => {
+  ensureIngest();
+
+  const chunks = readJsonl(path.join(CACHE_DIR, "entities.chunk.jsonl"));
+  const exported = chunks.filter((c) => c.exported === true);
+  const unexported = chunks.filter((c) => c.exported === false);
+
+  assert.ok(exported.length > 0, "should have some exported chunks");
+  assert.ok(unexported.length > 0, "should have some non-exported chunks");
+});
+
+test("ingest produces module entities", () => {
+  ensureIngest();
+
+  const modules = readJsonl(path.join(CACHE_DIR, "entities.module.jsonl"));
+  assert.ok(modules.length > 0, "should have module entities");
+
+  for (const mod of modules) {
+    assert.ok(mod.id.startsWith("module:"), `module id should start with "module:": ${mod.id}`);
+    assert.ok(mod.path, `module ${mod.id} should have a path`);
+    assert.ok(mod.name, `module ${mod.id} should have a name`);
+    assert.ok(typeof mod.summary === "string", `module ${mod.id} should have a summary`);
+    assert.ok(typeof mod.file_count === "number", `module ${mod.id} should have file_count`);
+    assert.ok(mod.file_count >= 2, `module ${mod.id} should have at least 2 files (got ${mod.file_count})`);
+    assert.ok(typeof mod.source_of_truth === "boolean", `module ${mod.id} missing source_of_truth`);
+    assert.ok(typeof mod.trust_level === "number", `module ${mod.id} missing trust_level`);
+    assert.ok(mod.status === "active", `module ${mod.id} should have status "active"`);
+  }
+});
+
+test("no single-file directories become modules", () => {
+  ensureIngest();
+
+  const modules = readJsonl(path.join(CACHE_DIR, "entities.module.jsonl"));
+
+  for (const mod of modules) {
+    assert.ok(
+      mod.file_count >= 2,
+      `module ${mod.id} has only ${mod.file_count} file(s) — should be excluded`
+    );
+  }
+});
+
+test("module name matches directory basename", () => {
+  ensureIngest();
+
+  const modules = readJsonl(path.join(CACHE_DIR, "entities.module.jsonl"));
+
+  for (const mod of modules) {
+    const expectedName = path.basename(mod.path);
+    assert.strictEqual(mod.name, expectedName, `module ${mod.id} name should be "${expectedName}"`);
+  }
+});
+
+test("CONTAINS relations link modules to files", () => {
+  ensureIngest();
+
+  const contains = readJsonl(path.join(CACHE_DIR, "relations.contains.jsonl"));
+  assert.ok(contains.length > 0, "should have CONTAINS relations");
+
+  for (const rel of contains) {
+    assert.ok(rel.from.startsWith("module:"), `CONTAINS from should be module: ${rel.from}`);
+    assert.ok(rel.to.startsWith("file:"), `CONTAINS to should be file: ${rel.to}`);
+  }
+});
+
+test("CONTAINS_MODULE relations link parent to child modules", () => {
+  ensureIngest();
+
+  const containsModule = readJsonl(path.join(CACHE_DIR, "relations.contains_module.jsonl"));
+  // May be empty for flat repos, but if present they should be valid
+  for (const rel of containsModule) {
+    assert.ok(rel.from.startsWith("module:"), `CONTAINS_MODULE from should be module: ${rel.from}`);
+    assert.ok(rel.to.startsWith("module:"), `CONTAINS_MODULE to should be module: ${rel.to}`);
+
+    // Parent path should be dirname of child path
+    const parentPath = rel.from.replace("module:", "");
+    const childPath = rel.to.replace("module:", "");
+    assert.strictEqual(
+      path.dirname(childPath),
+      parentPath,
+      `parent ${parentPath} should be dirname of child ${childPath}`
+    );
+  }
+});
+
+test("EXPORTS relations link modules to exported chunks", () => {
+  ensureIngest();
+
+  const exports = readJsonl(path.join(CACHE_DIR, "relations.exports.jsonl"));
+  assert.ok(exports.length > 0, "should have EXPORTS relations");
+
+  for (const rel of exports) {
+    assert.ok(rel.from.startsWith("module:"), `EXPORTS from should be module: ${rel.from}`);
+    assert.ok(rel.to.startsWith("chunk:"), `EXPORTS to should be chunk: ${rel.to}`);
+  }
+});
+
+test("DEFINES relations exist", () => {
+  ensureIngest();
+
+  const defines = readJsonl(path.join(CACHE_DIR, "relations.defines.jsonl"));
+  assert.ok(defines.length > 0, "should have DEFINES relations");
+
+  for (const rel of defines) {
+    assert.ok(rel.from.startsWith("file:"), `DEFINES from should be file: ${rel.from}`);
+    assert.ok(rel.to.startsWith("chunk:"), `DEFINES to should be chunk: ${rel.to}`);
+  }
+});
+
+test("ontology.cypher includes description and exported columns on Chunk", () => {
+  const ontology = fs.readFileSync(path.join(REPO_ROOT, ".context", "ontology.cypher"), "utf8");
+  assert.ok(ontology.includes("description STRING"), "ontology should have description column on Chunk");
+  assert.ok(ontology.includes("exported BOOL"), "ontology should have exported column on Chunk");
+});


### PR DESCRIPTION
## Summary
- Adds **Module** entity type representing directory-level code groupings, with `CONTAINS`, `CONTAINS_MODULE`, and `EXPORTS` relations
- Enriches **Chunk** entities with `description` (auto-generated from kind/signature/JSDoc) and `exported` boolean fields
- Full vertical slice: ontology schema, ingest pipeline, graph loading, graph querying, search, embeddings, and types
- Includes integration test suite (`tests/multi-level.test.mjs`) validating JSONL outputs

## Test plan
- [ ] Run `node --test tests/multi-level.test.mjs` to verify ingest produces correct Module entities, Chunk descriptions, and all new relations
- [ ] Run existing test suite to confirm no regressions
- [ ] Verify `npm run build` compiles TypeScript without errors
- [ ] Run ingest on a real repo and inspect `entities.module.jsonl`, `relations.contains.jsonl`, `relations.exports.jsonl` outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)