### PR TITLE
feat: telemetry hook for enterprise + fix version

### DIFF
--- a/mcp/src/enterprise.d.ts
+++ b/mcp/src/enterprise.d.ts
@@ -3,4 +3,5 @@ declare module "@danielblomma/cortex-enterprise" {
   export const name: string;
   export const version: string;
   export function register(server: McpServer): void | Promise<void>;
+  export function onToolCall(toolName: string, resultCount: number, tokensSaved: number): void;
 }

--- a/mcp/src/plugin.ts
+++ b/mcp/src/plugin.ts
@@ -1,9 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+export type ToolCallHook = (toolName: string, resultCount: number, tokensSaved: number) => void;
+
 export type CortexPlugin = {
   name: string;
   version: string;
   register: (server: McpServer) => void | Promise<void>;
+  onToolCall?: ToolCallHook;
 };
 
 export type EditionInfo = {
@@ -13,9 +16,14 @@ export type EditionInfo = {
 };
 
 let loadedEdition: EditionInfo = { edition: "community" };
+let toolCallHook: ToolCallHook | null = null;
 
 export function getEdition(): EditionInfo {
   return loadedEdition;
+}
+
+export function getToolCallHook(): ToolCallHook | null {
+  return toolCallHook;
 }
 
 export async function loadPlugins(server: McpServer): Promise<void> {
@@ -28,6 +36,9 @@ export async function loadPlugins(server: McpServer): Promise<void> {
         name: enterprise.name ?? "enterprise",
         version: enterprise.version ?? "unknown",
       };
+      if (typeof enterprise.onToolCall === "function") {
+        toolCallHook = enterprise.onToolCall;
+      }
       process.stderr.write(`[cortex] Enterprise plugin loaded: ${loadedEdition.version}\n`);
     }
   } catch (error: unknown) {

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,8 +1,9 @@
+import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { reloadContextGraph } from "./graph.js";
-import { loadPlugins } from "./plugin.js";
+import { getToolCallHook, loadPlugins } from "./plugin.js";
 import { runContextRules } from "./rules.js";
 import {
   runContextFindCallers,
@@ -11,6 +12,13 @@ import {
   runContextSearch,
   runContextTraceCalls
 } from "./search.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { version: string };
+
+// Average file ~1200 tokens; cortex returns ~400 token snippets → savings ~800/result.
+// The enterprise collector adds resultCount * 400 to get the full "without cortex" total.
+const ESTIMATED_TOKENS_SAVED_PER_RESULT = 800;
 
 type ToolPayload = Record<string, unknown>;
 
@@ -102,6 +110,13 @@ function buildToolResult(data: ToolPayload) {
   };
 }
 
+function notifyToolCall(toolName: string, result: ToolPayload): void {
+  const hook = getToolCallHook();
+  if (!hook) return;
+  const resultCount = Array.isArray(result.results) ? result.results.length : 0;
+  hook(toolName, resultCount, resultCount * ESTIMATED_TOKENS_SAVED_PER_RESULT);
+}
+
 function registerTools(server: McpServer): void {
   server.registerTool(
     "context.search",
@@ -109,7 +124,11 @@ function registerTools(server: McpServer): void {
       description: "Search ranked context documents and code using semantic, graph and trust weighting.",
       inputSchema: SearchInput
     },
-    async (input) => buildToolResult(await runContextSearch(SearchInput.parse(input ?? {})))
+    async (input) => {
+      const result = await runContextSearch(SearchInput.parse(input ?? {}));
+      notifyToolCall("context.search", result);
+      return buildToolResult(result);
+    }
   );
 
   server.registerTool(
@@ -118,7 +137,11 @@ function registerTools(server: McpServer): void {
       description: "Return related entities and graph edges for a context entity id.",
       inputSchema: RelatedInput
     },
-    async (input) => buildToolResult(await runContextRelated(RelatedInput.parse(input ?? {})))
+    async (input) => {
+      const result = await runContextRelated(RelatedInput.parse(input ?? {}));
+      notifyToolCall("context.get_related", result);
+      return buildToolResult(result);
+    }
   );
 
   server.registerTool(
@@ -127,7 +150,11 @@ function registerTools(server: McpServer): void {
       description: "Return chunk callers for a chunk or file entity using the indexed call graph.",
       inputSchema: FindCallersInput
     },
-    async (input) => buildToolResult(await runContextFindCallers(FindCallersInput.parse(input ?? {})))
+    async (input) => {
+      const result = await runContextFindCallers(FindCallersInput.parse(input ?? {}));
+      notifyToolCall("context.find_callers", result);
+      return buildToolResult(result);
+    }
   );
 
   server.registerTool(
@@ -136,7 +163,11 @@ function registerTools(server: McpServer): void {
       description: "Trace call graph neighbors from a chunk or file entity in the requested direction.",
       inputSchema: TraceCallsInput
     },
-    async (input) => buildToolResult(await runContextTraceCalls(TraceCallsInput.parse(input ?? {})))
+    async (input) => {
+      const result = await runContextTraceCalls(TraceCallsInput.parse(input ?? {}));
+      notifyToolCall("context.trace_calls", result);
+      return buildToolResult(result);
+    }
   );
 
   server.registerTool(
@@ -145,8 +176,11 @@ function registerTools(server: McpServer): void {
       description: "Analyze likely impacted call-graph entities starting from an entity id or search query.",
       inputSchema: ImpactAnalysisInput
     },
-    async (input) =>
-      buildToolResult(await runContextImpactAnalysis(ImpactAnalysisInput.parse(input ?? {})))
+    async (input) => {
+      const result = await runContextImpactAnalysis(ImpactAnalysisInput.parse(input ?? {}));
+      notifyToolCall("context.impact_analysis", result);
+      return buildToolResult(result);
+    }
   );
 
   server.registerTool(
@@ -155,7 +189,11 @@ function registerTools(server: McpServer): void {
       description: "List indexed rules filtered by scope and active status.",
       inputSchema: RulesInput.optional()
     },
-    async (input) => buildToolResult(await runContextRules(RulesInput.parse(input ?? {})))
+    async (input) => {
+      const result = await runContextRules(RulesInput.parse(input ?? {}));
+      notifyToolCall("context.get_rules", result);
+      return buildToolResult(result);
+    }
   );
 
   server.registerTool(
@@ -166,7 +204,9 @@ function registerTools(server: McpServer): void {
     },
     async (input) => {
       const parsed = ReloadInput.parse(input ?? {});
-      return buildToolResult(await reloadContextGraph(parsed.force));
+      const result = await reloadContextGraph(parsed.force);
+      notifyToolCall("context.reload", result);
+      return buildToolResult(result);
     }
   );
 }
@@ -174,7 +214,7 @@ function registerTools(server: McpServer): void {
 async function main(): Promise<void> {
   const server = new McpServer({
     name: "cortex-context",
-    version: "0.1.0"
+    version: pkg.version
   });
 
   registerTools(server);


### PR DESCRIPTION
## Summary
- Add `onToolCall` hook to the plugin system so enterprise can track usage of all 7 core tools
- Call the hook after each tool handler with tool name, result count, and estimated tokens saved
- Fix MCP server version: read from package.json instead of hardcoded `"0.1.0"`

## Context
The cortex-enterprise telemetry collector had a `record()` method that was never called — there was no mechanism for core tools to notify the plugin. This adds that mechanism via the existing `CortexPlugin` interface.

## Test plan
- [ ] Run tests: `npm test`
- [ ] Start MCP server without enterprise installed — verify no errors (hook is null, no-op)
- [ ] Start MCP server with enterprise — verify `[cortex] Enterprise plugin loaded` message
- [ ] Execute `context.search` — verify enterprise telemetry records the call

🤖 Generated with [Claude Code](https://claude.com/claude-code)