### PR TITLE
feat(tree-sitter): robustness — size guard, Unicode/BOM/CRLF tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "docs/MCP_MARKETPLACE.md"
   ],
   "scripts": {
-    "test": "node tests/context-regressions.test.mjs && node --test tests/ingest-units.test.mjs tests/javascript-parser.test.mjs tests/sql-parser.test.mjs tests/config-parser.test.mjs tests/resources-parser.test.mjs tests/vbnet-parser.test.mjs tests/cpp-parser.test.mjs tests/multi-level.test.mjs tests/no-legacy-paths.test.mjs tests/tree-sitter-error-reporting.test.mjs tests/tree-sitter-body-cap.test.mjs tests/tree-sitter-exported.test.mjs",
+    "test": "node tests/context-regressions.test.mjs && node --test tests/ingest-units.test.mjs tests/javascript-parser.test.mjs tests/sql-parser.test.mjs tests/config-parser.test.mjs tests/resources-parser.test.mjs tests/vbnet-parser.test.mjs tests/cpp-parser.test.mjs tests/multi-level.test.mjs tests/no-legacy-paths.test.mjs tests/tree-sitter-error-reporting.test.mjs tests/tree-sitter-body-cap.test.mjs tests/tree-sitter-exported.test.mjs tests/tree-sitter-robustness.test.mjs",
     "release:sync-version": "node scripts/sync-release-version.mjs",
     "release:check-version-sync": "node scripts/sync-release-version.mjs --check",
     "prepublishOnly": "echo 'Ready to publish to npm'"

--- a/scaffold/scripts/parsers/bash-treesitter.mjs
+++ b/scaffold/scripts/parsers/bash-treesitter.mjs
@@ -195,7 +195,8 @@ function buildFunctionChunk(node, imports, language) {
 
 export async function parseCode(code, filePath, language = "bash") {
   await ensureLanguage();
-  const { tree } = parseSource(BASH_LANG, code);
+  const { tree, reason } = parseSource(BASH_LANG, code);
+  if (!tree) return { chunks: [], errors: [{ message: reason }] };
   const root = tree.rootNode;
   const imports = collectImports(root);
 

--- a/scaffold/scripts/parsers/cpp-treesitter.mjs
+++ b/scaffold/scripts/parsers/cpp-treesitter.mjs
@@ -329,7 +329,8 @@ function buildNamespaceChunk(node, language) {
 
 export async function parseCode(code, filePath, language = "cpp") {
   await ensureLanguage();
-  const { tree } = parseSource(CPP_LANG, code);
+  const { tree, reason } = parseSource(CPP_LANG, code);
+  if (!tree) return { chunks: [], errors: [{ message: reason }] };
   const root = tree.rootNode;
   const imports = collectImports(root);
 

--- a/scaffold/scripts/parsers/go-treesitter.mjs
+++ b/scaffold/scripts/parsers/go-treesitter.mjs
@@ -225,7 +225,8 @@ function buildTypeChunk(node, nameNode, language) {
 
 export async function parseCode(code, filePath, language = "go") {
   await ensureLanguage();
-  const { tree } = parseSource(GO_LANG, code);
+  const { tree, reason } = parseSource(GO_LANG, code);
+  if (!tree) return { chunks: [], errors: [{ message: reason }] };
   const root = tree.rootNode;
   const imports = collectImports(root);
 

--- a/scaffold/scripts/parsers/java-treesitter.mjs
+++ b/scaffold/scripts/parsers/java-treesitter.mjs
@@ -209,7 +209,8 @@ function buildConstructorChunk(node, imports, language) {
 
 export async function parseCode(code, filePath, language = "java") {
   await ensureLanguage();
-  const { tree } = parseSource(JAVA_LANG, code);
+  const { tree, reason } = parseSource(JAVA_LANG, code);
+  if (!tree) return { chunks: [], errors: [{ message: reason }] };
   const root = tree.rootNode;
   const imports = collectImports(root);
 

--- a/scaffold/scripts/parsers/python-treesitter.mjs
+++ b/scaffold/scripts/parsers/python-treesitter.mjs
@@ -234,7 +234,8 @@ function buildClassChunk(node, language) {
 
 export async function parseCode(code, filePath, language = "python") {
   await ensureLanguage();
-  const { tree } = parseSource(PY_LANG, code);
+  const { tree, reason } = parseSource(PY_LANG, code);
+  if (!tree) return { chunks: [], errors: [{ message: reason }] };
   const root = tree.rootNode;
   const imports = collectImports(root);
 

--- a/scaffold/scripts/parsers/ruby-treesitter.mjs
+++ b/scaffold/scripts/parsers/ruby-treesitter.mjs
@@ -232,7 +232,8 @@ function buildMethodChunk(node, imports, language, isSingleton) {
 
 export async function parseCode(code, filePath, language = "ruby") {
   await ensureLanguage();
-  const { tree } = parseSource(RUBY_LANG, code);
+  const { tree, reason } = parseSource(RUBY_LANG, code);
+  if (!tree) return { chunks: [], errors: [{ message: reason }] };
   const root = tree.rootNode;
   const imports = collectImports(root);
 

--- a/scaffold/scripts/parsers/rust-treesitter.mjs
+++ b/scaffold/scripts/parsers/rust-treesitter.mjs
@@ -201,7 +201,8 @@ function extractFunctionCalls(functionNode) {
 
 export async function parseCode(code, filePath, language = "rust") {
   await ensureLanguage();
-  const { tree } = parseSource(RUST_LANG, code);
+  const { tree, reason } = parseSource(RUST_LANG, code);
+  if (!tree) return { chunks: [], errors: [{ message: reason }] };
   const root = tree.rootNode;
 
   const imports = collectImports(root);

--- a/scaffold/scripts/parsers/tree-sitter/base.mjs
+++ b/scaffold/scripts/parsers/tree-sitter/base.mjs
@@ -77,10 +77,42 @@ export function createParser(language) {
   return parser;
 }
 
+/**
+ * Hard size limit on input passed to tree-sitter. Swift was dropped
+ * because its grammar OOM'd on large files (see aa52c93); even
+ * supported grammars can exhaust WASM memory on adversarial input.
+ * Callers receive { tree: null, reason } when the limit is hit.
+ * Override via CORTEX_TREE_SITTER_MAX_BYTES.
+ */
+const DEFAULT_MAX_SOURCE_BYTES = 4 * 1024 * 1024; // 4 MiB
+
+function getMaxSourceBytes() {
+  const override = process.env.CORTEX_TREE_SITTER_MAX_BYTES;
+  if (!override) return DEFAULT_MAX_SOURCE_BYTES;
+  const n = Number.parseInt(override, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_SOURCE_BYTES;
+}
+
 export function parseSource(language, code) {
+  const max = getMaxSourceBytes();
+  if (typeof code === "string" && code.length > max) {
+    return {
+      tree: null,
+      parser: null,
+      reason: `source exceeds CORTEX_TREE_SITTER_MAX_BYTES (${code.length} > ${max})`
+    };
+  }
   const parser = createParser(language);
-  const tree = parser.parse(code);
-  return { tree, parser };
+  try {
+    const tree = parser.parse(code);
+    return { tree, parser };
+  } catch (error) {
+    return {
+      tree: null,
+      parser,
+      reason: `tree-sitter parse threw: ${error instanceof Error ? error.message : String(error)}`
+    };
+  }
 }
 
 export function runQuery(language, queryString, node) {

--- a/tests/tree-sitter-robustness.test.mjs
+++ b/tests/tree-sitter-robustness.test.mjs
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseCode as parseRust } from "../scaffold/scripts/parsers/rust-treesitter.mjs";
+import { parseCode as parsePython } from "../scaffold/scripts/parsers/python-treesitter.mjs";
+import { parseCode as parseJava } from "../scaffold/scripts/parsers/java-treesitter.mjs";
+import { parseCode as parseGo } from "../scaffold/scripts/parsers/go-treesitter.mjs";
+import { parseCode as parseRuby } from "../scaffold/scripts/parsers/ruby-treesitter.mjs";
+import { parseCode as parseCpp } from "../scaffold/scripts/parsers/cpp-treesitter.mjs";
+import { parseCode as parseBash } from "../scaffold/scripts/parsers/bash-treesitter.mjs";
+
+/**
+ * Robustness tests per the parser-parity project rule. Each tree-sitter
+ * parser must survive:
+ *   - Unicode identifiers (non-ASCII names)
+ *   - BOM at start of file
+ *   - CRLF line endings
+ *   - Oversize input (hit the CORTEX_TREE_SITTER_MAX_BYTES guard)
+ * without throwing, producing corrupt output, or hanging.
+ */
+
+const PARSERS = [
+  {
+    name: "rust",
+    parse: parseRust,
+    file: "mod.rs",
+    unicode: `fn greet_世界() -> &'static str { "hello" }\n`,
+    simple: `fn add(a: i32, b: i32) -> i32 { a + b }\n`,
+    expectName: "add"
+  },
+  {
+    name: "python",
+    parse: parsePython,
+    file: "mod.py",
+    unicode: `def greet_世界():\n    return "hello"\n`,
+    simple: `def add(a, b):\n    return a + b\n`,
+    expectName: "add"
+  },
+  {
+    name: "java",
+    parse: parseJava,
+    file: "Mod.java",
+    unicode: `class Greeter { String greet世界() { return "hi"; } }\n`,
+    simple: `class A { int add(int a, int b) { return a + b; } }\n`,
+    expectName: "A.add"
+  },
+  {
+    name: "go",
+    parse: parseGo,
+    file: "mod.go",
+    unicode: `package main\nfunc Greet世界() string { return "hi" }\n`,
+    simple: `package main\nfunc Add(a, b int) int { return a + b }\n`,
+    expectName: "Add"
+  },
+  {
+    name: "ruby",
+    parse: parseRuby,
+    file: "mod.rb",
+    unicode: `def greet_世界\n  "hi"\nend\n`,
+    simple: `def add(a, b)\n  a + b\nend\n`,
+    expectName: "add"
+  },
+  {
+    name: "cpp",
+    parse: parseCpp,
+    file: "mod.cpp",
+    // C++ identifiers can be Unicode since C++11 (N2249).
+    unicode: `int greet世界() { return 1; }\n`,
+    simple: `int add(int a, int b) { return a + b; }\n`,
+    expectName: "add"
+  },
+  {
+    name: "bash",
+    parse: parseBash,
+    file: "mod.sh",
+    unicode: `greet_世界() {\n  echo hi\n}\n`,
+    simple: `add() {\n  echo $(( $1 + $2 ))\n}\n`,
+    expectName: "add"
+  }
+];
+
+for (const { name, parse, file, unicode, simple, expectName } of PARSERS) {
+  test(`${name}: handles Unicode identifiers without throwing`, async () => {
+    const result = await parse(unicode, file, name);
+    assert.ok(Array.isArray(result.chunks), `${name}: expected chunks array`);
+    assert.ok(Array.isArray(result.errors), `${name}: expected errors array`);
+    // Minimum guarantee: parser doesn't throw. Unicode identifier may or
+    // may not produce a chunk depending on grammar; both are acceptable
+    // so long as the parser returned a shape.
+  });
+
+  test(`${name}: handles UTF-8 BOM at start of file`, async () => {
+    const withBom = "\uFEFF" + simple;
+    const result = await parse(withBom, file, name);
+    assert.ok(Array.isArray(result.chunks));
+    const names = new Set(result.chunks.map((c) => c.name));
+    assert.ok(
+      names.has(expectName),
+      `${name}: expected chunk "${expectName}" after BOM, got ${JSON.stringify([...names])}`
+    );
+  });
+
+  test(`${name}: handles CRLF line endings`, async () => {
+    const crlf = simple.replace(/\n/g, "\r\n");
+    const result = await parse(crlf, file, name);
+    const names = new Set(result.chunks.map((c) => c.name));
+    assert.ok(
+      names.has(expectName),
+      `${name}: expected chunk "${expectName}" with CRLF, got ${JSON.stringify([...names])}`
+    );
+  });
+
+  test(`${name}: oversize input returns error without throwing`, async () => {
+    const prev = process.env.CORTEX_TREE_SITTER_MAX_BYTES;
+    process.env.CORTEX_TREE_SITTER_MAX_BYTES = "1024";
+    try {
+      const huge = simple + "// " + "x".repeat(2000) + "\n";
+      const result = await parse(huge, file, name);
+      assert.deepEqual(result.chunks, [], `${name}: expected empty chunks for oversize input`);
+      assert.ok(result.errors.length > 0, `${name}: expected an error for oversize input`);
+      assert.match(
+        result.errors[0].message,
+        /CORTEX_TREE_SITTER_MAX_BYTES|exceeds/,
+        `${name}: error message should reference the size limit`
+      );
+    } finally {
+      if (prev === undefined) delete process.env.CORTEX_TREE_SITTER_MAX_BYTES;
+      else process.env.CORTEX_TREE_SITTER_MAX_BYTES = prev;
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Swift was dropped because \`tree-sitter-swift\` OOM'd on moderately large files (aa52c93). Nothing protected supported grammars from the same fate — no size cap, no try/catch around \`parser.parse()\`. Plus no tests for adversarial-but-legitimate input: Unicode identifiers, UTF-8 BOM, CRLF line endings.

## Changes

### \`scaffold/scripts/parsers/tree-sitter/base.mjs\`

\`parseSource()\` now:
1. Checks input against \`CORTEX_TREE_SITTER_MAX_BYTES\` (default 4 MiB) before calling tree-sitter. On overrun, returns \`{ tree: null, reason: \"source exceeds ...\" }\`.
2. Wraps \`parser.parse(code)\` in try/catch. On throw, returns \`{ tree: null, reason: \"tree-sitter parse threw: ...\" }\`.

Never throws to callers.

### All 7 parsers

Each parseCode() now destructures \`{ tree, reason }\` and short-circuits with \`{ chunks: [], errors: [{ message: reason }] }\` when tree is null.

### \`tests/tree-sitter-robustness.test.mjs\` — 28 new tests

4 scenarios × 7 languages (Rust, Python, Java, Go, Ruby, C/C++, Bash):

- **Unicode identifiers** (e.g. \`greet_世界\`) — parser must not throw.
- **UTF-8 BOM** at start — simple function after BOM must still be extracted.
- **CRLF line endings** — simple function with \`\\r\\n\` must still be extracted.
- **Oversize input** (\`CORTEX_TREE_SITTER_MAX_BYTES=1024\`) — parser returns empty chunks + error message referencing the limit, never throws.

## Result

- Full suite: **132/132** (was 104/104)
- Every supported tree-sitter language has the same adversarial-input degradation: graceful return with a structured error.

## Parity

Final PR in the parity milestone. Combined with #54 (VB.NET perf+fix), #55 (error reporting), #56 (body cap), and #57 (exported): all supported languages now have equal quality, perf, and robustness guarantees. Ready for v1.5.0.

## Out of scope

- Swift resurrection — separate research PR. If alternative grammar or SourceKit-sidecar becomes viable, it'll land with these same guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)