### PR TITLE
fix(cli): cortex CLI silent when invoked via symlink

### DIFF
--- a/bin/cortex.mjs
+++ b/bin/cortex.mjs
@@ -734,8 +734,17 @@ async function run() {
   await runContextCommand(process.cwd(), [command, ...rest]);
 }
 
+function resolveArgv1() {
+  if (!process.argv[1]) return null;
+  try {
+    return fs.realpathSync(process.argv[1]);
+  } catch {
+    return process.argv[1];
+  }
+}
+
 const invokedAsScript =
-  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+  process.argv[1] && import.meta.url === pathToFileURL(resolveArgv1()).href;
 
 if (invokedAsScript) {
   run().catch((error) => {


### PR DESCRIPTION
## Bug

Installing v1.4.0 globally and running \`cortex --version\` produces no output and exits 0. Direct \`node /path/to/bin/cortex.mjs --version\` works fine.

### Root cause

\`bin/cortex.mjs\` gates its main \`run()\` call on:

\`\`\`js
const invokedAsScript =
  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
\`\`\`

When invoked via npm's global symlink (\`~/.npm-global/bin/cortex → .../lib/node_modules/.../bin/cortex.mjs\`):
- \`process.argv[1]\` = the symlink path
- \`import.meta.url\` = the resolved real path

They don't match → \`invokedAsScript\` is false → \`run()\` never fires → silent exit.

## Fix

Realpath \`process.argv[1]\` before URL conversion. Falls back to the original path if realpath fails.

## Verification

\`\`\`bash
# Before
$ cortex --version
(silent, exit 0)

# After
$ cortex --version
1.4.0
\`\`\`

Tested via a local symlink against the patched file — prints version correctly.

## Test plan

- [x] \`npm test\` 71/71 green
- [x] Symlink invocation prints version after fix
- [ ] Reinstall global on local machine after merge+release — verify \`cortex --version\` and \`cortex doctor\` work

## Release

Target: v1.4.1 (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)