### PR TITLE
Move project mcp/ under .context/mcp/ + ignore .context/ by default

### DIFF
--- a/bin/cortex.mjs
+++ b/bin/cortex.mjs
@@ -22,17 +22,20 @@ const PACKAGE_ROOT = path.resolve(__dirname, "..");
 const SCAFFOLD_ROOT = path.join(PACKAGE_ROOT, "scaffold");
 const PACKAGE_JSON_PATH = path.join(PACKAGE_ROOT, "package.json");
 
+// v2.0.5: project layout moved mcp/ under .context/mcp/, and the
+// gitignore policy flipped to "ignore everything in .context/, whitelist
+// only the three editable config files". Generated artifacts (db,
+// embeddings, cache, hooks, mcp/, govern.local.json) never land in git.
+const MCP_PROJECT_REL = path.join(".context", "mcp");
+
 const GITIGNORE_LINES = [
   "",
   "# Cortex local storage",
-  ".context/db/",
-  ".context/embeddings/",
-  ".context/cache/",
-  ".context/hooks/",
-  ".npm-cache/",
-  "mcp/.npm-cache/",
-  "mcp/dist/",
-  "mcp/node_modules/"
+  ".context/",
+  "!.context/config.yaml",
+  "!.context/rules.yaml",
+  "!.context/ontology.cypher",
+  ".npm-cache/"
 ];
 
 function printBanner(title) {
@@ -199,7 +202,6 @@ const INIT_SKIP_DIRECTORIES = new Set([
   ".cache",
   ".context",
   "scripts",
-  "mcp",
   ".githooks",
   "bin",
   "obj"
@@ -439,11 +441,26 @@ function mergeGitignore(targetDir) {
   fs.writeFileSync(gitignorePath, merged, "utf8");
 }
 
+function migrateLegacyMcpLocation(targetDir) {
+  const legacyMcp = path.join(targetDir, "mcp");
+  const newMcp = path.join(targetDir, MCP_PROJECT_REL);
+  if (!fs.existsSync(legacyMcp)) return;
+  if (fs.existsSync(newMcp)) return;
+  fs.mkdirSync(path.join(targetDir, ".context"), { recursive: true });
+  fs.renameSync(legacyMcp, newMcp);
+  console.log(
+    "[cortex] migrated legacy mcp/ → .context/mcp/ to keep project root clean. " +
+      "Re-run 'cortex connect' if Claude/Codex MCP registrations need to be refreshed.",
+  );
+}
+
 function installScaffold(targetDir, force) {
+  migrateLegacyMcpLocation(targetDir);
+
   const copyMap = [
     [path.join(SCAFFOLD_ROOT, ".context"), path.join(targetDir, ".context")],
     [path.join(SCAFFOLD_ROOT, "scripts"), path.join(targetDir, "scripts")],
-    [path.join(SCAFFOLD_ROOT, "mcp"), path.join(targetDir, "mcp")],
+    [path.join(SCAFFOLD_ROOT, "mcp"), path.join(targetDir, MCP_PROJECT_REL)],
     [path.join(SCAFFOLD_ROOT, ".githooks"), path.join(targetDir, ".githooks")]
   ];
 
@@ -633,7 +650,7 @@ async function connectClaude(targetDir) {
   }
 
   const serverName = "cortex";
-  const projectServerEntry = path.join("mcp", "dist", "server.js");
+  const projectServerEntry = path.join(MCP_PROJECT_REL, "dist", "server.js");
   await runCommandResult("claude", ["mcp", "remove", "-s", "project", serverName], targetDir, "ignore");
   await runCommand(
     "claude",
@@ -646,7 +663,7 @@ async function connectClaude(targetDir) {
 
 async function connectMcpClients(targetDir, options = {}) {
   const { skipBuild = false } = options;
-  const mcpDir = path.join(targetDir, "mcp");
+  const mcpDir = path.join(targetDir, MCP_PROJECT_REL);
   const packageJson = path.join(mcpDir, "package.json");
   const nodeModules = path.join(mcpDir, "node_modules");
   const serverEntry = path.join(mcpDir, "dist", "server.js");
@@ -662,7 +679,7 @@ async function connectMcpClients(targetDir, options = {}) {
       console.log(`[cortex] MCP build failed, continuing with existing dist output: ${toErrorMessage(error)}`);
     }
   } else if (!skipBuild) {
-    console.log("[cortex] mcp/node_modules not found, skipping build (run cortex bootstrap first)");
+    console.log("[cortex] .context/mcp/node_modules not found, skipping build (run cortex bootstrap first)");
   }
 
   if (!fs.existsSync(serverEntry)) {
@@ -716,7 +733,7 @@ async function maybeInstallGitHooks(targetDir) {
 }
 
 function ensureProjectInitialized(targetDir) {
-  const mcpPackageJson = path.join(targetDir, "mcp", "package.json");
+  const mcpPackageJson = path.join(targetDir, MCP_PROJECT_REL, "package.json");
   if (!fs.existsSync(mcpPackageJson)) {
     throw new Error(`Missing ${mcpPackageJson}. Run 'cortex init --bootstrap' first.`);
   }
@@ -731,7 +748,9 @@ function isTruthyEnv(value) {
 }
 
 function canAutoInitialize(targetDir) {
-  const scaffoldPaths = [".context", "scripts", "mcp", ".githooks"].map((entry) => path.join(targetDir, entry));
+  // Legacy mcp/ at root no longer counted — pre-v2.0.5 projects are migrated
+  // by installScaffold rather than blocking auto-init.
+  const scaffoldPaths = [".context", "scripts", ".githooks"].map((entry) => path.join(targetDir, entry));
   return scaffoldPaths.every((entryPath) => !fs.existsSync(entryPath));
 }
 
@@ -744,7 +763,12 @@ function isScaffoldOutOfDate(targetDir) {
   if (!fs.existsSync(doctorScript)) {
     return true;
   }
-  const mcpPackage = path.join(targetDir, "mcp", "package.json");
+  // Treat legacy mcp/ at project root as out-of-date so existing installs
+  // get migrated into .context/mcp/ on the next bootstrap.
+  if (fs.existsSync(path.join(targetDir, "mcp", "package.json"))) {
+    return true;
+  }
+  const mcpPackage = path.join(targetDir, MCP_PROJECT_REL, "package.json");
   if (!fs.existsSync(mcpPackage)) {
     return true;
   }
@@ -780,7 +804,8 @@ async function maybeMigrateScaffold(targetDir, command) {
 
   console.error(
     `[cortex] scaffold in ${targetDir} is out of date ` +
-      `(missing scripts/doctor.sh, mcp/package.json, or doctor subcommand in context.sh).`
+      `(missing scripts/doctor.sh, .context/mcp/package.json, doctor subcommand in context.sh, ` +
+      `or carries a legacy mcp/ directory at the project root).`
   );
 
   let proceed = autoYes;
@@ -808,8 +833,8 @@ async function maybeMigrateScaffold(targetDir, command) {
 }
 
 async function ensureProjectInitializedForMcp(targetDir) {
-  const mcpPackageJson = path.join(targetDir, "mcp", "package.json");
-  const serverEntry = path.join(targetDir, "mcp", "dist", "server.js");
+  const mcpPackageJson = path.join(targetDir, MCP_PROJECT_REL, "package.json");
+  const serverEntry = path.join(targetDir, MCP_PROJECT_REL, "dist", "server.js");
 
   if (fs.existsSync(mcpPackageJson) && fs.existsSync(serverEntry)) {
     return;
@@ -947,7 +972,7 @@ async function run() {
     process.env.CORTEX_PROJECT_ROOT = target;
     await ensureProjectInitializedForMcp(target);
     ensureProjectInitialized(target);
-    const serverEntry = path.join(target, "mcp", "dist", "server.js");
+    const serverEntry = path.join(target, MCP_PROJECT_REL, "dist", "server.js");
     if (!fs.existsSync(serverEntry)) {
       throw new Error(`Missing ${serverEntry}. Run 'cortex bootstrap' in ${target} first.`);
     }
@@ -1038,12 +1063,12 @@ function isPidAlive(pid) {
 }
 
 function resolveProjectMcpDist() {
-  // v2.0.0: daemon/hooks/cli are built into the project's mcp/dist/
-  // (via 'cortex bootstrap'). PACKAGE_ROOT/scaffold/mcp/ is the source
-  // tree the scaffold is copied from. The actual built code lives in
-  // each project's <cwd>/mcp/dist/ after bootstrap.
+  // v2.0.5: project layout was moved from <cwd>/mcp/ to <cwd>/.context/mcp/.
+  // PACKAGE_ROOT/scaffold/mcp/ is still the source tree the scaffold is
+  // copied from; the actual built code lives in each project's
+  // <cwd>/.context/mcp/dist/ after bootstrap.
   const target = process.env.CORTEX_PROJECT_ROOT?.trim() || process.cwd();
-  return path.join(target, "mcp", "dist");
+  return path.join(target, MCP_PROJECT_REL, "dist");
 }
 
 function resolveDaemonEntry() {

--- a/scaffold/scripts/bootstrap.sh
+++ b/scaffold/scripts/bootstrap.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-MCP_DIR="$REPO_ROOT/mcp"
+MCP_DIR="$REPO_ROOT/.context/mcp"
 TOTAL_STEPS=6
 STEP_INDEX=0
 

--- a/scaffold/scripts/doctor.sh
+++ b/scaffold/scripts/doctor.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONTEXT_DIR="$REPO_ROOT/.context"
-MCP_DIR="$REPO_ROOT/mcp"
+MCP_DIR="$CONTEXT_DIR/mcp"
 
 PASS=0
 FAIL=0
@@ -165,15 +165,15 @@ echo ""
 echo "  MCP Server"
 
 if [[ -f "$MCP_DIR/dist/server.js" ]]; then
-  pass "mcp/dist/server.js exists"
+  pass ".context/mcp/dist/server.js exists"
 else
-  fail "mcp/dist/server.js missing — run: cd mcp && npm run build"
+  fail ".context/mcp/dist/server.js missing — run: cd .context/mcp && npm run build"
 fi
 
 if [[ -d "$MCP_DIR/node_modules" ]]; then
-  pass "mcp/node_modules present"
+  pass ".context/mcp/node_modules present"
 else
-  fail "mcp/node_modules missing — run: cd mcp && npm install"
+  fail ".context/mcp/node_modules missing — run: cd .context/mcp && npm install"
 fi
 
 # Quick MCP import check
@@ -181,7 +181,7 @@ if [[ -f "$MCP_DIR/dist/server.js" ]] && [[ -d "$MCP_DIR/node_modules" ]]; then
   MCP_CHECK=$(cd "$REPO_ROOT" && timeout 10 node -e '
     const start = Date.now();
     try {
-      require("./mcp/dist/graph.js");
+      require("./.context/mcp/dist/graph.js");
       console.log("ok " + (Date.now() - start));
     } catch(e) {
       console.log("fail " + e.message);

--- a/scaffold/scripts/embed.sh
+++ b/scaffold/scripts/embed.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-MCP_DIR="$REPO_ROOT/mcp"
+MCP_DIR="$REPO_ROOT/.context/mcp"
 
 if ! command -v npm >/dev/null 2>&1; then
   echo "[embed] npm is required but not found on PATH"
@@ -11,5 +11,5 @@ fi
 
 mkdir -p "$MCP_DIR/.npm-cache"
 
-echo "[embed] generating embeddings via mcp/embed"
+echo "[embed] generating embeddings via .context/mcp/embed"
 NPM_CONFIG_CACHE="$MCP_DIR/.npm-cache" npm --prefix "$MCP_DIR" run embed --silent -- "$@"

--- a/scaffold/scripts/load-ryu.sh
+++ b/scaffold/scripts/load-ryu.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-MCP_DIR="$REPO_ROOT/mcp"
+MCP_DIR="$REPO_ROOT/.context/mcp"
 
 if [[ ! -f "$MCP_DIR/package.json" ]]; then
   echo "[graph-load] missing $MCP_DIR/package.json"
@@ -10,8 +10,8 @@ if [[ ! -f "$MCP_DIR/package.json" ]]; then
 fi
 
 if [[ ! -d "$MCP_DIR/node_modules" ]]; then
-  echo "[graph-load] node_modules missing in mcp/"
-  echo "[graph-load] run: cd mcp && NPM_CONFIG_CACHE=$MCP_DIR/.npm-cache npm install"
+  echo "[graph-load] node_modules missing in .context/mcp/"
+  echo "[graph-load] run: cd .context/mcp && NPM_CONFIG_CACHE=$MCP_DIR/.npm-cache npm install"
   exit 1
 fi
 

--- a/scaffold/scripts/memory-compile.mjs
+++ b/scaffold/scripts/memory-compile.mjs
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseFrontmatter, parseStringList } from "../mcp/dist/frontmatter.js";
+import { parseFrontmatter, parseStringList } from "../.context/mcp/dist/frontmatter.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/scaffold/scripts/memory-lint.mjs
+++ b/scaffold/scripts/memory-lint.mjs
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseFrontmatter, parseStringList } from "../mcp/dist/frontmatter.js";
+import { parseFrontmatter, parseStringList } from "../.context/mcp/dist/frontmatter.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/scaffold/scripts/watch.sh
+++ b/scaffold/scripts/watch.sh
@@ -146,11 +146,9 @@ status_digest() {
   fi
 
   # Fallback for non-git directories.
+  # .context/ excludes the relocated .context/mcp/ tree as well.
   find "$REPO_ROOT" -type f \
     ! -path "$REPO_ROOT/.context/*" \
-    ! -path "$REPO_ROOT/mcp/node_modules/*" \
-    ! -path "$REPO_ROOT/mcp/dist/*" \
-    ! -path "$REPO_ROOT/mcp/.npm-cache/*" \
     ! -path "$REPO_ROOT/scripts/parsers/node_modules/*" \
     ! -path "$REPO_ROOT/scripts/parsers/.npm-cache/*" \
     -print \
@@ -201,16 +199,13 @@ wait_for_change_event() {
     inotifywait)
       inotifywait -q -r \
         -e modify,create,delete,move \
-        --exclude '(^|/)\\.git(/|$)|(^|/)\\.context(/|$)|(^|/)mcp/(node_modules|dist|\\.npm-cache)(/|$)|(^|/)scripts/parsers/(node_modules|\\.npm-cache)(/|$)' \
+        --exclude '(^|/)\\.git(/|$)|(^|/)\\.context(/|$)|(^|/)scripts/parsers/(node_modules|\\.npm-cache)(/|$)' \
         "$REPO_ROOT" >/dev/null 2>&1 || true
       ;;
     fswatch)
       fswatch -1 -r \
         --exclude '(^|/)\\.git(/|$)' \
         --exclude '(^|/)\\.context(/|$)' \
-        --exclude '(^|/)mcp/node_modules(/|$)' \
-        --exclude '(^|/)mcp/dist(/|$)' \
-        --exclude '(^|/)mcp/\\.npm-cache(/|$)' \
         --exclude '(^|/)scripts/parsers/node_modules(/|$)' \
         --exclude '(^|/)scripts/parsers/\\.npm-cache(/|$)' \
         "$REPO_ROOT" >/dev/null 2>&1 || true

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-MCP_DIR="$REPO_ROOT/mcp"
+MCP_DIR="$REPO_ROOT/.context/mcp"
 TOTAL_STEPS=6
 STEP_INDEX=0
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONTEXT_DIR="$REPO_ROOT/.context"
-MCP_DIR="$REPO_ROOT/mcp"
+MCP_DIR="$CONTEXT_DIR/mcp"
 
 PASS=0
 FAIL=0
@@ -165,15 +165,15 @@ echo ""
 echo "  MCP Server"
 
 if [[ -f "$MCP_DIR/dist/server.js" ]]; then
-  pass "mcp/dist/server.js exists"
+  pass ".context/mcp/dist/server.js exists"
 else
-  fail "mcp/dist/server.js missing — run: cd mcp && npm run build"
+  fail ".context/mcp/dist/server.js missing — run: cd .context/mcp && npm run build"
 fi
 
 if [[ -d "$MCP_DIR/node_modules" ]]; then
-  pass "mcp/node_modules present"
+  pass ".context/mcp/node_modules present"
 else
-  fail "mcp/node_modules missing — run: cd mcp && npm install"
+  fail ".context/mcp/node_modules missing — run: cd .context/mcp && npm install"
 fi
 
 # Quick MCP import check
@@ -181,7 +181,7 @@ if [[ -f "$MCP_DIR/dist/server.js" ]] && [[ -d "$MCP_DIR/node_modules" ]]; then
   MCP_CHECK=$(cd "$REPO_ROOT" && timeout 10 node -e '
     const start = Date.now();
     try {
-      require("./mcp/dist/graph.js");
+      require("./.context/mcp/dist/graph.js");
       console.log("ok " + (Date.now() - start));
     } catch(e) {
       console.log("fail " + e.message);

--- a/scripts/embed.sh
+++ b/scripts/embed.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-MCP_DIR="$REPO_ROOT/mcp"
+MCP_DIR="$REPO_ROOT/.context/mcp"
 
 if ! command -v npm >/dev/null 2>&1; then
   echo "[embed] npm is required but not found on PATH"
@@ -11,5 +11,5 @@ fi
 
 mkdir -p "$MCP_DIR/.npm-cache"
 
-echo "[embed] generating embeddings via mcp/embed"
+echo "[embed] generating embeddings via .context/mcp/embed"
 NPM_CONFIG_CACHE="$MCP_DIR/.npm-cache" npm --prefix "$MCP_DIR" run embed --silent -- "$@"

--- a/scripts/load-ryu.sh
+++ b/scripts/load-ryu.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-MCP_DIR="$REPO_ROOT/mcp"
+MCP_DIR="$REPO_ROOT/.context/mcp"
 
 if [[ ! -f "$MCP_DIR/package.json" ]]; then
   echo "[graph-load] missing $MCP_DIR/package.json"
@@ -10,8 +10,8 @@ if [[ ! -f "$MCP_DIR/package.json" ]]; then
 fi
 
 if [[ ! -d "$MCP_DIR/node_modules" ]]; then
-  echo "[graph-load] node_modules missing in mcp/"
-  echo "[graph-load] run: cd mcp && NPM_CONFIG_CACHE=$MCP_DIR/.npm-cache npm install"
+  echo "[graph-load] node_modules missing in .context/mcp/"
+  echo "[graph-load] run: cd .context/mcp && NPM_CONFIG_CACHE=$MCP_DIR/.npm-cache npm install"
   exit 1
 fi
 

--- a/scripts/memory-compile.mjs
+++ b/scripts/memory-compile.mjs
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseFrontmatter, parseStringList } from "../mcp/dist/frontmatter.js";
+import { parseFrontmatter, parseStringList } from "../.context/mcp/dist/frontmatter.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/scripts/memory-lint.mjs
+++ b/scripts/memory-lint.mjs
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseFrontmatter, parseStringList } from "../mcp/dist/frontmatter.js";
+import { parseFrontmatter, parseStringList } from "../.context/mcp/dist/frontmatter.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -146,11 +146,9 @@ status_digest() {
   fi
 
   # Fallback for non-git directories.
+  # .context/ excludes the relocated .context/mcp/ tree as well.
   find "$REPO_ROOT" -type f \
     ! -path "$REPO_ROOT/.context/*" \
-    ! -path "$REPO_ROOT/mcp/node_modules/*" \
-    ! -path "$REPO_ROOT/mcp/dist/*" \
-    ! -path "$REPO_ROOT/mcp/.npm-cache/*" \
     ! -path "$REPO_ROOT/scripts/parsers/node_modules/*" \
     ! -path "$REPO_ROOT/scripts/parsers/.npm-cache/*" \
     -print \
@@ -201,16 +199,13 @@ wait_for_change_event() {
     inotifywait)
       inotifywait -q -r \
         -e modify,create,delete,move \
-        --exclude '(^|/)\\.git(/|$)|(^|/)\\.context(/|$)|(^|/)mcp/(node_modules|dist|\\.npm-cache)(/|$)|(^|/)scripts/parsers/(node_modules|\\.npm-cache)(/|$)' \
+        --exclude '(^|/)\\.git(/|$)|(^|/)\\.context(/|$)|(^|/)scripts/parsers/(node_modules|\\.npm-cache)(/|$)' \
         "$REPO_ROOT" >/dev/null 2>&1 || true
       ;;
     fswatch)
       fswatch -1 -r \
         --exclude '(^|/)\\.git(/|$)' \
         --exclude '(^|/)\\.context(/|$)' \
-        --exclude '(^|/)mcp/node_modules(/|$)' \
-        --exclude '(^|/)mcp/dist(/|$)' \
-        --exclude '(^|/)mcp/\\.npm-cache(/|$)' \
         --exclude '(^|/)scripts/parsers/node_modules(/|$)' \
         --exclude '(^|/)scripts/parsers/\\.npm-cache(/|$)' \
         "$REPO_ROOT" >/dev/null 2>&1 || true


### PR DESCRIPTION
Two related cleanups for the user's two reported bugs.

## Bug 1: Project root cluttered by \`mcp/\`

The scaffold previously dropped a top-level \`mcp/\` directory in every project (containing \`src\`, \`dist\`, \`node_modules\`, \`package.json\`, \`tsconfig.json\`), which clutters the project root and makes it easy to accidentally \`git add\` \`package.json\` + \`tsconfig.json\` into the user's repo. The MCP tree now installs under \`.context/mcp/\` — the same place the scaffold-managed config lives.

- \`bin/cortex.mjs\` derives all project-mcp paths from a single \`MCP_PROJECT_REL = ".context/mcp"\` constant.
- \`installScaffold\` runs \`migrateLegacyMcpLocation()\` first: when a legacy \`mcp/\` exists at the project root and \`.context/mcp/\` doesn't, it renames the directory in place and prints a notice (re-run \`cortex connect\` so Claude/Codex MCP registrations point at the new path).
- Claude / Codex MCP registration uses the new relative path.
- \`isScaffoldOutOfDate\` treats a legacy root \`mcp/\` as out-of-date so existing installs auto-trigger the migration through the existing scaffold-upgrade flow.
- Scaffolded helper scripts (\`doctor.sh\`, \`watch.sh\`, \`embed.sh\`, \`load-ryu.sh\`, \`bootstrap.sh\`, \`memory-{lint,compile}.mjs\`) updated for the new path. Umbrella \`scripts/\` kept in sync.

## Bug 2: \`.context/\` not in \`.gitignore\`

\`GITIGNORE_LINES\` now ignores all of \`.context/\` and whitelists only the three editable config files (\`config.yaml\`, \`rules.yaml\`, \`ontology.cypher\`). Generated artifacts — db, embeddings, cache, hooks, the new \`mcp/\` tree, \`govern.local.json\` — never land in git again.

The previous selective list (\`.context/db/\`, \`.context/embeddings/\`, \`.context/cache/\`, \`.context/hooks/\`, plus dead \`mcp/.npm-cache/\`, \`mcp/dist/\`, \`mcp/node_modules/\` entries) was incomplete and the dead \`mcp/*\` lines just rot now.

## Migration of existing projects

Existing projects with the old layout get auto-migrated on the next \`cortex init --bootstrap\` run (or any path that triggers \`maybeMigrateScaffold\`). The migration is idempotent: it only runs when legacy \`mcp/\` exists and \`.context/mcp/\` doesn't. After migration, run \`cortex connect\` so Claude/Codex re-register the MCP server at the new path.

Project layout before:
\`\`\`
<project>/
├── .context/    ← config + db + embeddings
├── .githooks/
├── mcp/         ← THE BUG: src, dist, node_modules, package.json, tsconfig.json
├── scripts/
└── CLAUDE.md
\`\`\`

After:
\`\`\`
<project>/
├── .context/
│   ├── config.yaml      ← only this + 2 siblings tracked in git
│   ├── ontology.cypher
│   ├── rules.yaml
│   ├── db/              ← gitignored
│   ├── embeddings/      ← gitignored
│   ├── cache/           ← gitignored
│   ├── hooks/           ← gitignored
│   ├── govern.local.json ← gitignored
│   └── mcp/             ← MCP server lives here now, gitignored
├── .githooks/
├── scripts/
└── CLAUDE.md
\`\`\`

## Test plan

- [x] \`scaffold/mcp\` test suite green (126/126)
- [x] Root \`tests/context-regressions.test.mjs\` green (81/81)
- [ ] Smoke: fresh \`cortex init --bootstrap\` in an empty dir → confirm \`.context/mcp/\` exists, no project-root \`mcp/\`, \`.gitignore\` has the new policy
- [ ] Smoke: in a project carrying legacy \`mcp/\`, run \`cortex init --bootstrap\` → confirm migration moves \`mcp/\` → \`.context/mcp/\`, prints the notice, and \`cortex connect\` re-registers the MCP server
- [ ] Smoke: \`cortex doctor\` reports the new paths

## Release

After merge, trigger release-bump workflow with \`patch\` to publish v2.0.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)