### PR TITLE
fix: address pre-release review findings for v1.5.0

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
       - name: Configure git author
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -26,6 +26,11 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
       - name: Verify tag and metadata versions
         env:
           TAG_NAME: ${{ github.ref_name }}

--- a/docs/parser-exported-semantics.md
+++ b/docs/parser-exported-semantics.md
@@ -12,7 +12,7 @@ When the language has explicit visibility keywords (`public`, `pub`, `export`), 
 
 | Language | Rule | Source |
 |---|---|---|
-| **C#** | `public` or `internal` modifier on member | `IsExported()` in CSharpParser/Program.cs |
+| **C#** | `public` modifier on member | `IsExported()` in CSharpParser/Program.cs |
 | **VB.NET** | `Public` modifier on member | `IsExported()` in VbNetParser/Program.cs |
 | **Java** | `public` modifier on member | `hasPublicModifier()` in java-treesitter.mjs |
 | **Rust** | `pub` visibility modifier on declaration | `isRustPublic()` in rust-treesitter.mjs |

--- a/scaffold/scripts/parsers/tree-sitter/base.mjs
+++ b/scaffold/scripts/parsers/tree-sitter/base.mjs
@@ -179,7 +179,8 @@ export function dedupe(items) {
  * and ERROR nodes during parsing; a clean parse has none. Returns
  * `{message, line, column}` entries compatible with Cortex's existing
  * parser error shape. Limits output to `maxErrors` to keep DB rows
- * small on pathological input.
+ * small on pathological input. Descends into ERROR subtrees so nested
+ * errors are also reported (capped by maxErrors).
  */
 export function collectErrors(tree, { maxErrors = 32 } = {}) {
   const errors = [];
@@ -193,17 +194,17 @@ export function collectErrors(tree, { maxErrors = 32 } = {}) {
         line: node.startPosition.row + 1,
         column: node.startPosition.column + 1
       });
-      return;
-    }
-    if (node.isMissing) {
+      // fall through — ERROR nodes can contain nested errors we still want to report
+    } else if (node.isMissing) {
       errors.push({
         message: `Missing ${node.type || "token"}`,
         line: node.startPosition.row + 1,
         column: node.startPosition.column + 1
       });
       return;
+    } else if (!node.hasError) {
+      return;
     }
-    if (!node.hasError) return;
     for (let i = 0; i < node.childCount; i++) {
       visit(node.child(i));
     }

--- a/tests/tree-sitter-error-reporting.test.mjs
+++ b/tests/tree-sitter-error-reporting.test.mjs
@@ -88,3 +88,30 @@ for (const { name, parse, file, valid, malformed } of CASES) {
     assert.ok(first.column >= 1, `${name}: error.column should be 1-based`);
   });
 }
+
+// Multiple disjoint syntax errors should produce multiple error entries,
+// not collapse to a single top-level ERROR report. Uses Python since its
+// grammar reliably produces distinct errors at distinct locations.
+test("tree-sitter parser reports multiple errors for multiple disjoint problems", async () => {
+  const { parse, file, name } = CASES.find((c) => c.name === "python");
+  const source = [
+    "def broken1(a, b:",     // missing paren
+    "    return a",
+    "",
+    "def broken2(x, y:",     // another missing paren, different location
+    "    return x",
+    ""
+  ].join("\n");
+
+  const result = await parse(source, file, name);
+  assert.ok(
+    result.errors.length >= 2,
+    `${name}: expected ≥ 2 errors for 2 distinct syntax problems, got ${result.errors.length}: ${JSON.stringify(result.errors)}`
+  );
+
+  const uniqueLines = new Set(result.errors.map((e) => e.line));
+  assert.ok(
+    uniqueLines.size >= 2,
+    `${name}: expected errors on at least 2 distinct lines, got lines ${JSON.stringify([...uniqueLines])}`
+  );
+});


### PR DESCRIPTION
## Summary

Fresh-context code review of the v1.5.0 parity milestone (PRs #54–#58) caught three legitimate issues. This PR fixes all three so we can cut v1.5.0 cleanly.

## Fix 1: \`collectErrors\` premature return

**\`scaffold/scripts/parsers/tree-sitter/base.mjs\`**

A tree-sitter ERROR node can contain further ERROR/MISSING children (common in cascading malformed input). The previous implementation \`return\`ed after emitting the outer ERROR, so only one error per subtree was ever reported.

Fix: fall through to recursion. Still capped by \`maxErrors = 32\`.

New test in \`tree-sitter-error-reporting.test.mjs\`: malformed Python with two disjoint syntax problems must produce ≥ 2 errors on distinct lines. Verifies the recursion fires.

## Fix 2: C# exported-semantics doc was wrong

**\`docs/parser-exported-semantics.md\`**

The doc added in #57 claimed C# honors both \`public\` and \`internal\`. \`CSharpParser/Program.cs:420\` actually only checks \`PublicKeyword\` — same as VB.NET. Updated doc to match code.

## Fix 3: CI had no .NET — Roslyn live tests silently skipped

**\`.github/workflows/release-publish.yml\`**, **\`.github/workflows/release-bump.yml\`**

\`tests/{csharp,vbnet}-parser.test.mjs\` use \`const liveTest = dotnetAvailable ? test : test.skip\` at module load. On a runner without dotnet, every live-parse test becomes \`test.skip\` with no distinction from intentional skips.

That's exactly the blind spot that let VB.NET's compile errors go undetected until PR #54 surfaced them.

Added \`actions/setup-dotnet@v4\` with \`dotnet-version: 10.0.x\` to both workflows so live Roslyn tests run in CI before tag-push.

## Verification

- \`npm test\` — 133/133 pass (132 prior + 1 new multi-error test)
- Expected impact on next release bump: CI will actually exercise live C#/VB.NET parse logic

## Out of scope (tracked for follow-up)

Review also flagged — none blocking:
- Truncation marker on \`bodyOf()\` output
- \`stderr\` logging in \`parseSource\` catch
- VB6 still uses \`body: source\` (whole file) — larger refactor
- C++ identity+position comparison belt-and-braces

🤖 Generated with [Claude Code](https://claude.com/claude-code)