### PR TITLE
refactor(scaffold): bring scaffold to parity with scripts/

### DIFF
--- a/scaffold/scripts/dashboard.mjs
+++ b/scaffold/scripts/dashboard.mjs
@@ -543,6 +543,19 @@ function emptyLine(width) {
   return col("│", C.gray) + " ".repeat(width - 2) + col("│", C.gray);
 }
 
+// ── Edition detection ────────────────────────────────────────
+import { createRequire } from "node:module";
+const __require = createRequire(import.meta.url);
+
+function detectEdition() {
+  try {
+    __require.resolve("@danielblomma/cortex-enterprise");
+    return "Enterprise";
+  } catch {
+    return "Community";
+  }
+}
+
 // ── Render sections ──────────────────────────────────────────
 function render(data, isTTY) {
   const termWidth = process.stdout.columns || 80;
@@ -551,7 +564,8 @@ function render(data, isTTY) {
 
   // Header
   const clock = new Date().toLocaleTimeString("sv-SE", { hour: "2-digit", minute: "2-digit" });
-  const title = "─ cortex dashboard ";
+  const edition = detectEdition();
+  const title = `─ cortex dashboard [${edition}] `;
   const clockPart = ` ${clock} ─`;
   const fillLen = w - 2 - title.length - clockPart.length;
   lines.push(col(`┌${title}${"─".repeat(Math.max(0, fillLen))}${clockPart}┐`, C.gray));

--- a/scaffold/scripts/ingest.mjs
+++ b/scaffold/scripts/ingest.mjs
@@ -4,30 +4,85 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { execSync } from "node:child_process";
-import { parseCode as parseJavaScriptCode } from "./parsers/javascript.mjs";
-import {
-  isVbNetParserAvailable,
-  parseCode as parseVbNetCode
-} from "./parsers/vbnet.mjs";
-import {
-  isCSharpParserAvailable,
-  parseCode as parseCSharpCode,
-  parseProject as parseCSharpProject
-} from "./parsers/csharp.mjs";
-import {
-  isCppParserAvailable,
-  parseCode as parseCppCode
-} from "./parsers/cpp-dispatch.mjs";
-import { parseCode as parseConfigCode } from "./parsers/config.mjs";
-import { parseCode as parseResourcesCode } from "./parsers/resources.mjs";
-import { parseCode as parseSqlCode } from "./parsers/sql.mjs";
-import { parseCode as parseRustCode } from "./parsers/rust-dispatch.mjs";
-import { parseCode as parsePythonCode } from "./parsers/python-treesitter.mjs";
-import { parseCode as parseGoCode } from "./parsers/go-treesitter.mjs";
-import { parseCode as parseJavaCode } from "./parsers/java-treesitter.mjs";
-import { parseCode as parseRubyCode } from "./parsers/ruby-treesitter.mjs";
-import { parseCode as parseBashCode } from "./parsers/bash-treesitter.mjs";
-import { parseCode as parseVb6Code } from "./parsers/vb6.mjs";
+import { parseCode } from "./parsers/javascript.mjs";
+
+const parseJavaScriptCode = parseCode;
+let parseVbNetCode = null;
+let parseCSharpCode = null;
+let parseCSharpProject = null;
+let parseCppCode = null;
+let parseConfigCode = null;
+let parseResourcesCode = null;
+let parseSqlCode = null;
+let parseRustCode = null;
+let parsePythonCode = null;
+let parseGoCode = null;
+let parseJavaCode = null;
+let parseRubyCode = null;
+let parseBashCode = null;
+let parseVb6Code = null;
+let isVbNetParserAvailable = () => false;
+let isCSharpParserAvailable = () => false;
+let isCppParserAvailable = () => false;
+
+async function loadOptionalParsers() {
+  const loaders = [
+    import("./parsers/vbnet.mjs").then((module) => {
+      parseVbNetCode = module.parseCode;
+      isVbNetParserAvailable =
+        typeof module.isVbNetParserAvailable === "function"
+          ? module.isVbNetParserAvailable
+          : () => typeof module.parseCode === "function";
+    }),
+    import("./parsers/csharp.mjs").then((module) => {
+      parseCSharpCode = module.parseCode;
+      parseCSharpProject = module.parseProject ?? null;
+      isCSharpParserAvailable =
+        typeof module.isCSharpParserAvailable === "function"
+          ? module.isCSharpParserAvailable
+          : () => typeof module.parseCode === "function";
+    }),
+    import("./parsers/cpp-dispatch.mjs").then((module) => {
+      parseCppCode = module.parseCode;
+      isCppParserAvailable =
+        typeof module.isCppParserAvailable === "function"
+          ? module.isCppParserAvailable
+          : () => typeof module.parseCode === "function";
+    }),
+    import("./parsers/config.mjs").then((module) => {
+      parseConfigCode = module.parseCode;
+    }),
+    import("./parsers/resources.mjs").then((module) => {
+      parseResourcesCode = module.parseCode;
+    }),
+    import("./parsers/sql.mjs").then((module) => {
+      parseSqlCode = module.parseCode;
+    }),
+    import("./parsers/rust-dispatch.mjs").then((module) => {
+      parseRustCode = module.parseCode;
+    }),
+    import("./parsers/python-treesitter.mjs").then((module) => {
+      parsePythonCode = module.parseCode;
+    }),
+    import("./parsers/go-treesitter.mjs").then((module) => {
+      parseGoCode = module.parseCode;
+    }),
+    import("./parsers/java-treesitter.mjs").then((module) => {
+      parseJavaCode = module.parseCode;
+    }),
+    import("./parsers/ruby-treesitter.mjs").then((module) => {
+      parseRubyCode = module.parseCode;
+    }),
+    import("./parsers/bash-treesitter.mjs").then((module) => {
+      parseBashCode = module.parseCode;
+    }),
+    import("./parsers/vb6.mjs").then((module) => {
+      parseVb6Code = module.parseCode;
+    })
+  ];
+
+  await Promise.allSettled(loaders);
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -101,7 +156,7 @@ const LEGACY_DOTNET_METADATA_EXTENSIONS = new Set([
   ".settings"
 ]);
 
-const PROJECT_DEFINITION_EXTENSIONS = new Set([".sln", ".vbproj", ".csproj", ".fsproj"]);
+const PROJECT_DEFINITION_EXTENSIONS = new Set([".sln", ".vbproj", ".csproj", ".fsproj", ".vcxproj"]);
 const STRUCTURED_NON_CODE_CHUNK_EXTENSIONS = new Set([".config", ".resx", ".settings"]);
 
 const CODE_FILE_EXTENSIONS = new Set([
@@ -214,176 +269,200 @@ const CHUNK_PARSERS = new Map([
     ".vb",
     {
       language: "vbnet",
-      parse: parseVbNetCode,
-      isAvailable: isVbNetParserAvailable
+      parse: (...args) => parseVbNetCode(...args),
+      isAvailable: () =>
+        typeof parseVbNetCode === "function" && isVbNetParserAvailable()
     }
   ],
   [
     ".cs",
     {
       language: "csharp",
-      parse: parseCSharpCode,
-      isAvailable: isCSharpParserAvailable
+      parse: (...args) => parseCSharpCode(...args),
+      isAvailable: () =>
+        typeof parseCSharpCode === "function" && isCSharpParserAvailable()
     }
   ],
   [
     ".sql",
     {
       language: "sql",
-      parse: parseSqlCode
+      parse: (...args) => parseSqlCode(...args),
+      isAvailable: () => typeof parseSqlCode === "function"
     }
   ],
   [
     ".config",
     {
       language: "config",
-      parse: parseConfigCode
+      parse: (...args) => parseConfigCode(...args),
+      isAvailable: () => typeof parseConfigCode === "function"
     }
   ],
   [
     ".resx",
     {
       language: "resource",
-      parse: parseResourcesCode
+      parse: (...args) => parseResourcesCode(...args),
+      isAvailable: () => typeof parseResourcesCode === "function"
     }
   ],
   [
     ".settings",
     {
       language: "settings",
-      parse: parseResourcesCode
+      parse: (...args) => parseResourcesCode(...args),
+      isAvailable: () => typeof parseResourcesCode === "function"
     }
   ],
   [
     ".c",
     {
       language: "c",
-      parse: parseCppCode,
-      isAvailable: isCppParserAvailable
+      parse: (...args) => parseCppCode(...args),
+      isAvailable: () =>
+        typeof parseCppCode === "function" && isCppParserAvailable()
     }
   ],
   [
     ".h",
     {
       language: "c",
-      parse: parseCppCode,
-      isAvailable: isCppParserAvailable
+      parse: (...args) => parseCppCode(...args),
+      isAvailable: () =>
+        typeof parseCppCode === "function" && isCppParserAvailable()
     }
   ],
   [
     ".cpp",
     {
       language: "cpp",
-      parse: parseCppCode,
-      isAvailable: isCppParserAvailable
+      parse: (...args) => parseCppCode(...args),
+      isAvailable: () =>
+        typeof parseCppCode === "function" && isCppParserAvailable()
     }
   ],
   [
     ".cc",
     {
       language: "cpp",
-      parse: parseCppCode,
-      isAvailable: isCppParserAvailable
+      parse: (...args) => parseCppCode(...args),
+      isAvailable: () =>
+        typeof parseCppCode === "function" && isCppParserAvailable()
     }
   ],
   [
     ".hpp",
     {
       language: "cpp",
-      parse: parseCppCode,
-      isAvailable: isCppParserAvailable
+      parse: (...args) => parseCppCode(...args),
+      isAvailable: () =>
+        typeof parseCppCode === "function" && isCppParserAvailable()
     }
   ],
   [
     ".hh",
     {
       language: "cpp",
-      parse: parseCppCode,
-      isAvailable: isCppParserAvailable
+      parse: (...args) => parseCppCode(...args),
+      isAvailable: () =>
+        typeof parseCppCode === "function" && isCppParserAvailable()
     }
   ],
   [
     ".rs",
     {
       language: "rust",
-      parse: parseRustCode
+      parse: (...args) => parseRustCode(...args),
+      isAvailable: () => typeof parseRustCode === "function"
     }
   ],
   [
     ".py",
     {
       language: "python",
-      parse: parsePythonCode
+      parse: (...args) => parsePythonCode(...args),
+      isAvailable: () => typeof parsePythonCode === "function"
     }
   ],
   [
     ".go",
     {
       language: "go",
-      parse: parseGoCode
+      parse: (...args) => parseGoCode(...args),
+      isAvailable: () => typeof parseGoCode === "function"
     }
   ],
   [
     ".java",
     {
       language: "java",
-      parse: parseJavaCode
+      parse: (...args) => parseJavaCode(...args),
+      isAvailable: () => typeof parseJavaCode === "function"
     }
   ],
   [
     ".rb",
     {
       language: "ruby",
-      parse: parseRubyCode
+      parse: (...args) => parseRubyCode(...args),
+      isAvailable: () => typeof parseRubyCode === "function"
     }
   ],
   [
     ".sh",
     {
       language: "bash",
-      parse: parseBashCode
+      parse: (...args) => parseBashCode(...args),
+      isAvailable: () => typeof parseBashCode === "function"
     }
   ],
   [
     ".bash",
     {
       language: "bash",
-      parse: parseBashCode
+      parse: (...args) => parseBashCode(...args),
+      isAvailable: () => typeof parseBashCode === "function"
     }
   ],
   [
     ".zsh",
     {
       language: "bash",
-      parse: parseBashCode
+      parse: (...args) => parseBashCode(...args),
+      isAvailable: () => typeof parseBashCode === "function"
     }
   ],
   [
     ".bas",
     {
       language: "vb6",
-      parse: parseVb6Code
+      parse: (...args) => parseVb6Code(...args),
+      isAvailable: () => typeof parseVb6Code === "function"
     }
   ],
   [
     ".cls",
     {
       language: "vb6",
-      parse: parseVb6Code
+      parse: (...args) => parseVb6Code(...args),
+      isAvailable: () => typeof parseVb6Code === "function"
     }
   ],
   [
     ".frm",
     {
       language: "vb6",
-      parse: parseVb6Code
+      parse: (...args) => parseVb6Code(...args),
+      isAvailable: () => typeof parseVb6Code === "function"
     }
   ],
   [
     ".ctl",
     {
       language: "vb6",
-      parse: parseVb6Code
+      parse: (...args) => parseVb6Code(...args),
+      isAvailable: () => typeof parseVb6Code === "function"
     }
   ]
 ]);
@@ -1043,6 +1122,58 @@ function namedEntryChunkAliases(chunk) {
     aliases.add(normalizedTail);
   }
   return [...aliases];
+}
+
+function buildChunkAliasIndexes(chunkRecords) {
+  const sqlChunkIdsByAlias = new Map();
+  const configChunkIdsByAlias = new Map();
+  const resourceChunkIdsByAlias = new Map();
+  const settingChunkIdsByAlias = new Map();
+
+  for (const chunk of chunkRecords) {
+    if (isWindowChunkId(chunk?.id)) {
+      continue;
+    }
+
+    const language = String(chunk?.language ?? "").toLowerCase();
+    if (language === "sql") {
+      for (const alias of sqlChunkAliases(chunk.name)) {
+        const existing = sqlChunkIdsByAlias.get(alias) ?? [];
+        sqlChunkIdsByAlias.set(alias, [...existing, chunk.id]);
+      }
+      continue;
+    }
+
+    if (language === "config") {
+      for (const alias of configChunkAliases(chunk)) {
+        const existing = configChunkIdsByAlias.get(alias) ?? [];
+        configChunkIdsByAlias.set(alias, [...existing, chunk.id]);
+      }
+      continue;
+    }
+
+    if (language === "resource") {
+      for (const alias of namedEntryChunkAliases(chunk)) {
+        const existing = resourceChunkIdsByAlias.get(alias) ?? [];
+        resourceChunkIdsByAlias.set(alias, [...existing, chunk.id]);
+      }
+      continue;
+    }
+
+    if (language === "settings") {
+      for (const alias of namedEntryChunkAliases(chunk)) {
+        const existing = settingChunkIdsByAlias.get(alias) ?? [];
+        settingChunkIdsByAlias.set(alias, [...existing, chunk.id]);
+      }
+    }
+  }
+
+  return {
+    sqlChunkIdsByAlias,
+    configChunkIdsByAlias,
+    resourceChunkIdsByAlias,
+    settingChunkIdsByAlias
+  };
 }
 
 function extractSqlReferenceNamesFromString(text) {
@@ -1793,6 +1924,8 @@ function projectLanguageForExtension(ext) {
       return "csharp";
     case ".fsproj":
       return "fsharp";
+    case ".vcxproj":
+      return "cpp";
     case ".sln":
       return "solution";
     default:
@@ -1826,7 +1959,7 @@ function parseSolutionProject(fileRecord, indexedFileIds) {
   const ext = path.extname(fileRecord.path).toLowerCase();
   const fallbackName = path.basename(fileRecord.path, ext);
   const projectPattern =
-    /^Project\([^)]*\)\s*=\s*"([^"]+)",\s*"([^"]+\.(?:vbproj|csproj|fsproj))",\s*"\{[^"]+\}"$/gim;
+    /^Project\([^)]*\)\s*=\s*"([^"]+)",\s*"([^"]+\.(?:vbproj|csproj|fsproj|vcxproj))",\s*"\{[^"]+\}"$/gim;
 
   let match;
   while ((match = projectPattern.exec(fileRecord.content)) !== null) {
@@ -2366,7 +2499,8 @@ function splitChunkIntoWindows(chunkRecord, options) {
   return windows;
 }
 
-function main() {
+async function main() {
+  await loadOptionalParsers();
   const { mode, verbose } = parseArgs(process.argv);
   const configPath = path.join(CONTEXT_DIR, "config.yaml");
   const rulesPath = path.join(CONTEXT_DIR, "rules.yaml");
@@ -2574,15 +2708,19 @@ function main() {
 
   // Extract chunks from changed or uncached code files
   let windowedChunkCount = 0;
-  const sqlChunkIdsByAlias = new Map();
-  const configChunkIdsByAlias = new Map();
-  const resourceChunkIdsByAlias = new Map();
-  const settingChunkIdsByAlias = new Map();
+  let {
+    sqlChunkIdsByAlias,
+    configChunkIdsByAlias,
+    resourceChunkIdsByAlias,
+    settingChunkIdsByAlias
+  } = buildChunkAliasIndexes([...chunkRecordMap.values()]);
   const deferredSqlCallEdges = [];
 
-  // C# project-wide batch parse: compile all .cs files together via
-  // CSharpCompilation for SemanticModel-resolved calls. Falls back to
-  // per-file parse silently if batch isn't usable.
+  // C# project-wide batch parse: when Roslyn is available and batching
+  // isn't disabled, compile all .cs files together via CSharpCompilation
+  // to enable SemanticModel-resolved calls (e.g. "System.IO.File.ReadAllText"
+  // instead of bare "ReadAllText"). Falls back silently to per-file parse
+  // if batch isn't usable.
   const csharpBatchCache = new Map();
   if (
     typeof parseCSharpProject === "function" &&
@@ -2788,6 +2926,12 @@ function main() {
   }
 
   const chunkRecords = [...chunkRecordMap.values()].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  ({
+    sqlChunkIdsByAlias,
+    configChunkIdsByAlias,
+    resourceChunkIdsByAlias,
+    settingChunkIdsByAlias
+  } = buildChunkAliasIndexes(chunkRecords));
 
   // Filter CALLS relations to only valid targets (chunks that actually exist)
   const chunkIdSet = new Set(chunkRecords.map(c => c.id));
@@ -3401,10 +3545,14 @@ function main() {
 
 const isMainModule = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename);
 if (isMainModule) {
-  main();
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
 }
 
 export {
+  buildChunkAliasIndexes,
   buildSqlResourceReferenceMap,
   detectKind,
   extractSqlObjectReferencesFromContent,

--- a/scaffold/scripts/parsers/javascript.mjs
+++ b/scaffold/scripts/parsers/javascript.mjs
@@ -4,21 +4,10 @@
  * Extracts functions, methods, classes and call relationships
  */
 
-let parseAst;
-let discoverChunks;
-let extractCalls;
-let collectStaticImports;
-let extractImportsForChunk;
-let fallbackParseCode = null;
-
-try {
-  ({ parseAst } = await import("./javascript/ast.mjs"));
-  ({ discoverChunks } = await import("./javascript/chunks.mjs"));
-  ({ extractCalls } = await import("./javascript/calls.mjs"));
-  ({ collectStaticImports, extractImportsForChunk } = await import("./javascript/imports.mjs"));
-} catch {
-  ({ parseCode: fallbackParseCode } = await import("../../../scripts/parsers/javascript.mjs"));
-}
+import { parseAst } from "./javascript/ast.mjs";
+import { discoverChunks } from "./javascript/chunks.mjs";
+import { extractCalls } from "./javascript/calls.mjs";
+import { collectStaticImports, extractImportsForChunk } from "./javascript/imports.mjs";
 
 /**
  * Parse JavaScript/TypeScript code and extract chunks + calls
@@ -28,10 +17,6 @@ try {
  * @returns {Object} { chunks: Array, errors: Array }
  */
 export function parseCode(code, filePath, language = "javascript") {
-  if (fallbackParseCode) {
-    return fallbackParseCode(code, filePath, language);
-  }
-
   const { ast, errors } = parseAst(code, filePath);
   if (!ast) {
     return { chunks: [], errors };

--- a/scaffold/scripts/parsers/javascript/ast.mjs
+++ b/scaffold/scripts/parsers/javascript/ast.mjs
@@ -2,12 +2,67 @@ import { Parser } from "acorn";
 import tsPlugin from "acorn-typescript";
 import { base } from "acorn-walk";
 
+const baseIdentifier = base.Identifier;
+const baseFunction = base.Function;
+const baseClass = base.Class;
+
+base.Identifier = (node, st, visit) => {
+  baseIdentifier(node, st, visit);
+  if (node.typeAnnotation) {
+    visit(node.typeAnnotation, st);
+  }
+};
+
+base.Function = (node, st, visit) => {
+  baseFunction(node, st, visit);
+  if (node.returnType) {
+    visit(node.returnType, st);
+  }
+  if (node.typeParameters) {
+    visit(node.typeParameters, st);
+  }
+};
+
+base.Class = (node, st, visit) => {
+  baseClass(node, st, visit);
+  for (const implementedType of node.implements || []) {
+    visit(implementedType, st);
+  }
+  if (node.typeParameters) {
+    visit(node.typeParameters, st);
+  }
+};
+
 const tsNodeHandlers = {
   TSAsExpression(node, st, visit) { visit(node.expression, st); },
-  TSTypeAnnotation() {},
-  TSTypeParameterInstantiation() {},
-  TSTypeParameterDeclaration() {},
-  TSTypeReference() {},
+  TSTypeAnnotation(node, st, visit) {
+    if (node.typeAnnotation) {
+      visit(node.typeAnnotation, st);
+    }
+  },
+  TSTypeParameterInstantiation(node, st, visit) {
+    for (const param of node.params || []) {
+      visit(param, st);
+    }
+  },
+  TSTypeParameterDeclaration(node, st, visit) {
+    for (const param of node.params || []) {
+      if (param.constraint) {
+        visit(param.constraint, st);
+      }
+      if (param.default) {
+        visit(param.default, st);
+      }
+    }
+  },
+  TSTypeReference(node, st, visit) {
+    if (node.typeName) {
+      visit(node.typeName, st);
+    }
+    if (node.typeParameters) {
+      visit(node.typeParameters, st);
+    }
+  },
   TSInterfaceDeclaration() {},
   TSTypeAliasDeclaration() {},
   TSEnumDeclaration() {},
@@ -17,14 +72,65 @@ const tsNodeHandlers = {
   TSMethodSignature() {},
   TSIndexSignature() {},
   TSTypeLiteral() {},
-  TSUnionType() {},
-  TSIntersectionType() {},
-  TSArrayType() {},
-  TSTupleType() {},
-  TSOptionalType() {},
-  TSRestType() {},
-  TSFunctionType() {},
-  TSConstructorType() {},
+  TSUnionType(node, st, visit) {
+    for (const typeNode of node.types || []) {
+      visit(typeNode, st);
+    }
+  },
+  TSIntersectionType(node, st, visit) {
+    for (const typeNode of node.types || []) {
+      visit(typeNode, st);
+    }
+  },
+  TSArrayType(node, st, visit) {
+    if (node.elementType) {
+      visit(node.elementType, st);
+    }
+  },
+  TSTupleType(node, st, visit) {
+    for (const elementType of node.elementTypes || []) {
+      visit(elementType, st);
+    }
+  },
+  TSOptionalType(node, st, visit) {
+    if (node.typeAnnotation) {
+      visit(node.typeAnnotation, st);
+    }
+  },
+  TSRestType(node, st, visit) {
+    if (node.typeAnnotation) {
+      visit(node.typeAnnotation, st);
+    }
+  },
+  TSFunctionType(node, st, visit) {
+    for (const param of node.params || []) {
+      visit(param, st);
+    }
+    if (node.returnType) {
+      visit(node.returnType, st);
+    }
+  },
+  TSConstructorType(node, st, visit) {
+    for (const param of node.params || []) {
+      visit(param, st);
+    }
+    if (node.returnType) {
+      visit(node.returnType, st);
+    }
+  },
+  TSExpressionWithTypeArguments(node, st, visit) {
+    if (node.expression) {
+      visit(node.expression, st);
+    }
+    if (node.typeParameters) {
+      visit(node.typeParameters, st);
+    }
+  },
+  TSParameterProperty(node, st, visit) {
+    if (node.parameter) {
+      visit(node.parameter, st);
+    }
+  },
   TSNonNullExpression(node, st, visit) { visit(node.expression, st); },
   TSInstantiationExpression(node, st, visit) { visit(node.expression, st); }
 };

--- a/scaffold/scripts/parsers/javascript/chunks.mjs
+++ b/scaffold/scripts/parsers/javascript/chunks.mjs
@@ -376,6 +376,10 @@ function findLeadingCommentStart(code, node) {
 }
 
 function formatParameterName(param) {
+  if (param.type === "TSParameterProperty") {
+    return formatParameterName(param.parameter);
+  }
+
   if (param.type === "Identifier") {
     return param.name;
   }

--- a/scaffold/scripts/parsers/javascript/patterns.mjs
+++ b/scaffold/scripts/parsers/javascript/patterns.mjs
@@ -4,6 +4,9 @@ export function collectPatternIdentifiers(pattern, visit) {
   }
 
   switch (pattern.type) {
+    case "TSParameterProperty":
+      collectPatternIdentifiers(pattern.parameter, visit);
+      break;
     case "Identifier":
       visit(pattern.name);
       break;
@@ -44,6 +47,9 @@ export function walkPatternExpressions(pattern, visit) {
   }
 
   switch (pattern.type) {
+    case "TSParameterProperty":
+      walkPatternExpressions(pattern.parameter, visit);
+      break;
     case "AssignmentPattern":
       walkPatternExpressions(pattern.left, visit);
       if (pattern.right) {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -37,6 +37,7 @@ step "Installing MCP dependencies"
 info "note: upstream RyuGraph dependencies may print deprecation warnings during install"
 NPM_CONFIG_CACHE="$MCP_DIR/.npm-cache" npm --prefix "$MCP_DIR" install --no-fund --no-update-notifier --loglevel=warn
 NPM_CONFIG_CACHE="$REPO_ROOT/scripts/parsers/.npm-cache" npm --prefix "$REPO_ROOT/scripts/parsers" install --no-fund --no-update-notifier --loglevel=warn
+NPM_CONFIG_CACHE="$REPO_ROOT/scaffold/scripts/parsers/.npm-cache" npm --prefix "$REPO_ROOT/scaffold/scripts/parsers" install --no-fund --no-update-notifier --loglevel=warn
 
 source "$REPO_ROOT/scripts/lib/enterprise-check.sh"
 


### PR DESCRIPTION
## Summary

Scaffold had silently diverged from \`scripts/\` — the repo's dev-time tooling copy. In several places \`scripts/\` had newer/richer behavior than \`scaffold/\` (the npm-published copy). This meant **npm users received a feature-poor variant** while the repo itself ran on the better code.

This PR reconciles scaffold up to scripts so the next PR can safely delete the duplicated \`scripts/parsers/\` and \`scripts/ingest.mjs\` without losing features.

## What moved scripts/ → scaffold/

- **\`scaffold/scripts/ingest.mjs\`** — lazy dynamic-import pattern, per-parser \`isAvailable()\` guards, \`.vcxproj\` in project-definition extensions. Previously eager-imported everything and couldn't degrade when one parser failed to load.
- **\`scaffold/scripts/parsers/javascript/ast.mjs\`** — TypeScript AST walker with full Identifier/Function/Class visitor overrides and proper traversal of \`typeAnnotation\`, \`returnType\`, \`typeParameters\`, \`implements\`, \`TSParameterProperty\`. Scaffold previously stubbed these, missing any call/import that lived inside a type annotation.
- **\`scaffold/scripts/parsers/javascript/chunks.mjs\`** and **\`patterns.mjs\`** — \`TSParameterProperty\` handling.
- **\`scaffold/scripts/parsers/javascript.mjs\`** — eager imports, no more reach-back fallback to \`../../../scripts/parsers/javascript.mjs\`. Scaffold now stands on its own.
- **\`scaffold/scripts/dashboard.mjs\`** — edition detection (Community vs Enterprise badge in dashboard title).

## Dev-setup change

- **\`scripts/bootstrap.sh\`** — \`npm install\` now runs in **both** \`scripts/parsers/\` and \`scaffold/scripts/parsers/\` so scaffold tests have deps locally. User-facing \`scaffold/scripts/bootstrap.sh\` unchanged (one parsers/ dir in user repos).

## Not in this PR

- Deleting \`scripts/parsers/\` and \`scripts/ingest.mjs\` — next PR.
- \`scripts/memory-compile.sh\` / \`memory-lint.sh\` — diff is a single self-referential \"Keep in sync with X\" comment, moot once duplicates are deleted.
- \`bootstrap.sh\` divergence between scripts/ (cortex dev) and scaffold/ (user-facing) is intentional and expected.

## Test plan

- [x] \`npm test\` — 76/76 pass
- [x] \`node --test tests/csharp-parser.test.mjs\` — 20/20 pass
- [x] \`node --test tests/javascript-parser.test.mjs\` — 8/8 pass after installing deps in scaffold/
- [ ] Fresh-clone bootstrap verification on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)