### PR TITLE
feat(parsers): normalize exported semantics across all languages

### DIFF
--- a/docs/parser-exported-semantics.md
+++ b/docs/parser-exported-semantics.md
@@ -1,0 +1,46 @@
+# Parser `exported` semantics
+
+Every chunk emitted by a language parser carries an `exported: boolean` field. Downstream tools (dashboard filters, "find exports" queries, relation builders) assume consistent meaning across languages. This document defines what `exported = true` means per language.
+
+## Rule
+
+**`exported = true`** means *"reachable by name from outside the declaring scope"*. It approximates "is this part of the module's public API?".
+
+When the language has explicit visibility keywords (`public`, `pub`, `export`), those rule. When the language uses a naming convention instead, the convention rules. The goal is a consistent mental model: "can someone else see this?"
+
+## Per-language rules
+
+| Language | Rule | Source |
+|---|---|---|
+| **C#** | `public` or `internal` modifier on member | `IsExported()` in CSharpParser/Program.cs |
+| **VB.NET** | `Public` modifier on member | `IsExported()` in VbNetParser/Program.cs |
+| **Java** | `public` modifier on member | `hasPublicModifier()` in java-treesitter.mjs |
+| **Rust** | `pub` visibility modifier on declaration | `isRustPublic()` in rust-treesitter.mjs |
+| **Go** | Name starts with uppercase letter | `isExported()` in go-treesitter.mjs |
+| **Python** | Name does not start with underscore | `isExported()` in python-treesitter.mjs |
+| **Ruby** | Name does not start with underscore (*) | inline check in ruby-treesitter.mjs |
+| **Bash** | Function name does not start with underscore | inline check in bash-treesitter.mjs |
+| **C / C++** | At namespace scope, or nested inside `public:` block | `isCppVisible()` in cpp-treesitter.mjs |
+| **JavaScript / TypeScript** | Has `export` keyword or is in `module.exports` / `exports.foo` | `chunks.mjs` in javascript/ |
+| **VB6** | `Public` keyword (explicit or implied by `Attribute`) | regex-based in vb6.mjs |
+| **SQL** | Always `true` (all schema objects are externally referenceable) | sql.mjs |
+| **Config / Resources** | Always `true` (config entries are by definition public surface) | config.mjs, resources.mjs |
+
+(*) Ruby's `private`/`protected` keywords could override this but require scope tracking we don't yet implement. The underscore convention is an acceptable approximation that matches Python; track [future work](#future-work) below.
+
+## What this means downstream
+
+- **Dashboard "public API" counts** rely on this field being consistent.
+- **Graph "EXPORTS" edges** are emitted only when `exported === true`.
+- **Search filters** like "public methods only" use the same field.
+- A parser that hard-codes `exported: true` (as C++ did before) produces misleading data.
+
+## Testing
+
+Per the parser-parity project rule, every parser must have at least one test asserting `exported = true` for a visibly-public declaration and `exported = false` for a non-public one. See `tests/<lang>-treesitter-parser.test.mjs` and `tests/<lang>-parser.test.mjs`.
+
+## Future work
+
+- **Ruby**: track `private`/`protected` keywords via scope traversal for full fidelity.
+- **C++**: protected members are currently treated the same as private (both `exported: false`). If callers need to distinguish, extend the field to a tri-state.
+- **TypeScript declaration merging**: ambient declarations (`declare module`) are not currently annotated; they're functionally public but the parser doesn't mark them.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "docs/MCP_MARKETPLACE.md"
   ],
   "scripts": {
-    "test": "node tests/context-regressions.test.mjs && node --test tests/ingest-units.test.mjs tests/javascript-parser.test.mjs tests/sql-parser.test.mjs tests/config-parser.test.mjs tests/resources-parser.test.mjs tests/vbnet-parser.test.mjs tests/cpp-parser.test.mjs tests/multi-level.test.mjs tests/no-legacy-paths.test.mjs tests/tree-sitter-error-reporting.test.mjs tests/tree-sitter-body-cap.test.mjs",
+    "test": "node tests/context-regressions.test.mjs && node --test tests/ingest-units.test.mjs tests/javascript-parser.test.mjs tests/sql-parser.test.mjs tests/config-parser.test.mjs tests/resources-parser.test.mjs tests/vbnet-parser.test.mjs tests/cpp-parser.test.mjs tests/multi-level.test.mjs tests/no-legacy-paths.test.mjs tests/tree-sitter-error-reporting.test.mjs tests/tree-sitter-body-cap.test.mjs tests/tree-sitter-exported.test.mjs",
     "release:sync-version": "node scripts/sync-release-version.mjs",
     "release:check-version-sync": "node scripts/sync-release-version.mjs --check",
     "prepublishOnly": "echo 'Ready to publish to npm'"

--- a/scaffold/scripts/parsers/cpp-treesitter.mjs
+++ b/scaffold/scripts/parsers/cpp-treesitter.mjs
@@ -72,6 +72,52 @@ function normalizeWhitespace(value) {
   return String(value).replace(/\s+/g, " ").trim();
 }
 
+/**
+ * Determine whether a declaration is visible from outside its
+ * enclosing class/struct. Walks up the AST and, when the nearest
+ * class_specifier/struct_specifier ancestor is found, inspects the
+ * preceding access_specifier sibling inside the class body. Defaults:
+ * `class` members are private until an `access_specifier` says
+ * otherwise; `struct`/`union` members are public.
+ *
+ * Returns true when the declaration is at namespace scope or under
+ * a `public:` access specifier.
+ */
+function isCppVisible(node) {
+  let current = node;
+  while (current?.parent) {
+    const parent = current.parent;
+    const parentType = parent.type;
+
+    if (parentType === "field_declaration_list") {
+      // web-tree-sitter returns fresh wrapper objects per call, so compare
+      // by source position rather than identity.
+      let access = null;
+      for (let i = 0; i < parent.namedChildCount; i += 1) {
+        const sib = parent.namedChild(i);
+        if (sib.startIndex === current.startIndex && sib.endIndex === current.endIndex) break;
+        if (sib.type === "access_specifier") access = sib.text.trim();
+      }
+      const enclosing = parent.parent?.type;
+      if (access == null) {
+        // No access_specifier yet — use the enclosing type's default.
+        return enclosing === "struct_specifier" || enclosing === "union_specifier";
+      }
+      return access === "public";
+    }
+
+    if (parentType === "class_specifier" || parentType === "struct_specifier" || parentType === "union_specifier") {
+      // Direct member of a named type body not wrapped in a field list (rare).
+      // Treat as if under the default access.
+      return parentType !== "class_specifier";
+    }
+
+    current = parent;
+  }
+  // No enclosing class/struct body — namespace or file scope: always visible.
+  return true;
+}
+
 function signatureOfDecl(node) {
   const braceIndex = node.text.indexOf("{");
   const semiIndex = node.text.indexOf(";");
@@ -234,7 +280,7 @@ function buildFunctionChunk(node, imports, language) {
     startLine,
     endLine,
     language,
-    exported: true,
+    exported: isCppVisible(node),
     calls: collectCallsInNode(node),
     imports
   };
@@ -255,7 +301,7 @@ function buildTypeChunk(node, kind, language) {
     startLine,
     endLine,
     language,
-    exported: true,
+    exported: isCppVisible(node),
     calls: [],
     imports: []
   };
@@ -275,7 +321,7 @@ function buildNamespaceChunk(node, language) {
     startLine,
     endLine,
     language,
-    exported: true,
+    exported: isCppVisible(node),
     calls: [],
     imports: []
   };

--- a/scaffold/scripts/parsers/rust-treesitter.mjs
+++ b/scaffold/scripts/parsers/rust-treesitter.mjs
@@ -161,6 +161,13 @@ function groupDeclarations(rootNode) {
   return entries;
 }
 
+function isRustPublic(node) {
+  for (let i = 0; i < node.namedChildCount; i += 1) {
+    if (node.namedChild(i).type === "visibility_modifier") return true;
+  }
+  return false;
+}
+
 function chunkFrom(kind, node, name, signatureOverride, calls, imports, language) {
   const { startLine, endLine } = lineRangeOf(node);
   return {
@@ -171,6 +178,7 @@ function chunkFrom(kind, node, name, signatureOverride, calls, imports, language
     startLine,
     endLine,
     language,
+    exported: isRustPublic(node),
     calls,
     imports
   };
@@ -259,10 +267,11 @@ export async function parseCode(code, filePath, language = "rust") {
           name: qualifiedName,
           kind: "method",
           signature: buildSignature(child.text),
-          body: child.text,
+          body: bodyOf(child),
           startLine,
           endLine,
           language,
+          exported: isRustPublic(child),
           calls: extractFunctionCalls(child),
           imports
         });

--- a/tests/tree-sitter-exported.test.mjs
+++ b/tests/tree-sitter-exported.test.mjs
@@ -1,0 +1,146 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseCode as parseRust } from "../scaffold/scripts/parsers/rust-treesitter.mjs";
+import { parseCode as parsePython } from "../scaffold/scripts/parsers/python-treesitter.mjs";
+import { parseCode as parseJava } from "../scaffold/scripts/parsers/java-treesitter.mjs";
+import { parseCode as parseGo } from "../scaffold/scripts/parsers/go-treesitter.mjs";
+import { parseCode as parseRuby } from "../scaffold/scripts/parsers/ruby-treesitter.mjs";
+import { parseCode as parseCpp } from "../scaffold/scripts/parsers/cpp-treesitter.mjs";
+import { parseCode as parseBash } from "../scaffold/scripts/parsers/bash-treesitter.mjs";
+
+/**
+ * Verifies every tree-sitter parser emits a consistent `exported`
+ * boolean per the project parser-parity rule. Each language gets one
+ * visible declaration (should report exported=true) and one hidden
+ * declaration (should report exported=false). See
+ * docs/parser-exported-semantics.md for the per-language rules.
+ */
+
+async function chunksByName(parser, source, file, language) {
+  const result = await parser(source, file, language);
+  return new Map(result.chunks.map((c) => [c.name, c]));
+}
+
+test("rust: pub items are exported, non-pub are not", async () => {
+  const source = [
+    "pub fn public_fn() {}",
+    "fn private_fn() {}",
+    "pub struct PublicStruct;",
+    "struct PrivateStruct;"
+  ].join("\n");
+
+  const m = await chunksByName(parseRust, source, "lib.rs", "rust");
+  assert.equal(m.get("public_fn")?.exported, true);
+  assert.equal(m.get("private_fn")?.exported, false);
+  assert.equal(m.get("PublicStruct")?.exported, true);
+  assert.equal(m.get("PrivateStruct")?.exported, false);
+});
+
+test("python: names without leading underscore are exported", async () => {
+  const source = [
+    "def api_func():",
+    "    pass",
+    "",
+    "def _internal_func():",
+    "    pass",
+    "",
+    "class PublicClass:",
+    "    pass",
+    "",
+    "class _PrivateClass:",
+    "    pass"
+  ].join("\n");
+
+  const m = await chunksByName(parsePython, source, "mod.py", "python");
+  assert.equal(m.get("api_func")?.exported, true);
+  assert.equal(m.get("_internal_func")?.exported, false);
+  assert.equal(m.get("PublicClass")?.exported, true);
+  assert.equal(m.get("_PrivateClass")?.exported, false);
+});
+
+test("java: public modifier determines exported", async () => {
+  const source = [
+    "public class Svc {",
+    "  public int visible() { return 1; }",
+    "  private int hidden() { return 2; }",
+    "  int packagePrivate() { return 3; }",
+    "}"
+  ].join("\n");
+
+  const m = await chunksByName(parseJava, source, "Svc.java", "java");
+  assert.equal(m.get("Svc")?.exported, true);
+  assert.equal(m.get("Svc.visible")?.exported, true);
+  assert.equal(m.get("Svc.hidden")?.exported, false);
+  assert.equal(m.get("Svc.packagePrivate")?.exported, false);
+});
+
+test("go: uppercase-initial names are exported", async () => {
+  const source = [
+    "package main",
+    "",
+    "func Public() {}",
+    "func private() {}",
+    "",
+    "type PublicType struct{}",
+    "type privateType struct{}"
+  ].join("\n");
+
+  const m = await chunksByName(parseGo, source, "mod.go", "go");
+  assert.equal(m.get("Public")?.exported, true);
+  assert.equal(m.get("private")?.exported, false);
+  assert.equal(m.get("PublicType")?.exported, true);
+  assert.equal(m.get("privateType")?.exported, false);
+});
+
+test("ruby: names without leading underscore are exported", async () => {
+  const source = [
+    "def public_method",
+    "end",
+    "",
+    "def _internal_method",
+    "end"
+  ].join("\n");
+
+  const m = await chunksByName(parseRuby, source, "mod.rb", "ruby");
+  assert.equal(m.get("public_method")?.exported, true);
+  assert.equal(m.get("_internal_method")?.exported, false);
+});
+
+test("cpp: access_specifier determines class-member visibility", async () => {
+  const source = [
+    "int free_func() { return 0; }",
+    "",
+    "class Widget {",
+    "public:",
+    "  void visible_method() {}",
+    "private:",
+    "  void hidden_method() {}",
+    "};",
+    "",
+    "struct Point {",
+    "  int default_public_field;",
+    "};"
+  ].join("\n");
+
+  const m = await chunksByName(parseCpp, source, "widget.cpp", "cpp");
+  assert.equal(m.get("free_func")?.exported, true, "free functions at namespace scope are exported");
+  assert.equal(m.get("Widget")?.exported, true, "types at namespace scope are exported");
+  assert.equal(m.get("Widget::visible_method")?.exported, true, "public class member");
+  assert.equal(m.get("Widget::hidden_method")?.exported, false, "private class member");
+});
+
+test("bash: function names without leading underscore are exported", async () => {
+  const source = [
+    "public_helper() {",
+    "  echo 'ok'",
+    "}",
+    "",
+    "_internal_helper() {",
+    "  echo 'hidden'",
+    "}"
+  ].join("\n");
+
+  const m = await chunksByName(parseBash, source, "lib.sh", "bash");
+  assert.equal(m.get("public_helper")?.exported, true);
+  assert.equal(m.get("_internal_helper")?.exported, false);
+});


### PR DESCRIPTION
## Summary

Two concrete bugs plus a documentation gap:

- **C++ hard-coded \`exported: true\`** for every chunk. A \`private\` method was reported the same as \`public\`.
- **Rust emitted no \`exported\` field at all.** Downstream saw \`undefined\`.
- No shared spec for what \`exported\` should mean across languages.

## Fix

### 1. \`docs/parser-exported-semantics.md\` — the rule

\"\`exported = true\` iff reachable by name from outside the declaring scope.\" Explicit keywords win when available (public/pub/export), conventions win otherwise (leading underscore, uppercase initial). Table of rules per supported language.

### 2. Rust (\`rust-treesitter.mjs\`)

New \`isRustPublic(node)\` that checks for a \`visibility_modifier\` named child. Applied to \`chunkFrom()\` and the inline impl-method chunk. The impl-method chunk also had \`body: child.text\` instead of \`bodyOf(child)\` — fixed in passing.

### 3. C++ (\`cpp-treesitter.mjs\`)

New \`isCppVisible(node)\`:
- Walks up to the nearest enclosing \`field_declaration_list\`.
- Scans preceding siblings for an \`access_specifier\` (\`public\` / \`private\` / \`protected\`).
- Defaults when absent: \`class\` → private, \`struct\`/\`union\` → public.
- No enclosing class/struct → namespace scope → always exported.

Note: comparison uses \`startIndex\`/\`endIndex\` because \`web-tree-sitter\` returns fresh wrapper objects per \`namedChild()\` call. Identity won't match.

### 4. Ruby / Python / Go / Java / Bash

Already correct. Documented the rules.

## Tests

\`tests/tree-sitter-exported.test.mjs\` — 7 new tests, one per tree-sitter language. Each asserts a visible declaration (\`exported=true\`) and a hidden one (\`exported=false\`).

Full suite: **104/104** (was 97/97).

## Out of scope

- Ruby \`private\`/\`protected\` keyword tracking (requires scope traversal). Underscore convention is acceptable per the doc. Future work.
- Distinguishing \`protected\` from \`private\` in C++ (currently both → \`exported=false\`). Future work if callers need tri-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)