### PR TITLE
fix: auto-detect out-of-date scaffold on cortex doctor

### DIFF
--- a/bin/cortex.mjs
+++ b/bin/cortex.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { spawn } from "node:child_process";
 import { normalizeProjectRoot } from "./wsl.mjs";
 
@@ -490,12 +490,91 @@ function canAutoInitialize(targetDir) {
   return scaffoldPaths.every((entryPath) => !fs.existsSync(entryPath));
 }
 
+function isScaffoldOutOfDate(targetDir) {
+  const contextScript = path.join(targetDir, "scripts", "context.sh");
+  if (!fs.existsSync(contextScript)) {
+    return false;
+  }
+  const doctorScript = path.join(targetDir, "scripts", "doctor.sh");
+  if (!fs.existsSync(doctorScript)) {
+    return true;
+  }
+  const mcpPackage = path.join(targetDir, "mcp", "package.json");
+  if (!fs.existsSync(mcpPackage)) {
+    return true;
+  }
+  try {
+    const contents = fs.readFileSync(contextScript, "utf8");
+    if (!/\bdoctor\)\s*\n/.test(contents)) {
+      return true;
+    }
+  } catch {
+    return true;
+  }
+  return false;
+}
+
+async function confirmPrompt(message) {
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = (await rl.question(message)).trim().toLowerCase();
+    return answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+async function maybeMigrateScaffold(targetDir, command) {
+  if (!isScaffoldOutOfDate(targetDir)) {
+    return;
+  }
+
+  const autoYes = isTruthyEnv(process.env.CORTEX_AUTO_MIGRATE);
+  const interactive = Boolean(process.stdin.isTTY && process.stderr.isTTY);
+
+  console.error(
+    `[cortex] scaffold in ${targetDir} is out of date ` +
+      `(missing scripts/doctor.sh, mcp/package.json, or doctor subcommand in context.sh).`
+  );
+
+  let proceed = autoYes;
+  if (!autoYes) {
+    if (!interactive) {
+      throw new Error(
+        `Cortex CLI ${process.env.CORTEX_CLI_VERSION ?? ""} needs an updated scaffold to run '${command}'. ` +
+          `Run 'cortex init --bootstrap' to upgrade, or re-run with CORTEX_AUTO_MIGRATE=true.`
+      );
+    }
+    proceed = await confirmPrompt("[cortex] Upgrade scaffold now (runs 'cortex init --bootstrap')? [y/N] ");
+  }
+
+  if (!proceed) {
+    throw new Error("Scaffold upgrade declined. Run 'cortex init --bootstrap' manually to continue.");
+  }
+
+  console.error(`[cortex] migrating scaffold in ${targetDir}`);
+  ensureScaffoldExists();
+  installScaffold(targetDir, true);
+  installAssistantHelpers(targetDir);
+  await maybeInstallGitHooks(targetDir);
+  await runContextCommand(targetDir, ["bootstrap"]);
+  console.error(`[cortex] scaffold upgraded; continuing with '${command}'`);
+}
+
 async function ensureProjectInitializedForMcp(targetDir) {
   const mcpPackageJson = path.join(targetDir, "mcp", "package.json");
   const serverEntry = path.join(targetDir, "mcp", "dist", "server.js");
 
   if (fs.existsSync(mcpPackageJson) && fs.existsSync(serverEntry)) {
     return;
+  }
+
+  if (isScaffoldOutOfDate(targetDir)) {
+    await maybeMigrateScaffold(targetDir, "mcp");
+    if (fs.existsSync(mcpPackageJson) && fs.existsSync(serverEntry)) {
+      return;
+    }
   }
 
   if (!isTruthyEnv(process.env.CORTEX_AUTO_BOOTSTRAP_ON_MCP)) {
@@ -651,10 +730,18 @@ async function run() {
     throw new Error(`Unknown command: ${command}`);
   }
 
+  await maybeMigrateScaffold(process.cwd(), command);
   await runContextCommand(process.cwd(), [command, ...rest]);
 }
 
-run().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
-});
+const invokedAsScript =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedAsScript) {
+  run().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  });
+}
+
+export { isScaffoldOutOfDate };

--- a/tests/scaffold-migration.test.mjs
+++ b/tests/scaffold-migration.test.mjs
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { isScaffoldOutOfDate } from "../bin/cortex.mjs";
+
+const NEW_CONTEXT_SH = `#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+COMMAND="\${1:-help}"
+case "$COMMAND" in
+  bootstrap)
+    "$SCRIPT_DIR/bootstrap.sh" "$@"
+    ;;
+  doctor)
+    "$SCRIPT_DIR/doctor.sh"
+    ;;
+  *)
+    echo "Unknown command"
+    exit 1
+    ;;
+esac
+`;
+
+const OLD_CONTEXT_SH = `#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"
+COMMAND="\${1:-help}"
+case "$COMMAND" in
+  bootstrap)
+    "$SCRIPT_DIR/bootstrap.sh" "$@"
+    ;;
+  *)
+    echo "Unknown command"
+    exit 1
+    ;;
+esac
+`;
+
+function makeTempProject() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-scaffold-test-"));
+  fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
+  fs.mkdirSync(path.join(root, "mcp"), { recursive: true });
+  return root;
+}
+
+function writeUpToDate(root) {
+  fs.writeFileSync(path.join(root, "scripts", "context.sh"), NEW_CONTEXT_SH);
+  fs.writeFileSync(path.join(root, "scripts", "doctor.sh"), "#!/usr/bin/env bash\necho ok\n");
+  fs.writeFileSync(path.join(root, "mcp", "package.json"), "{}");
+}
+
+test("returns false when context.sh does not exist (not initialized)", () => {
+  const root = makeTempProject();
+  assert.equal(isScaffoldOutOfDate(root), false);
+});
+
+test("returns true when scripts/doctor.sh is missing", () => {
+  const root = makeTempProject();
+  writeUpToDate(root);
+  fs.rmSync(path.join(root, "scripts", "doctor.sh"));
+  assert.equal(isScaffoldOutOfDate(root), true);
+});
+
+test("returns true when mcp/package.json is missing", () => {
+  const root = makeTempProject();
+  writeUpToDate(root);
+  fs.rmSync(path.join(root, "mcp", "package.json"));
+  assert.equal(isScaffoldOutOfDate(root), true);
+});
+
+test("returns true when context.sh lacks a doctor subcommand case", () => {
+  const root = makeTempProject();
+  writeUpToDate(root);
+  fs.writeFileSync(path.join(root, "scripts", "context.sh"), OLD_CONTEXT_SH);
+  assert.equal(isScaffoldOutOfDate(root), true);
+});
+
+test("returns false when scaffold is fully up to date", () => {
+  const root = makeTempProject();
+  writeUpToDate(root);
+  assert.equal(isScaffoldOutOfDate(root), false);
+});


### PR DESCRIPTION
## Summary
- CLI now detects old scaffolds (missing `scripts/doctor.sh`, `mcp/package.json`, or `doctor)` case in `context.sh`) before delegating to `context.sh`.
- Interactive prompt offers to run `init --bootstrap`; non-TTY paths surface an actionable error instead of cryptic stderr. `CORTEX_AUTO_MIGRATE=true` enables auto-migrate for CI.
- Wires migration check into both passthrough dispatcher and `ensureProjectInitializedForMcp`, so `cortex mcp` (MCP plugin load) self-heals identically.

## Problem
Customer report: CLI forwards `cortex doctor` to `./scripts/context.sh doctor`, but projects on older scaffolds lack the subcommand. MCP load also failed with `Missing mcp/package.json. Run 'cortex init --bootstrap' first.` — no in-UX path to recover.

## Test plan
- [x] New `tests/scaffold-migration.test.mjs` — 5 unit tests covering: uninitialized dir, missing `doctor.sh`, missing `mcp/package.json`, old `context.sh` without doctor case, fully up-to-date dir. All pass.
- [x] Full test suite: 155/155 pass, no regressions.
- [x] Smoke test: fake old-scaffold tempdir + non-TTY stdin → clean actionable error instead of cryptic failure.
- [ ] Manual interactive: run `cortex doctor` in a real old-scaffold project, answer `y` at prompt → migration + bootstrap + doctor output.
- [ ] Manual auto: `CORTEX_AUTO_MIGRATE=true cortex doctor` in an old-scaffold project → same outcome without prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)