### PR TITLE
feat(tree-sitter): report syntax errors with line/column

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "docs/MCP_MARKETPLACE.md"
   ],
   "scripts": {
-    "test": "node tests/context-regressions.test.mjs && node --test tests/ingest-units.test.mjs tests/javascript-parser.test.mjs tests/sql-parser.test.mjs tests/config-parser.test.mjs tests/resources-parser.test.mjs tests/vbnet-parser.test.mjs tests/cpp-parser.test.mjs tests/multi-level.test.mjs tests/no-legacy-paths.test.mjs",
+    "test": "node tests/context-regressions.test.mjs && node --test tests/ingest-units.test.mjs tests/javascript-parser.test.mjs tests/sql-parser.test.mjs tests/config-parser.test.mjs tests/resources-parser.test.mjs tests/vbnet-parser.test.mjs tests/cpp-parser.test.mjs tests/multi-level.test.mjs tests/no-legacy-paths.test.mjs tests/tree-sitter-error-reporting.test.mjs",
     "release:sync-version": "node scripts/sync-release-version.mjs",
     "release:check-version-sync": "node scripts/sync-release-version.mjs --check",
     "prepublishOnly": "echo 'Ready to publish to npm'"

--- a/scaffold/scripts/parsers/bash-treesitter.mjs
+++ b/scaffold/scripts/parsers/bash-treesitter.mjs
@@ -35,6 +35,7 @@ import {
   initTreeSitter,
   lineRangeOf,
   loadGrammar,
+  collectErrors,
   parseSource,
   runQuery
 } from "./tree-sitter/base.mjs";
@@ -214,7 +215,7 @@ export async function parseCode(code, filePath, language = "bash") {
     return true;
   });
 
-  return { chunks: deduped, errors: [] };
+  return { chunks: deduped, errors: collectErrors(tree) };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scaffold/scripts/parsers/cpp-treesitter.mjs
+++ b/scaffold/scripts/parsers/cpp-treesitter.mjs
@@ -29,6 +29,7 @@ import {
   initTreeSitter,
   lineRangeOf,
   loadGrammar,
+  collectErrors,
   parseSource,
   runQuery
 } from "./tree-sitter/base.mjs";
@@ -309,7 +310,7 @@ export async function parseCode(code, filePath, language = "cpp") {
     return true;
   });
 
-  return { chunks: deduped, errors: [] };
+  return { chunks: deduped, errors: collectErrors(tree) };
 }
 
 export async function isAvailable() {

--- a/scaffold/scripts/parsers/go-treesitter.mjs
+++ b/scaffold/scripts/parsers/go-treesitter.mjs
@@ -26,6 +26,7 @@ import {
   initTreeSitter,
   lineRangeOf,
   loadGrammar,
+  collectErrors,
   parseSource,
   runQuery
 } from "./tree-sitter/base.mjs";
@@ -268,7 +269,7 @@ export async function parseCode(code, filePath, language = "go") {
     return true;
   });
 
-  return { chunks: deduped, errors: [] };
+  return { chunks: deduped, errors: collectErrors(tree) };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scaffold/scripts/parsers/java-treesitter.mjs
+++ b/scaffold/scripts/parsers/java-treesitter.mjs
@@ -28,6 +28,7 @@ import {
   initTreeSitter,
   lineRangeOf,
   loadGrammar,
+  collectErrors,
   parseSource,
   runQuery
 } from "./tree-sitter/base.mjs";
@@ -235,7 +236,7 @@ export async function parseCode(code, filePath, language = "java") {
     return true;
   });
 
-  return { chunks: deduped, errors: [] };
+  return { chunks: deduped, errors: collectErrors(tree) };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scaffold/scripts/parsers/python-treesitter.mjs
+++ b/scaffold/scripts/parsers/python-treesitter.mjs
@@ -26,6 +26,7 @@ import {
   initTreeSitter,
   lineRangeOf,
   loadGrammar,
+  collectErrors,
   parseSource,
   runQuery
 } from "./tree-sitter/base.mjs";
@@ -256,7 +257,7 @@ export async function parseCode(code, filePath, language = "python") {
     return true;
   });
 
-  return { chunks: deduped, errors: [] };
+  return { chunks: deduped, errors: collectErrors(tree) };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scaffold/scripts/parsers/ruby-treesitter.mjs
+++ b/scaffold/scripts/parsers/ruby-treesitter.mjs
@@ -33,6 +33,7 @@ import {
   initTreeSitter,
   lineRangeOf,
   loadGrammar,
+  collectErrors,
   parseSource,
   runQuery
 } from "./tree-sitter/base.mjs";
@@ -256,7 +257,7 @@ export async function parseCode(code, filePath, language = "ruby") {
     return true;
   });
 
-  return { chunks: deduped, errors: [] };
+  return { chunks: deduped, errors: collectErrors(tree) };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scaffold/scripts/parsers/rust-treesitter.mjs
+++ b/scaffold/scripts/parsers/rust-treesitter.mjs
@@ -19,6 +19,7 @@ import {
   initTreeSitter,
   lineRangeOf,
   loadGrammar,
+  collectErrors,
   parseSource,
   runQuery
 } from "./tree-sitter/base.mjs";
@@ -276,7 +277,7 @@ export async function parseCode(code, filePath, language = "rust") {
     return true;
   });
 
-  return { chunks: deduped, errors: [] };
+  return { chunks: deduped, errors: collectErrors(tree) };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scaffold/scripts/parsers/tree-sitter/base.mjs
+++ b/scaffold/scripts/parsers/tree-sitter/base.mjs
@@ -143,6 +143,45 @@ export function dedupe(items) {
 }
 
 /**
+ * Walk the tree collecting syntax errors. Tree-sitter flags MISSING
+ * and ERROR nodes during parsing; a clean parse has none. Returns
+ * `{message, line, column}` entries compatible with Cortex's existing
+ * parser error shape. Limits output to `maxErrors` to keep DB rows
+ * small on pathological input.
+ */
+export function collectErrors(tree, { maxErrors = 32 } = {}) {
+  const errors = [];
+  if (!tree?.rootNode?.hasError) return errors;
+
+  const visit = (node) => {
+    if (errors.length >= maxErrors) return;
+    if (node.isError || node.type === "ERROR") {
+      errors.push({
+        message: "Syntax error",
+        line: node.startPosition.row + 1,
+        column: node.startPosition.column + 1
+      });
+      return;
+    }
+    if (node.isMissing) {
+      errors.push({
+        message: `Missing ${node.type || "token"}`,
+        line: node.startPosition.row + 1,
+        column: node.startPosition.column + 1
+      });
+      return;
+    }
+    if (!node.hasError) return;
+    for (let i = 0; i < node.childCount; i++) {
+      visit(node.child(i));
+    }
+  };
+
+  visit(tree.rootNode);
+  return errors;
+}
+
+/**
  * Convenience loader for language modules — initializes tree-sitter and
  * pre-loads a grammar. Returns an object with the grammar handle and
  * shared helpers so language modules don't need to reimport base.mjs.

--- a/tests/tree-sitter-error-reporting.test.mjs
+++ b/tests/tree-sitter-error-reporting.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseCode as parseRust } from "../scaffold/scripts/parsers/rust-treesitter.mjs";
+import { parseCode as parsePython } from "../scaffold/scripts/parsers/python-treesitter.mjs";
+import { parseCode as parseJava } from "../scaffold/scripts/parsers/java-treesitter.mjs";
+import { parseCode as parseGo } from "../scaffold/scripts/parsers/go-treesitter.mjs";
+import { parseCode as parseRuby } from "../scaffold/scripts/parsers/ruby-treesitter.mjs";
+import { parseCode as parseCpp } from "../scaffold/scripts/parsers/cpp-treesitter.mjs";
+import { parseCode as parseBash } from "../scaffold/scripts/parsers/bash-treesitter.mjs";
+
+/**
+ * Verifies that every tree-sitter parser reports syntax errors with
+ * line/column info instead of silently returning errors: []. Ensures
+ * parity across all supported tree-sitter languages per the project
+ * parser-parity rule.
+ */
+
+const CASES = [
+  {
+    name: "rust",
+    parse: parseRust,
+    file: "broken.rs",
+    valid: "fn add(a: i32, b: i32) -> i32 { a + b }\n",
+    malformed: "fn add(a: i32, b: i32 -> i32 {\n    a + b\n"
+  },
+  {
+    name: "python",
+    parse: parsePython,
+    file: "broken.py",
+    valid: "def add(a, b):\n    return a + b\n",
+    malformed: "def add(a, b:\n    return a +\n"
+  },
+  {
+    name: "java",
+    parse: parseJava,
+    file: "Broken.java",
+    valid: "class A { int add(int a, int b) { return a + b; } }\n",
+    malformed: "class A { int add(int a, int b { return a + b; } }\n"
+  },
+  {
+    name: "go",
+    parse: parseGo,
+    file: "broken.go",
+    valid: "package main\nfunc add(a, b int) int { return a + b }\n",
+    malformed: "package main\nfunc add(a, b int int { return a + b\n"
+  },
+  {
+    name: "ruby",
+    parse: parseRuby,
+    file: "broken.rb",
+    valid: "def add(a, b)\n  a + b\nend\n",
+    malformed: "def add(a, b\n  a + b\n"
+  },
+  {
+    name: "cpp",
+    parse: parseCpp,
+    file: "broken.cpp",
+    valid: "int add(int a, int b) { return a + b; }\n",
+    malformed: "int add(int a, int b { return a + b; }\n"
+  },
+  {
+    name: "bash",
+    parse: parseBash,
+    file: "broken.sh",
+    valid: "add() {\n  echo $(( $1 + $2 ))\n}\n",
+    malformed: "add() {\n  echo $(( $1 + $2\n"
+  }
+];
+
+for (const { name, parse, file, valid, malformed } of CASES) {
+  test(`tree-sitter ${name} parser: clean source has no errors`, async () => {
+    const result = await parse(valid, file, name);
+    assert.deepEqual(result.errors, [], `expected no errors for valid ${name} input, got ${JSON.stringify(result.errors)}`);
+  });
+
+  test(`tree-sitter ${name} parser: malformed source reports errors with line/column`, async () => {
+    const result = await parse(malformed, file, name);
+    assert.ok(
+      result.errors.length > 0,
+      `expected at least one error for malformed ${name} input, got none`
+    );
+
+    const first = result.errors[0];
+    assert.equal(typeof first.message, "string", `${name}: error.message should be a string`);
+    assert.equal(typeof first.line, "number", `${name}: error.line should be a number`);
+    assert.equal(typeof first.column, "number", `${name}: error.column should be a number`);
+    assert.ok(first.line >= 1, `${name}: error.line should be 1-based`);
+    assert.ok(first.column >= 1, `${name}: error.column should be 1-based`);
+  });
+}


### PR DESCRIPTION
## Summary

All 7 tree-sitter parsers (Rust, Python, Java, Go, Ruby, C/C++, Bash) previously returned \`errors: []\` no matter what. Parse errors from malformed input were silently dropped — partial chunks came out with no signal that anything went wrong.

Now they emit \`{message, line, column}\` entries that match the shape C#, VB.NET, and JavaScript parsers already produce.

## What changed

### \`scaffold/scripts/parsers/tree-sitter/base.mjs\`
New \`collectErrors(tree, { maxErrors = 32 })\`:
- Short-circuits when \`tree.rootNode.hasError\` is false
- Walks the tree; emits \`{message, line, column}\` for ERROR nodes and MISSING nodes
- 1-based line/column
- Caps output at 32 errors per file so pathological input doesn't blow out DB rows

### All 7 parsers
Two-line change per file:
- \`import { collectErrors, parseSource, ... }\`
- \`return { chunks: deduped, errors: collectErrors(tree) }\`

## Tests

**\`tests/tree-sitter-error-reporting.test.mjs\`** — 14 new tests, one clean + one malformed input per parser. Asserts clean input yields \`errors: []\` and malformed input yields at least one error with numeric line ≥ 1 and column ≥ 1. Covers all 7 supported tree-sitter languages.

Wired into \`npm test\`.

Full suite: **90/90 pass** (was 76/76 — +14 new).

## Parity

Per the parser-parity project rule: error reporting is now consistent across Rust, Python, Java, Go, Ruby, C/C++, Bash, C#, VB.NET, and JavaScript. No language silently swallows parse failures.

## Out of scope

- \`exported\` normalization (PR D)
- Chunk body-size cap (PR C)
- Unicode/BOM/CRLF tests (PR E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)