### PR TITLE
chore(dotnet): down-target sidecars to net8.0 with roll-forward

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: "8.0.x"
 
       - name: Configure git author
         run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: "8.0.x"
 
       - name: Verify tag and metadata versions
         env:

--- a/scaffold/scripts/parsers/csharp.mjs
+++ b/scaffold/scripts/parsers/csharp.mjs
@@ -20,7 +20,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DEFAULT_DOTNET_COMMAND = "dotnet";
 const DEFAULT_PROJECT_PATH = path.join(__dirname, "dotnet", "CSharpParser", "CSharpParser.csproj");
-const DEFAULT_TARGET_FRAMEWORK = "net10.0";
+const DEFAULT_TARGET_FRAMEWORK = "net8.0";
 
 let runtimeCache = null;
 let publishCache = null;

--- a/scaffold/scripts/parsers/dotnet/CSharpParser/CSharpParser.csproj
+++ b/scaffold/scripts/parsers/dotnet/CSharpParser/CSharpParser.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/scaffold/scripts/parsers/dotnet/VbNetParser/VbNetParser.csproj
+++ b/scaffold/scripts/parsers/dotnet/VbNetParser/VbNetParser.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/scaffold/scripts/parsers/vbnet.mjs
+++ b/scaffold/scripts/parsers/vbnet.mjs
@@ -20,7 +20,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DEFAULT_DOTNET_COMMAND = "dotnet";
 const DEFAULT_PROJECT_PATH = path.join(__dirname, "dotnet", "VbNetParser", "VbNetParser.csproj");
-const DEFAULT_TARGET_FRAMEWORK = "net10.0";
+const DEFAULT_TARGET_FRAMEWORK = "net8.0";
 
 let runtimeCache = null;
 let publishCache = null;


### PR DESCRIPTION
## Summary

Reduce install friction for .NET-light dev environments. Both Roslyn sidecars now target **net8.0** (LTS through Nov 2026) with \`<RollForward>Major</RollForward>\`, so they run on .NET 8, 10, or any future compatible major. Previously both required .NET 10 SDK — a brand-new requirement most Hogia dev boxes wouldn't have yet.

## What changed

- \`CSharpParser.csproj\` and \`VbNetParser.csproj\`: \`<TargetFramework>net10.0</TargetFramework>\` → \`net8.0\` + \`<RollForward>Major</RollForward>\`
- \`csharp.mjs\` / \`vbnet.mjs\`: \`DEFAULT_TARGET_FRAMEWORK = "net8.0"\` (affects publish output path)
- CI workflows (\`release-bump\`, \`release-publish\`): \`dotnet-version: "8.0.x"\`

## What this does NOT change

- **Reference assemblies** stay \`Basic.Reference.Assemblies.Net100\` — customer code is still resolved against .NET 10 BCL. Calls to \`System.IO.File.ReadAllText\` etc. still produce fully-qualified names. Works whether the customer targets \`net48\`, \`net6\`, \`net8\`, or \`net10\`.
- **Roslyn package** stays 4.11.0 (itself net8-compatible).
- **Parser output shape** (chunks, calls, exported) is identical.

## Install matrix

| User has installed | Before (net10 sidecar) | After (net8 + rollforward) |
|---|---|---|
| .NET 8 SDK only | ❌ publish fails | ✅ works |
| .NET 10 SDK only | ✅ works | ✅ works (roll-forward) |
| .NET 8 + .NET 10 | ✅ works | ✅ works |
| .NET Framework 4.x only | ❌ (no \`dotnet\`) | ❌ (no \`dotnet\`) |
| Nothing | ❌ | ❌ — falls back to file-level indexing (existing behavior) |

Customer **code** targeting .NET Framework 4.x parses fine regardless — the sidecar TFM is independent of the code being analyzed.

## Verification

- \`npm test\`: 133/133 pass on a machine with only .NET 10 installed. Proves roll-forward path works.
- Published DLL lands at \`bin/Release/net8.0/publish/\` — \`dotnet <dll>\` boots under .NET 10 via roll-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)