### PR TITLE
Add WSL mode for running MCP server from Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,59 @@ Codex (`~/.config/codex/mcp-config.json`):
 }
 ```
 
+## WSL Mode (Windows)
+
+If you run Node.js inside WSL but use Claude Desktop or another MCP client on Windows:
+
+1. Install Cortex inside WSL:
+
+```bash
+# In a WSL terminal
+npm i -g @danielblomma/cortex-mcp
+cd /mnt/c/Users/yourname/your-project
+cortex init --bootstrap
+```
+
+2. Configure Claude Desktop (`%APPDATA%\Claude\claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "cortex": {
+      "command": "wsl.exe",
+      "args": ["--distribution", "Ubuntu", "--exec", "cortex", "mcp"],
+      "env": {
+        "CORTEX_PROJECT_ROOT": "C:\\Users\\yourname\\your-project",
+        "CORTEX_AUTO_BOOTSTRAP_ON_MCP": "1"
+      }
+    }
+  }
+}
+```
+
+Cortex automatically converts Windows paths (e.g. `C:\Users\...`) to WSL paths (`/mnt/c/Users/...`).
+
+For projects on the WSL filesystem (e.g. `~/projects/myapp`), use the WSL path directly:
+
+```json
+{
+  "mcpServers": {
+    "cortex": {
+      "command": "wsl.exe",
+      "args": ["--distribution", "Ubuntu", "--exec", "cortex", "mcp"],
+      "env": {
+        "CORTEX_PROJECT_ROOT": "/home/yourname/projects/myapp",
+        "CORTEX_AUTO_BOOTSTRAP_ON_MCP": "1"
+      }
+    }
+  }
+}
+```
+
+**Notes:**
+- File watching on `/mnt/` paths (Windows filesystem) automatically uses poll mode since `inotify` is unreliable across filesystem boundaries.
+- For best performance, keep projects on the WSL filesystem (`~/...`) rather than `/mnt/c/...`.
+
 ## MCP Tools
 
 ### `context.search`
@@ -152,6 +205,40 @@ Input:
 
 - `entity_id` (string, required)
 - `depth` (int, 1-3, default `1`)
+- `include_edges` (bool, default `true`)
+
+### `context.find_callers`
+
+Return chunk callers for a chunk or file entity using the indexed call graph.
+
+Input:
+
+- `entity_id` (string, required)
+- `depth` (int, 1-4, default `1`)
+- `include_edges` (bool, default `true`)
+
+### `context.trace_calls`
+
+Trace call graph neighbors from a chunk or file entity in the requested direction.
+
+Input:
+
+- `entity_id` (string, required)
+- `depth` (int, 1-4, default `2`)
+- `direction` (`"outgoing"` | `"incoming"` | `"both"`, default `"outgoing"`)
+- `include_edges` (bool, default `true`)
+
+### `context.impact_analysis`
+
+Analyze likely impacted call-graph entities starting from an entity id or search query.
+
+Input:
+
+- `entity_id` (string, optional) — either `entity_id` or `query` is required
+- `query` (string, optional)
+- `depth` (int, 1-4, default `2`)
+- `top_k` (int, 1-20, default `8`)
+- `direction` (`"incoming"` | `"outgoing"` | `"both"`, default `"incoming"`)
 - `include_edges` (bool, default `true`)
 
 ### `context.get_rules`

--- a/bin/cortex.mjs
+++ b/bin/cortex.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
+import { normalizeProjectRoot } from "./wsl.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -599,9 +600,9 @@ async function run() {
   }
 
   if (command === "mcp") {
-    const target = process.env.CORTEX_PROJECT_ROOT
-      ? path.resolve(process.env.CORTEX_PROJECT_ROOT)
-      : process.cwd();
+    const rawTarget = process.env.CORTEX_PROJECT_ROOT || process.cwd();
+    const target = path.resolve(normalizeProjectRoot(rawTarget));
+    process.env.CORTEX_PROJECT_ROOT = target;
     await ensureProjectInitializedForMcp(target);
     ensureProjectInitialized(target);
     const serverEntry = path.join(target, "mcp", "dist", "server.js");

--- a/bin/wsl.mjs
+++ b/bin/wsl.mjs
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+
+let _isWSL = null;
+
+export function isWSL() {
+  if (_isWSL !== null) return _isWSL;
+  try {
+    const version = fs.readFileSync("/proc/version", "utf8");
+    _isWSL = /microsoft|wsl/i.test(version);
+  } catch {
+    _isWSL = false;
+  }
+  return _isWSL;
+}
+
+export function windowsToWslPath(winPath) {
+  const match = winPath.match(/^([A-Za-z]):[/\\](.*)/);
+  if (!match) return winPath;
+  const drive = match[1].toLowerCase();
+  const rest = match[2].replace(/\\/g, "/").replace(/\/+$/, "");
+  return `/mnt/${drive}/${rest}`;
+}
+
+export function normalizeProjectRoot(rawPath) {
+  if (!isWSL()) return rawPath;
+  if (/^[A-Za-z]:[/\\]/.test(rawPath)) {
+    return windowsToWslPath(rawPath);
+  }
+  return rawPath;
+}

--- a/mcp/src/paths.ts
+++ b/mcp/src/paths.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { RankingWeights } from "./types.js";
@@ -5,9 +6,23 @@ import type { RankingWeights } from "./types.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+function normalizeForWsl(rawPath: string): string {
+  const winMatch = rawPath.match(/^([A-Za-z]):[/\\](.*)/);
+  if (!winMatch) return rawPath;
+  try {
+    const version = fs.readFileSync("/proc/version", "utf8");
+    if (!/microsoft|wsl/i.test(version)) return rawPath;
+  } catch {
+    return rawPath;
+  }
+  const drive = winMatch[1].toLowerCase();
+  const rest = winMatch[2].replace(/\\/g, "/").replace(/\/+$/, "");
+  return `/mnt/${drive}/${rest}`;
+}
+
 const PROJECT_ROOT_OVERRIDE = process.env.CORTEX_PROJECT_ROOT?.trim();
 export const REPO_ROOT = PROJECT_ROOT_OVERRIDE
-  ? path.resolve(PROJECT_ROOT_OVERRIDE)
+  ? path.resolve(normalizeForWsl(PROJECT_ROOT_OVERRIDE))
   : path.resolve(__dirname, "../..");
 export const CONTEXT_DIR = path.join(REPO_ROOT, ".context");
 export const CACHE_DIR = path.join(CONTEXT_DIR, "cache");

--- a/scaffold/mcp/src/paths.ts
+++ b/scaffold/mcp/src/paths.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { RankingWeights } from "./types.js";
@@ -5,9 +6,23 @@ import type { RankingWeights } from "./types.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+function normalizeForWsl(rawPath: string): string {
+  const winMatch = rawPath.match(/^([A-Za-z]):[/\\](.*)/);
+  if (!winMatch) return rawPath;
+  try {
+    const version = fs.readFileSync("/proc/version", "utf8");
+    if (!/microsoft|wsl/i.test(version)) return rawPath;
+  } catch {
+    return rawPath;
+  }
+  const drive = winMatch[1].toLowerCase();
+  const rest = winMatch[2].replace(/\\/g, "/").replace(/\/+$/, "");
+  return `/mnt/${drive}/${rest}`;
+}
+
 const PROJECT_ROOT_OVERRIDE = process.env.CORTEX_PROJECT_ROOT?.trim();
 export const REPO_ROOT = PROJECT_ROOT_OVERRIDE
-  ? path.resolve(PROJECT_ROOT_OVERRIDE)
+  ? path.resolve(normalizeForWsl(PROJECT_ROOT_OVERRIDE))
   : path.resolve(__dirname, "../..");
 export const CONTEXT_DIR = path.join(REPO_ROOT, ".context");
 export const CACHE_DIR = path.join(CONTEXT_DIR, "cache");

--- a/scaffold/scripts/memory-compile.mjs
+++ b/scaffold/scripts/memory-compile.mjs
@@ -6,8 +6,17 @@ import { parseFrontmatter, parseStringList } from "../mcp/dist/frontmatter.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+function normalizeForWsl(rawPath) {
+  const m = rawPath.match(/^([A-Za-z]):[/\\](.*)/);
+  if (!m) return rawPath;
+  try { if (!/microsoft|wsl/i.test(fs.readFileSync("/proc/version", "utf8"))) return rawPath; }
+  catch { return rawPath; }
+  return `/mnt/${m[1].toLowerCase()}/${m[2].replace(/\\/g, "/").replace(/\/+$/, "")}`;
+}
+
 const REPO_ROOT = process.env.CORTEX_PROJECT_ROOT
-  ? path.resolve(process.env.CORTEX_PROJECT_ROOT)
+  ? path.resolve(normalizeForWsl(process.env.CORTEX_PROJECT_ROOT))
   : path.resolve(__dirname, "..");
 const CONTEXT_DIR = path.join(REPO_ROOT, ".context");
 const MEMORY_DIR = path.join(CONTEXT_DIR, "memory");

--- a/scaffold/scripts/memory-lint.mjs
+++ b/scaffold/scripts/memory-lint.mjs
@@ -6,8 +6,17 @@ import { parseFrontmatter, parseStringList } from "../mcp/dist/frontmatter.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+function normalizeForWsl(rawPath) {
+  const m = rawPath.match(/^([A-Za-z]):[/\\](.*)/);
+  if (!m) return rawPath;
+  try { if (!/microsoft|wsl/i.test(fs.readFileSync("/proc/version", "utf8"))) return rawPath; }
+  catch { return rawPath; }
+  return `/mnt/${m[1].toLowerCase()}/${m[2].replace(/\\/g, "/").replace(/\/+$/, "")}`;
+}
+
 const REPO_ROOT = process.env.CORTEX_PROJECT_ROOT
-  ? path.resolve(process.env.CORTEX_PROJECT_ROOT)
+  ? path.resolve(normalizeForWsl(process.env.CORTEX_PROJECT_ROOT))
   : path.resolve(__dirname, "..");
 const CONTEXT_DIR = path.join(REPO_ROOT, ".context");
 const MEMORY_DIR = path.join(CONTEXT_DIR, "memory");

--- a/scaffold/scripts/watch.sh
+++ b/scaffold/scripts/watch.sh
@@ -84,10 +84,18 @@ detect_event_backend() {
   return 1
 }
 
+is_wsl_mnt_path() {
+  grep -qi microsoft /proc/version 2>/dev/null && [[ "$REPO_ROOT" == /mnt/* ]]
+}
+
 resolve_mode() {
   case "$WATCH_MODE" in
     auto)
-      if EVENT_BACKEND="$(detect_event_backend)"; then
+      if is_wsl_mnt_path; then
+        echo "[watch] WSL detected with /mnt/ path, using poll mode (inotify unreliable on Windows mounts)"
+        WATCH_MODE="poll"
+        EVENT_BACKEND=""
+      elif EVENT_BACKEND="$(detect_event_backend)"; then
         WATCH_MODE="event"
       else
         WATCH_MODE="poll"

--- a/scripts/memory-compile.mjs
+++ b/scripts/memory-compile.mjs
@@ -6,8 +6,17 @@ import { parseFrontmatter, parseStringList } from "../mcp/dist/frontmatter.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+function normalizeForWsl(rawPath) {
+  const m = rawPath.match(/^([A-Za-z]):[/\\](.*)/);
+  if (!m) return rawPath;
+  try { if (!/microsoft|wsl/i.test(fs.readFileSync("/proc/version", "utf8"))) return rawPath; }
+  catch { return rawPath; }
+  return `/mnt/${m[1].toLowerCase()}/${m[2].replace(/\\/g, "/").replace(/\/+$/, "")}`;
+}
+
 const REPO_ROOT = process.env.CORTEX_PROJECT_ROOT
-  ? path.resolve(process.env.CORTEX_PROJECT_ROOT)
+  ? path.resolve(normalizeForWsl(process.env.CORTEX_PROJECT_ROOT))
   : path.resolve(__dirname, "..");
 const CONTEXT_DIR = path.join(REPO_ROOT, ".context");
 const MEMORY_DIR = path.join(CONTEXT_DIR, "memory");

--- a/scripts/memory-lint.mjs
+++ b/scripts/memory-lint.mjs
@@ -6,8 +6,17 @@ import { parseFrontmatter, parseStringList } from "../mcp/dist/frontmatter.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+function normalizeForWsl(rawPath) {
+  const m = rawPath.match(/^([A-Za-z]):[/\\](.*)/);
+  if (!m) return rawPath;
+  try { if (!/microsoft|wsl/i.test(fs.readFileSync("/proc/version", "utf8"))) return rawPath; }
+  catch { return rawPath; }
+  return `/mnt/${m[1].toLowerCase()}/${m[2].replace(/\\/g, "/").replace(/\/+$/, "")}`;
+}
+
 const REPO_ROOT = process.env.CORTEX_PROJECT_ROOT
-  ? path.resolve(process.env.CORTEX_PROJECT_ROOT)
+  ? path.resolve(normalizeForWsl(process.env.CORTEX_PROJECT_ROOT))
   : path.resolve(__dirname, "..");
 const CONTEXT_DIR = path.join(REPO_ROOT, ".context");
 const MEMORY_DIR = path.join(CONTEXT_DIR, "memory");

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -84,10 +84,18 @@ detect_event_backend() {
   return 1
 }
 
+is_wsl_mnt_path() {
+  grep -qi microsoft /proc/version 2>/dev/null && [[ "$REPO_ROOT" == /mnt/* ]]
+}
+
 resolve_mode() {
   case "$WATCH_MODE" in
     auto)
-      if EVENT_BACKEND="$(detect_event_backend)"; then
+      if is_wsl_mnt_path; then
+        echo "[watch] WSL detected with /mnt/ path, using poll mode (inotify unreliable on Windows mounts)"
+        WATCH_MODE="poll"
+        EVENT_BACKEND=""
+      elif EVENT_BACKEND="$(detect_event_backend)"; then
         WATCH_MODE="event"
       else
         WATCH_MODE="poll"

--- a/tests/wsl-paths.test.mjs
+++ b/tests/wsl-paths.test.mjs
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { windowsToWslPath, normalizeProjectRoot, isWSL } from "../bin/wsl.mjs";
+
+test("windowsToWslPath converts backslash Windows path", () => {
+  assert.equal(windowsToWslPath("C:\\Users\\foo\\bar"), "/mnt/c/Users/foo/bar");
+});
+
+test("windowsToWslPath converts forward-slash Windows path", () => {
+  assert.equal(windowsToWslPath("D:/projects/cortex"), "/mnt/d/projects/cortex");
+});
+
+test("windowsToWslPath handles mixed separators", () => {
+  assert.equal(windowsToWslPath("E:\\repos/my-project\\src"), "/mnt/e/repos/my-project/src");
+});
+
+test("windowsToWslPath lowercases drive letter", () => {
+  assert.equal(windowsToWslPath("F:\\Data"), "/mnt/f/Data");
+});
+
+test("windowsToWslPath strips trailing slashes", () => {
+  assert.equal(windowsToWslPath("C:\\Users\\foo\\"), "/mnt/c/Users/foo");
+  assert.equal(windowsToWslPath("C:\\Users\\foo\\\\"), "/mnt/c/Users/foo");
+});
+
+test("windowsToWslPath returns POSIX path unchanged", () => {
+  assert.equal(windowsToWslPath("/home/user/project"), "/home/user/project");
+});
+
+test("windowsToWslPath returns WSL /mnt/ path unchanged", () => {
+  assert.equal(windowsToWslPath("/mnt/c/Users/foo"), "/mnt/c/Users/foo");
+});
+
+test("windowsToWslPath returns relative path unchanged", () => {
+  assert.equal(windowsToWslPath("src/main.rs"), "src/main.rs");
+});
+
+test("windowsToWslPath handles drive root", () => {
+  assert.equal(windowsToWslPath("C:\\"), "/mnt/c/");
+});
+
+test("isWSL returns false on macOS/non-WSL Linux", () => {
+  // On macOS, /proc/version does not exist so isWSL returns false.
+  // On native Linux, /proc/version exists but doesn't contain "microsoft".
+  // This test verifies the function runs without error on the test platform.
+  const result = isWSL();
+  assert.equal(typeof result, "boolean");
+});
+
+test("normalizeProjectRoot returns POSIX path unchanged regardless of WSL", () => {
+  assert.equal(normalizeProjectRoot("/home/user/project"), "/home/user/project");
+  assert.equal(normalizeProjectRoot("/mnt/c/Users/foo"), "/mnt/c/Users/foo");
+});
+
+test("normalizeProjectRoot handles relative paths", () => {
+  assert.equal(normalizeProjectRoot("./my-project"), "./my-project");
+});


### PR DESCRIPTION
## Summary
- Adds WSL environment detection and automatic Windows-to-WSL path conversion for `CORTEX_PROJECT_ROOT`
- New `bin/wsl.mjs` utility module with `isWSL()`, `windowsToWslPath()`, and `normalizeProjectRoot()` exports
- Path normalization applied at all entry points: `bin/cortex.mjs`, `mcp/src/paths.ts`, and memory scripts
- File watcher (`watch.sh`) auto-switches to poll mode when WSL + `/mnt/` path detected (inotify unreliable on Windows mounts)
- README updated with WSL setup section and 3 missing MCP tools (`find_callers`, `trace_calls`, `impact_analysis`)

## Files changed
| File | Change |
|------|--------|
| `bin/wsl.mjs` | **New** — WSL detection + path conversion |
| `bin/cortex.mjs` | Normalize `CORTEX_PROJECT_ROOT` in MCP handler |
| `mcp/src/paths.ts` + scaffold | Defensive inline normalization |
| `scripts/watch.sh` + scaffold | Auto poll mode on WSL /mnt/ |
| `scripts/memory-*.mjs` + scaffold | Inline path normalization |
| `tests/wsl-paths.test.mjs` | **New** — 12 unit tests |
| `README.md` | WSL docs + missing MCP tools |

## Test plan
- [x] 12 new WSL path conversion tests pass
- [x] All 106 existing tests pass — no regressions
- [x] On macOS/Linux: WSL code is a no-op (cached `false` from `/proc/version`)
- [ ] On WSL: `CORTEX_PROJECT_ROOT="C:\Users\test"` converts to `/mnt/c/Users/test`
- [ ] On WSL: `cortex watch start` on `/mnt/c/...` path uses poll mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)