### PR TITLE
fix: doctor sends enterprise api_key (Policy/Telemetry auth check)

### DIFF
--- a/scaffold/scripts/doctor.sh
+++ b/scaffold/scripts/doctor.sh
@@ -221,19 +221,59 @@ if [[ -n "$ENTERPRISE_CONFIG" ]]; then
     console.log(fields["policy.endpoint"] || "");
   ' "$ENTERPRISE_CONFIG" 2>/dev/null || echo "")
 
+  TELEMETRY_API_KEY=$(node -e '
+    const fs = require("node:fs");
+    const raw = fs.readFileSync(process.argv[1], "utf8");
+    let section = "", fields = {};
+    for (const line of raw.split("\n")) {
+      const t = line.trimEnd();
+      if (!t || t.startsWith("#")) continue;
+      const sm = t.match(/^(\w+):\s*$/);
+      if (sm) { section = sm[1]; continue; }
+      const kv = t.match(/^\s+(\w+):\s*(.+?)\s*$/);
+      if (kv && section) fields[section + "." + kv[1]] = kv[2].replace(/^["\x27]|["\x27]$/g, "");
+    }
+    console.log(fields["telemetry.api_key"] || "");
+  ' "$ENTERPRISE_CONFIG" 2>/dev/null || echo "")
+
+  POLICY_API_KEY=$(node -e '
+    const fs = require("node:fs");
+    const raw = fs.readFileSync(process.argv[1], "utf8");
+    let section = "", fields = {};
+    for (const line of raw.split("\n")) {
+      const t = line.trimEnd();
+      if (!t || t.startsWith("#")) continue;
+      const sm = t.match(/^(\w+):\s*$/);
+      if (sm) { section = sm[1]; continue; }
+      const kv = t.match(/^\s+(\w+):\s*(.+?)\s*$/);
+      if (kv && section) fields[section + "." + kv[1]] = kv[2].replace(/^["\x27]|["\x27]$/g, "");
+    }
+    console.log(fields["policy.api_key"] || "");
+  ' "$ENTERPRISE_CONFIG" 2>/dev/null || echo "")
+
   # Telemetry
   if [[ -n "$TELEMETRY_ENDPOINT" ]]; then
     pass "Telemetry: endpoint configured"
-    HTTP_CODE=$(curl -so /dev/null -w '%{http_code}' --max-time 5 -X POST \
-      -H "Content-Type: application/json" \
-      -d '{}' \
-      "$TELEMETRY_ENDPOINT" 2>/dev/null | tail -c 3 || echo "000")
+    TELEMETRY_CURL_ARGS=(-so /dev/null -w '%{http_code}' --max-time 5 -X POST \
+      -H "Content-Type: application/json" -d '{}')
+    if [[ -n "$TELEMETRY_API_KEY" ]]; then
+      TELEMETRY_CURL_ARGS+=(-H "Authorization: Bearer ${TELEMETRY_API_KEY}")
+    fi
+    HTTP_CODE=$(curl "${TELEMETRY_CURL_ARGS[@]}" "$TELEMETRY_ENDPOINT" 2>/dev/null | tail -c 3 || echo "000")
     if [[ "$HTTP_CODE" == "000" ]]; then
       fail "Telemetry: endpoint not reachable (timeout/DNS)"
     elif [[ "$HTTP_CODE" =~ ^[23] ]]; then
-      pass "Telemetry: endpoint reachable (HTTP ${HTTP_CODE})"
-    elif [[ "$HTTP_CODE" == "401" ]]; then
-      pass "Telemetry: endpoint reachable (auth required — expected)"
+      if [[ -n "$TELEMETRY_API_KEY" ]]; then
+        pass "Telemetry: endpoint authenticated (HTTP ${HTTP_CODE})"
+      else
+        pass "Telemetry: endpoint reachable (HTTP ${HTTP_CODE})"
+      fi
+    elif [[ "$HTTP_CODE" == "401" || "$HTTP_CODE" == "403" ]]; then
+      if [[ -n "$TELEMETRY_API_KEY" ]]; then
+        fail "Telemetry: auth rejected (HTTP ${HTTP_CODE}) — check telemetry.api_key in enterprise.yaml"
+      else
+        pass "Telemetry: endpoint reachable (auth required — expected)"
+      fi
     else
       warn "Telemetry: endpoint returned HTTP ${HTTP_CODE}"
     fi
@@ -258,11 +298,25 @@ if [[ -n "$ENTERPRISE_CONFIG" ]]; then
   fi
 
   if [[ -n "$POLICY_ENDPOINT" ]]; then
-    POLICY_HTTP=$(curl -so /dev/null -w '%{http_code}' --max-time 5 "$POLICY_ENDPOINT" 2>/dev/null | tail -c 3 || echo "000")
+    POLICY_CURL_ARGS=(-so /dev/null -w '%{http_code}' --max-time 5)
+    if [[ -n "$POLICY_API_KEY" ]]; then
+      POLICY_CURL_ARGS+=(-H "Authorization: Bearer ${POLICY_API_KEY}")
+    fi
+    POLICY_HTTP=$(curl "${POLICY_CURL_ARGS[@]}" "$POLICY_ENDPOINT" 2>/dev/null | tail -c 3 || echo "000")
     if [[ "$POLICY_HTTP" == "000" ]]; then
       fail "Policy: endpoint not reachable (timeout/DNS)"
-    elif [[ "$POLICY_HTTP" =~ ^[23] ]] || [[ "$POLICY_HTTP" == "401" ]]; then
-      pass "Policy: endpoint reachable (HTTP ${POLICY_HTTP})"
+    elif [[ "$POLICY_HTTP" =~ ^[23] ]]; then
+      if [[ -n "$POLICY_API_KEY" ]]; then
+        pass "Policy: endpoint authenticated (HTTP ${POLICY_HTTP})"
+      else
+        pass "Policy: endpoint reachable (HTTP ${POLICY_HTTP})"
+      fi
+    elif [[ "$POLICY_HTTP" == "401" || "$POLICY_HTTP" == "403" ]]; then
+      if [[ -n "$POLICY_API_KEY" ]]; then
+        fail "Policy: auth rejected (HTTP ${POLICY_HTTP}) — check policy.api_key in enterprise.yaml"
+      else
+        pass "Policy: endpoint reachable (auth required — expected)"
+      fi
     else
       warn "Policy: endpoint returned HTTP ${POLICY_HTTP}"
     fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -221,19 +221,59 @@ if [[ -n "$ENTERPRISE_CONFIG" ]]; then
     console.log(fields["policy.endpoint"] || "");
   ' "$ENTERPRISE_CONFIG" 2>/dev/null || echo "")
 
+  TELEMETRY_API_KEY=$(node -e '
+    const fs = require("node:fs");
+    const raw = fs.readFileSync(process.argv[1], "utf8");
+    let section = "", fields = {};
+    for (const line of raw.split("\n")) {
+      const t = line.trimEnd();
+      if (!t || t.startsWith("#")) continue;
+      const sm = t.match(/^(\w+):\s*$/);
+      if (sm) { section = sm[1]; continue; }
+      const kv = t.match(/^\s+(\w+):\s*(.+?)\s*$/);
+      if (kv && section) fields[section + "." + kv[1]] = kv[2].replace(/^["\x27]|["\x27]$/g, "");
+    }
+    console.log(fields["telemetry.api_key"] || "");
+  ' "$ENTERPRISE_CONFIG" 2>/dev/null || echo "")
+
+  POLICY_API_KEY=$(node -e '
+    const fs = require("node:fs");
+    const raw = fs.readFileSync(process.argv[1], "utf8");
+    let section = "", fields = {};
+    for (const line of raw.split("\n")) {
+      const t = line.trimEnd();
+      if (!t || t.startsWith("#")) continue;
+      const sm = t.match(/^(\w+):\s*$/);
+      if (sm) { section = sm[1]; continue; }
+      const kv = t.match(/^\s+(\w+):\s*(.+?)\s*$/);
+      if (kv && section) fields[section + "." + kv[1]] = kv[2].replace(/^["\x27]|["\x27]$/g, "");
+    }
+    console.log(fields["policy.api_key"] || "");
+  ' "$ENTERPRISE_CONFIG" 2>/dev/null || echo "")
+
   # Telemetry
   if [[ -n "$TELEMETRY_ENDPOINT" ]]; then
     pass "Telemetry: endpoint configured"
-    HTTP_CODE=$(curl -so /dev/null -w '%{http_code}' --max-time 5 -X POST \
-      -H "Content-Type: application/json" \
-      -d '{}' \
-      "$TELEMETRY_ENDPOINT" 2>/dev/null | tail -c 3 || echo "000")
+    TELEMETRY_CURL_ARGS=(-so /dev/null -w '%{http_code}' --max-time 5 -X POST \
+      -H "Content-Type: application/json" -d '{}')
+    if [[ -n "$TELEMETRY_API_KEY" ]]; then
+      TELEMETRY_CURL_ARGS+=(-H "Authorization: Bearer ${TELEMETRY_API_KEY}")
+    fi
+    HTTP_CODE=$(curl "${TELEMETRY_CURL_ARGS[@]}" "$TELEMETRY_ENDPOINT" 2>/dev/null | tail -c 3 || echo "000")
     if [[ "$HTTP_CODE" == "000" ]]; then
       fail "Telemetry: endpoint not reachable (timeout/DNS)"
     elif [[ "$HTTP_CODE" =~ ^[23] ]]; then
-      pass "Telemetry: endpoint reachable (HTTP ${HTTP_CODE})"
-    elif [[ "$HTTP_CODE" == "401" ]]; then
-      pass "Telemetry: endpoint reachable (auth required — expected)"
+      if [[ -n "$TELEMETRY_API_KEY" ]]; then
+        pass "Telemetry: endpoint authenticated (HTTP ${HTTP_CODE})"
+      else
+        pass "Telemetry: endpoint reachable (HTTP ${HTTP_CODE})"
+      fi
+    elif [[ "$HTTP_CODE" == "401" || "$HTTP_CODE" == "403" ]]; then
+      if [[ -n "$TELEMETRY_API_KEY" ]]; then
+        fail "Telemetry: auth rejected (HTTP ${HTTP_CODE}) — check telemetry.api_key in enterprise.yaml"
+      else
+        pass "Telemetry: endpoint reachable (auth required — expected)"
+      fi
     else
       warn "Telemetry: endpoint returned HTTP ${HTTP_CODE}"
     fi
@@ -258,11 +298,25 @@ if [[ -n "$ENTERPRISE_CONFIG" ]]; then
   fi
 
   if [[ -n "$POLICY_ENDPOINT" ]]; then
-    POLICY_HTTP=$(curl -so /dev/null -w '%{http_code}' --max-time 5 "$POLICY_ENDPOINT" 2>/dev/null | tail -c 3 || echo "000")
+    POLICY_CURL_ARGS=(-so /dev/null -w '%{http_code}' --max-time 5)
+    if [[ -n "$POLICY_API_KEY" ]]; then
+      POLICY_CURL_ARGS+=(-H "Authorization: Bearer ${POLICY_API_KEY}")
+    fi
+    POLICY_HTTP=$(curl "${POLICY_CURL_ARGS[@]}" "$POLICY_ENDPOINT" 2>/dev/null | tail -c 3 || echo "000")
     if [[ "$POLICY_HTTP" == "000" ]]; then
       fail "Policy: endpoint not reachable (timeout/DNS)"
-    elif [[ "$POLICY_HTTP" =~ ^[23] ]] || [[ "$POLICY_HTTP" == "401" ]]; then
-      pass "Policy: endpoint reachable (HTTP ${POLICY_HTTP})"
+    elif [[ "$POLICY_HTTP" =~ ^[23] ]]; then
+      if [[ -n "$POLICY_API_KEY" ]]; then
+        pass "Policy: endpoint authenticated (HTTP ${POLICY_HTTP})"
+      else
+        pass "Policy: endpoint reachable (HTTP ${POLICY_HTTP})"
+      fi
+    elif [[ "$POLICY_HTTP" == "401" || "$POLICY_HTTP" == "403" ]]; then
+      if [[ -n "$POLICY_API_KEY" ]]; then
+        fail "Policy: auth rejected (HTTP ${POLICY_HTTP}) — check policy.api_key in enterprise.yaml"
+      else
+        pass "Policy: endpoint reachable (auth required — expected)"
+      fi
     else
       warn "Policy: endpoint returned HTTP ${POLICY_HTTP}"
     fi

--- a/tests/doctor-auth.test.mjs
+++ b/tests/doctor-auth.test.mjs
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DOCTOR_SH = path.resolve(__dirname, "..", "scaffold", "scripts", "doctor.sh");
+
+const VALID_KEY = "ctx_test_valid_123";
+
+function startMock({ returnStatus } = {}) {
+  const server = http.createServer((req, res) => {
+    if (returnStatus) {
+      res.writeHead(returnStatus, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "forced" }));
+      return;
+    }
+    const auth = req.headers["authorization"] ?? "";
+    if (auth === `Bearer ${VALID_KEY}`) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ rules: [], version: "test" }));
+    } else {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Missing API key" }));
+    }
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function closeMock(server) {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function makeTempProject(enterpriseYaml) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-doctor-auth-"));
+  fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
+  fs.mkdirSync(path.join(root, ".context"), { recursive: true });
+  fs.copyFileSync(DOCTOR_SH, path.join(root, "scripts", "doctor.sh"));
+  fs.chmodSync(path.join(root, "scripts", "doctor.sh"), 0o755);
+  fs.writeFileSync(path.join(root, ".context", "enterprise.yaml"), enterpriseYaml);
+  return root;
+}
+
+function runDoctor(projectRoot) {
+  return new Promise((resolve) => {
+    const child = spawn("bash", [path.join(projectRoot, "scripts", "doctor.sh")], {
+      cwd: projectRoot,
+    });
+    let stdout = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on("data", () => {});
+    child.on("close", () => resolve(stdout));
+  });
+}
+
+function yaml({ telemetryEndpoint, telemetryKey, policyEndpoint, policyKey }) {
+  const lines = ["telemetry:", `  endpoint: ${telemetryEndpoint}`];
+  if (telemetryKey !== undefined) lines.push(`  api_key: ${telemetryKey}`);
+  lines.push("", "policy:", `  endpoint: ${policyEndpoint}`);
+  if (policyKey !== undefined) lines.push(`  api_key: ${policyKey}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+test("doctor reports authenticated when api_key matches", async () => {
+  const { server, baseUrl } = await startMock();
+  try {
+    const project = makeTempProject(
+      yaml({
+        telemetryEndpoint: `${baseUrl}/telemetry`,
+        telemetryKey: VALID_KEY,
+        policyEndpoint: `${baseUrl}/policy`,
+        policyKey: VALID_KEY,
+      })
+    );
+    const out = await runDoctor(project);
+    assert.match(out, /Policy: endpoint authenticated \(HTTP 200\)/);
+    assert.match(out, /Telemetry: endpoint authenticated \(HTTP 200\)/);
+  } finally {
+    await closeMock(server);
+  }
+});
+
+test("doctor fails loudly when api_key is wrong (policy 401)", async () => {
+  const { server, baseUrl } = await startMock();
+  try {
+    const project = makeTempProject(
+      yaml({
+        telemetryEndpoint: `${baseUrl}/telemetry`,
+        telemetryKey: "ctx_wrong",
+        policyEndpoint: `${baseUrl}/policy`,
+        policyKey: "ctx_wrong",
+      })
+    );
+    const out = await runDoctor(project);
+    assert.match(out, /Policy: auth rejected \(HTTP 401\) — check policy\.api_key/);
+    assert.match(out, /Telemetry: auth rejected \(HTTP 401\) — check telemetry\.api_key/);
+  } finally {
+    await closeMock(server);
+  }
+});
+
+test("doctor treats 401 as expected when no api_key configured", async () => {
+  const { server, baseUrl } = await startMock();
+  try {
+    const project = makeTempProject(
+      yaml({
+        telemetryEndpoint: `${baseUrl}/telemetry`,
+        policyEndpoint: `${baseUrl}/policy`,
+      })
+    );
+    const out = await runDoctor(project);
+    assert.match(out, /Policy: endpoint reachable \(auth required — expected\)/);
+    assert.match(out, /Telemetry: endpoint reachable \(auth required — expected\)/);
+  } finally {
+    await closeMock(server);
+  }
+});
+
+test("doctor warns on unexpected 500 response", async () => {
+  const { server, baseUrl } = await startMock({ returnStatus: 500 });
+  try {
+    const project = makeTempProject(
+      yaml({
+        telemetryEndpoint: `${baseUrl}/telemetry`,
+        telemetryKey: VALID_KEY,
+        policyEndpoint: `${baseUrl}/policy`,
+        policyKey: VALID_KEY,
+      })
+    );
+    const out = await runDoctor(project);
+    assert.match(out, /Policy: endpoint returned HTTP 500/);
+    assert.match(out, /Telemetry: endpoint returned HTTP 500/);
+  } finally {
+    await closeMock(server);
+  }
+});


### PR DESCRIPTION
## Summary
- Doctor now reads `policy.api_key` and `telemetry.api_key` from `.context/enterprise.yaml` and sends `Authorization: Bearer ${key}` on both probes.
- With a configured key: endpoint returning 2xx is reported as `authenticated (HTTP 200)`; 401/403 is a real **fail** with `— check <section>.api_key in enterprise.yaml`.
- Without a configured key: 401 is still a `pass "reachable (auth required — expected)"`, matching the prior intent but with consistent messaging across telemetry and policy.

## Problem
Customer on 1.3.1 reported `Policy: endpoint reachable (HTTP 401) — should be 200`. Probe was unauthenticated; 401 was labeled "reachable" without context, so customers couldn't tell if the key worked, or even that one was being used. Real sync callers (`cortex-enterprise/packages/local/src/policy/sync.ts`) already send Bearer — doctor was the outlier.

## Test plan
- [x] New `tests/doctor-auth.test.mjs` — in-process `node:http` mock covering: valid key → 200 authenticated, wrong key → 401 fail with guidance, no key → 401 expected, 500 → warn. All pass.
- [x] Full suite: 159/159 pass.
- [x] Manual smoke against a local mock — doctor correctly emits `✓ Policy: endpoint authenticated (HTTP 200)` with valid Bearer.
- [ ] After release: customer re-runs `cortex doctor` on 1.3.2 → if their `policy.api_key` is valid, `Policy: endpoint authenticated (HTTP 200)`; if invalid, clear remediation pointing at `policy.api_key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)