### PR TITLE
perf(csharp): publish Roslyn sidecar once, invoke DLL directly

### DIFF
--- a/docs/csharp-roslyn-semantic-upgrade.md
+++ b/docs/csharp-roslyn-semantic-upgrade.md
@@ -54,8 +54,9 @@ Unresolved calls (e.g. via `dynamic`, or when referenced type isn't in the compi
 
 ### Bridge (`csharp.mjs`)
 
-- `parseCode(code, filePath, language)` — unchanged. Per-file, syntax-only.
-- `parseProject(files: [{path, content}])` — new. Spawns one `dotnet run -- --batch`, streams JSON in/out, returns `Map<path, {chunks, errors}>`. Shares the same `getCSharpParserRuntime` probe cache.
+- `parseCode(code, filePath, language)` — per-file, syntax-only. Invokes the pre-published `CSharpParser.dll` via `dotnet <dll> --stdin --file X.cs`.
+- `parseProject(files: [{path, content}])` — batch. Invokes `dotnet <dll> --batch`, streams JSON in/out, returns `Map<path, {chunks, errors}>`.
+- `ensureCSharpParserPublished()` — on first use, runs `dotnet publish -c Release` once to `bin/Release/<tfm>/publish/` and caches the DLL path. Subsequent calls skip the msbuild cycle (~10× speedup per single-file call).
 
 ### Ingest integration
 

--- a/scaffold/scripts/parsers/csharp.mjs
+++ b/scaffold/scripts/parsers/csharp.mjs
@@ -2,11 +2,16 @@
 /**
  * Conditional C# parser bridge for Cortex.
  *
- * Uses a Roslyn sidecar via `dotnet run` when a .NET runtime is available.
- * If no runtime exists, callers should skip structured chunk extraction and
- * fall back to plain file-level indexing.
+ * Uses a Roslyn sidecar via a pre-published DLL when a .NET SDK is available.
+ * On first use the sidecar is published to bin/Release/<tfm>/publish/ and the
+ * DLL path is cached; subsequent invocations skip the msbuild cycle and run
+ * `dotnet <dll>` directly — roughly 10× faster per call than `dotnet run`.
+ *
+ * If no runtime/SDK exists, callers should skip structured chunk extraction
+ * and fall back to plain file-level indexing.
  */
 
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -15,8 +20,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DEFAULT_DOTNET_COMMAND = "dotnet";
 const DEFAULT_PROJECT_PATH = path.join(__dirname, "dotnet", "CSharpParser", "CSharpParser.csproj");
+const DEFAULT_TARGET_FRAMEWORK = "net10.0";
 
 let runtimeCache = null;
+let publishCache = null;
 
 function getDotnetCommand() {
   const override = process.env.CORTEX_DOTNET_CMD;
@@ -28,8 +35,51 @@ function getProjectPath() {
   return override && override.trim().length > 0 ? override.trim() : DEFAULT_PROJECT_PATH;
 }
 
+function getTargetFramework() {
+  const override = process.env.CORTEX_CSHARP_PARSER_TFM;
+  return override && override.trim().length > 0 ? override.trim() : DEFAULT_TARGET_FRAMEWORK;
+}
+
+function getPublishDir() {
+  const override = process.env.CORTEX_CSHARP_PUBLISH_DIR;
+  if (override && override.trim().length > 0) return override.trim();
+  const projectDir = path.dirname(getProjectPath());
+  return path.join(projectDir, "bin", "Release", getTargetFramework(), "publish");
+}
+
+function getDllPath() {
+  return path.join(getPublishDir(), "CSharpParser.dll");
+}
+
+function getMaxSourceMtime() {
+  const projectDir = path.dirname(getProjectPath());
+  const sources = [getProjectPath(), path.join(projectDir, "Program.cs")];
+  let max = 0;
+  for (const src of sources) {
+    try {
+      const mtime = fs.statSync(src).mtimeMs;
+      if (mtime > max) max = mtime;
+    } catch {
+      // missing source — treated as stale below
+    }
+  }
+  return max;
+}
+
+function needsPublish() {
+  const dll = getDllPath();
+  let dllMtime;
+  try {
+    dllMtime = fs.statSync(dll).mtimeMs;
+  } catch {
+    return true;
+  }
+  return getMaxSourceMtime() > dllMtime;
+}
+
 export function resetCSharpParserRuntimeCache() {
   runtimeCache = null;
+  publishCache = null;
 }
 
 export function getCSharpParserRuntime() {
@@ -69,19 +119,69 @@ export function isCSharpParserAvailable() {
   return getCSharpParserRuntime().available;
 }
 
+export function ensureCSharpParserPublished() {
+  if (publishCache) return publishCache;
+
+  const runtime = getCSharpParserRuntime();
+  if (!runtime.available) {
+    publishCache = { ok: false, reason: runtime.reason };
+    return publishCache;
+  }
+
+  const dllPath = getDllPath();
+  if (!needsPublish()) {
+    publishCache = { ok: true, dllPath };
+    return publishCache;
+  }
+
+  if (!process.env.CORTEX_QUIET) {
+    process.stderr.write("[cortex] Publishing Roslyn C# parser (one-time, ~15s)...\n");
+  }
+
+  const result = spawnSync(
+    runtime.command,
+    [
+      "publish",
+      runtime.projectPath,
+      "-c", "Release",
+      "-o", getPublishDir(),
+      "--nologo",
+      "-v", "quiet"
+    ],
+    { encoding: "utf8", timeout: 180000 }
+  );
+
+  if (result.error || result.status !== 0) {
+    publishCache = {
+      ok: false,
+      reason:
+        result.error?.message ||
+        result.stderr?.trim() ||
+        `dotnet publish failed with exit code ${result.status ?? "unknown"}`
+    };
+    return publishCache;
+  }
+
+  publishCache = { ok: true, dllPath };
+  return publishCache;
+}
+
 export function parseCode(code, filePath, language = "csharp") {
   const runtime = getCSharpParserRuntime();
   if (!runtime.available) {
     return { chunks: [], errors: [] };
   }
 
+  const published = ensureCSharpParserPublished();
+  if (!published.ok) {
+    return {
+      chunks: [],
+      errors: [{ message: `C# parser publish failed: ${published.reason}` }]
+    };
+  }
+
   const args = [
-    "run",
-    "--project",
-    runtime.projectPath,
-    "--configuration",
-    "Release",
-    "--",
+    published.dllPath,
     "--stdin",
     "--file",
     filePath,
@@ -147,15 +247,17 @@ export function parseProject(files) {
     return empty;
   }
 
-  const args = [
-    "run",
-    "--project",
-    runtime.projectPath,
-    "--configuration",
-    "Release",
-    "--",
-    "--batch"
-  ];
+  const published = ensureCSharpParserPublished();
+  if (!published.ok) {
+    const errors = [{ message: `C# parser publish failed: ${published.reason}` }];
+    const fallback = new Map();
+    for (const file of files) {
+      fallback.set(file.path, { chunks: [], errors });
+    }
+    return fallback;
+  }
+
+  const args = [published.dllPath, "--batch"];
 
   const payload = JSON.stringify({
     files: files.map((f) => ({ path: f.path, source: f.content }))
@@ -215,7 +317,6 @@ export function parseProject(files) {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const fs = await import("node:fs");
   const filePath = process.argv[2];
 
   if (!filePath) {

--- a/scripts/parsers/csharp.mjs
+++ b/scripts/parsers/csharp.mjs
@@ -2,11 +2,16 @@
 /**
  * Conditional C# parser bridge for Cortex.
  *
- * Uses a Roslyn sidecar via `dotnet run` when a .NET runtime is available.
- * If no runtime exists, callers should skip structured chunk extraction and
- * fall back to plain file-level indexing.
+ * Uses a Roslyn sidecar via a pre-published DLL when a .NET SDK is available.
+ * On first use the sidecar is published to bin/Release/<tfm>/publish/ and the
+ * DLL path is cached; subsequent invocations skip the msbuild cycle and run
+ * `dotnet <dll>` directly — roughly 10× faster per call than `dotnet run`.
+ *
+ * If no runtime/SDK exists, callers should skip structured chunk extraction
+ * and fall back to plain file-level indexing.
  */
 
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -15,8 +20,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DEFAULT_DOTNET_COMMAND = "dotnet";
 const DEFAULT_PROJECT_PATH = path.join(__dirname, "dotnet", "CSharpParser", "CSharpParser.csproj");
+const DEFAULT_TARGET_FRAMEWORK = "net10.0";
 
 let runtimeCache = null;
+let publishCache = null;
 
 function getDotnetCommand() {
   const override = process.env.CORTEX_DOTNET_CMD;
@@ -28,8 +35,51 @@ function getProjectPath() {
   return override && override.trim().length > 0 ? override.trim() : DEFAULT_PROJECT_PATH;
 }
 
+function getTargetFramework() {
+  const override = process.env.CORTEX_CSHARP_PARSER_TFM;
+  return override && override.trim().length > 0 ? override.trim() : DEFAULT_TARGET_FRAMEWORK;
+}
+
+function getPublishDir() {
+  const override = process.env.CORTEX_CSHARP_PUBLISH_DIR;
+  if (override && override.trim().length > 0) return override.trim();
+  const projectDir = path.dirname(getProjectPath());
+  return path.join(projectDir, "bin", "Release", getTargetFramework(), "publish");
+}
+
+function getDllPath() {
+  return path.join(getPublishDir(), "CSharpParser.dll");
+}
+
+function getMaxSourceMtime() {
+  const projectDir = path.dirname(getProjectPath());
+  const sources = [getProjectPath(), path.join(projectDir, "Program.cs")];
+  let max = 0;
+  for (const src of sources) {
+    try {
+      const mtime = fs.statSync(src).mtimeMs;
+      if (mtime > max) max = mtime;
+    } catch {
+      // missing source — treated as stale below
+    }
+  }
+  return max;
+}
+
+function needsPublish() {
+  const dll = getDllPath();
+  let dllMtime;
+  try {
+    dllMtime = fs.statSync(dll).mtimeMs;
+  } catch {
+    return true;
+  }
+  return getMaxSourceMtime() > dllMtime;
+}
+
 export function resetCSharpParserRuntimeCache() {
   runtimeCache = null;
+  publishCache = null;
 }
 
 export function getCSharpParserRuntime() {
@@ -69,19 +119,69 @@ export function isCSharpParserAvailable() {
   return getCSharpParserRuntime().available;
 }
 
+export function ensureCSharpParserPublished() {
+  if (publishCache) return publishCache;
+
+  const runtime = getCSharpParserRuntime();
+  if (!runtime.available) {
+    publishCache = { ok: false, reason: runtime.reason };
+    return publishCache;
+  }
+
+  const dllPath = getDllPath();
+  if (!needsPublish()) {
+    publishCache = { ok: true, dllPath };
+    return publishCache;
+  }
+
+  if (!process.env.CORTEX_QUIET) {
+    process.stderr.write("[cortex] Publishing Roslyn C# parser (one-time, ~15s)...\n");
+  }
+
+  const result = spawnSync(
+    runtime.command,
+    [
+      "publish",
+      runtime.projectPath,
+      "-c", "Release",
+      "-o", getPublishDir(),
+      "--nologo",
+      "-v", "quiet"
+    ],
+    { encoding: "utf8", timeout: 180000 }
+  );
+
+  if (result.error || result.status !== 0) {
+    publishCache = {
+      ok: false,
+      reason:
+        result.error?.message ||
+        result.stderr?.trim() ||
+        `dotnet publish failed with exit code ${result.status ?? "unknown"}`
+    };
+    return publishCache;
+  }
+
+  publishCache = { ok: true, dllPath };
+  return publishCache;
+}
+
 export function parseCode(code, filePath, language = "csharp") {
   const runtime = getCSharpParserRuntime();
   if (!runtime.available) {
     return { chunks: [], errors: [] };
   }
 
+  const published = ensureCSharpParserPublished();
+  if (!published.ok) {
+    return {
+      chunks: [],
+      errors: [{ message: `C# parser publish failed: ${published.reason}` }]
+    };
+  }
+
   const args = [
-    "run",
-    "--project",
-    runtime.projectPath,
-    "--configuration",
-    "Release",
-    "--",
+    published.dllPath,
     "--stdin",
     "--file",
     filePath,
@@ -147,15 +247,17 @@ export function parseProject(files) {
     return empty;
   }
 
-  const args = [
-    "run",
-    "--project",
-    runtime.projectPath,
-    "--configuration",
-    "Release",
-    "--",
-    "--batch"
-  ];
+  const published = ensureCSharpParserPublished();
+  if (!published.ok) {
+    const errors = [{ message: `C# parser publish failed: ${published.reason}` }];
+    const fallback = new Map();
+    for (const file of files) {
+      fallback.set(file.path, { chunks: [], errors });
+    }
+    return fallback;
+  }
+
+  const args = [published.dllPath, "--batch"];
 
   const payload = JSON.stringify({
     files: files.map((f) => ({ path: f.path, source: f.content }))
@@ -215,7 +317,6 @@ export function parseProject(files) {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const fs = await import("node:fs");
   const filePath = process.argv[2];
 
   if (!filePath) {


### PR DESCRIPTION
## Summary

- Replaces per-invocation \`dotnet run --project ...\` with a pre-published \`CSharpParser.dll\` invoked as \`dotnet <dll>\` — skips the msbuild cycle on every call.
- First call runs \`dotnet publish -c Release\` once (~15s); subsequent calls go from ~1–3s to ~60–250ms per file.
- Cache invalidated on \`Program.cs\` / \`.csproj\` mtime change. Runtime-missing fallback preserved; all existing \`withMissingDotnetRuntime\` tests unchanged.

## Measured

- \`tests/csharp-parser.test.mjs\` (20 tests, incl. parseCode + parseProject + syntax errors + cross-file resolution): **30–60s → 4.1s** total.
- First test includes the one-time publish (~1.5s on local machine, ~15s on a cold machine per message).

## Changes

- \`scripts/parsers/csharp.mjs\` and \`scaffold/scripts/parsers/csharp.mjs\` — add \`ensureCSharpParserPublished()\`, switch spawn args in both \`parseCode\` and \`parseProject\`.
- \`docs/csharp-roslyn-semantic-upgrade.md\` — bridge section updated to reflect DLL invocation instead of \`dotnet run\`.

## Knobs

- \`CORTEX_CSHARP_PUBLISH_DIR\` — override publish output location
- \`CORTEX_CSHARP_PARSER_TFM\` — target framework (default \`net10.0\`)
- \`CORTEX_QUIET\` — suppress first-run publish log line

## Test plan

- [x] \`node --test tests/csharp-parser.test.mjs\` — 20/20 pass
- [x] \`npm test\` — 76/76 pass (no regressions)
- [ ] Verify first-run publish on a clean machine (DLL missing) — publishes and succeeds
- [ ] Verify cache reuse — second run skips publish
- [ ] Verify mtime invalidation — touch Program.cs → next call republishes

## Out of scope

- VB.NET parser has the same \`dotnet run\` pattern; follow-up PR.
- Persistent Roslyn daemon (stdin JSON-RPC) — bigger change, defer until we see if ~200ms/file is still too slow in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)