### PR TITLE
Workflow engine foundation: schemas, artifact I/O, run lifecycle

### DIFF
--- a/scaffold/mcp/package-lock.json
+++ b/scaffold/mcp/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@huggingface/transformers": "^4.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@types/js-yaml": "^4.0.9",
+        "js-yaml": "^4.1.1",
         "ryugraph": "^25.9.1",
         "zod": "^3.24.1"
       },
@@ -842,12 +844,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -988,6 +995,12 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -1760,7 +1773,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1859,6 +1871,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -2611,7 +2635,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2764,7 +2787,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scaffold/mcp/package.json
+++ b/scaffold/mcp/package.json
@@ -12,8 +12,10 @@
     "test": "npm run build --silent && node --test tests/*.test.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
     "@huggingface/transformers": "^4.1.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@types/js-yaml": "^4.0.9",
+    "js-yaml": "^4.1.1",
     "ryugraph": "^25.9.1",
     "zod": "^3.24.1"
   },

--- a/scaffold/mcp/src/core/workflow/artifact-io.ts
+++ b/scaffold/mcp/src/core/workflow/artifact-io.ts
@@ -1,0 +1,156 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import * as yaml from "js-yaml";
+import {
+  runStateSchema,
+  stageArtifactFrontmatterSchema,
+  type RunState,
+  type StageArtifactFrontmatter,
+} from "./schemas.js";
+
+/**
+ * Filesystem layout for one workflow run:
+ *
+ *   <cwd>/.agents/<task-id>/
+ *     plan.md
+ *     review.md
+ *     ...
+ *     state.json
+ *
+ * All paths in this module are relative to the project's <cwd>. The caller
+ * is responsible for choosing cwd; we never assume process.cwd() here so
+ * tests can target a tmp directory.
+ */
+
+export const AGENTS_DIR = ".agents";
+export const STATE_FILENAME = "state.json";
+
+export function runDir(cwd: string, taskId: string): string {
+  return join(cwd, AGENTS_DIR, taskId);
+}
+
+export function stateFilePath(cwd: string, taskId: string): string {
+  return join(runDir(cwd, taskId), STATE_FILENAME);
+}
+
+export function artifactPath(
+  cwd: string,
+  taskId: string,
+  artifactName: string,
+): string {
+  return join(runDir(cwd, taskId), artifactName);
+}
+
+const FRONTMATTER_OPEN = /^---\s*\r?\n/;
+const FRONTMATTER_CLOSE = /\r?\n---\s*\r?\n/;
+
+export type ParsedArtifact = {
+  frontmatter: StageArtifactFrontmatter;
+  body: string;
+};
+
+export function parseStageArtifact(text: string): ParsedArtifact {
+  if (!FRONTMATTER_OPEN.test(text)) {
+    throw new Error("Stage artifact is missing YAML frontmatter (--- ... ---)");
+  }
+  const afterOpen = text.replace(FRONTMATTER_OPEN, "");
+  const closeMatch = afterOpen.match(FRONTMATTER_CLOSE);
+  if (!closeMatch || closeMatch.index === undefined) {
+    throw new Error("Stage artifact frontmatter is not terminated (--- ... ---)");
+  }
+  const yamlText = afterOpen.slice(0, closeMatch.index);
+  const body = afterOpen
+    .slice(closeMatch.index + closeMatch[0].length)
+    .replace(/^\s+/, "")
+    .replace(/\s+$/, "");
+
+  let raw: unknown;
+  try {
+    raw = yaml.load(yamlText);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse stage artifact frontmatter as YAML: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  const parsed = stageArtifactFrontmatterSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `Stage artifact frontmatter does not match schema: ${parsed.error.message}`,
+    );
+  }
+  return { frontmatter: parsed.data, body };
+}
+
+export function readStageArtifact(
+  cwd: string,
+  taskId: string,
+  artifactName: string,
+): ParsedArtifact {
+  const path = artifactPath(cwd, taskId, artifactName);
+  const text = readFileSync(path, "utf8");
+  return parseStageArtifact(text);
+}
+
+export function renderStageArtifact(
+  frontmatter: StageArtifactFrontmatter,
+  body: string,
+): string {
+  const yamlText = yaml.dump(frontmatter, {
+    lineWidth: 100,
+    noRefs: true,
+    sortKeys: false,
+  });
+  const trimmedBody = body.trim();
+  return `---\n${yamlText}---\n\n${trimmedBody}\n`;
+}
+
+export function writeStageArtifact(
+  cwd: string,
+  taskId: string,
+  artifactName: string,
+  frontmatter: StageArtifactFrontmatter,
+  body: string,
+): string {
+  const dir = runDir(cwd, taskId);
+  mkdirSync(dir, { recursive: true });
+  const path = artifactPath(cwd, taskId, artifactName);
+  writeFileSync(path, renderStageArtifact(frontmatter, body), "utf8");
+  return path;
+}
+
+export function readRunState(cwd: string, taskId: string): RunState | null {
+  const path = stateFilePath(cwd, taskId);
+  if (!existsSync(path)) return null;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new Error(
+      `Failed to parse run state at ${path}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  const parsed = runStateSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Run state at ${path} does not match schema: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+export function writeRunState(cwd: string, state: RunState): string {
+  const validated = runStateSchema.parse(state);
+  const dir = runDir(cwd, validated.task_id);
+  mkdirSync(dir, { recursive: true });
+  const path = stateFilePath(cwd, validated.task_id);
+  writeFileSync(path, JSON.stringify(validated, null, 2) + "\n", "utf8");
+  return path;
+}

--- a/scaffold/mcp/src/core/workflow/default-workflows.ts
+++ b/scaffold/mcp/src/core/workflow/default-workflows.ts
@@ -1,0 +1,83 @@
+import type { WorkflowDefinition } from "./schemas.js";
+
+/**
+ * The default secure-build workflow that ships with Cortex. Organizations
+ * can override this from cortex-web later (Phase 2 of the harness rollout);
+ * until then this is the workflow every project gets out of the box.
+ */
+export const SECURE_BUILD_WORKFLOW: WorkflowDefinition = {
+  id: "secure-build",
+  description:
+    "Plan → Review → Build → Review → Mutation Tests → Security Review → Human Approval. " +
+    "The default Cortex Harness workflow for AI-driven development on production code.",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: ["files_targeted", "constraints"],
+      capability: "planner",
+      description:
+        "Produce a step-by-step implementation plan grounded in the repo's rules and memory.",
+    },
+    {
+      name: "plan-review",
+      artifact: "plan-review.md",
+      reads: ["plan"],
+      required_fields: ["approved", "blocking_comments"],
+      capability: "reviewer",
+      description:
+        "Review the plan for architectural fit and rule compliance before any code is written.",
+    },
+    {
+      name: "build",
+      artifact: "changes.md",
+      reads: ["plan", "plan-review"],
+      required_fields: ["files_changed"],
+      capability: "builder",
+      description:
+        "Implement the approved plan. Produces the diff manifest used by the downstream reviewers.",
+    },
+    {
+      name: "build-review",
+      artifact: "build-review.md",
+      reads: ["plan", "changes"],
+      required_fields: ["approved", "blocking_comments"],
+      capability: "reviewer",
+      description:
+        "Review the implementation against the plan and the project's rules.",
+    },
+    {
+      name: "mutation",
+      artifact: "mutation-report.md",
+      reads: ["changes"],
+      required_fields: ["score", "survived"],
+      capability: "tester",
+      description:
+        "Run mutation tests on the changed files. Report score + surviving mutants.",
+    },
+    {
+      name: "security",
+      artifact: "security-report.md",
+      reads: ["changes"],
+      required_fields: ["findings", "severity_summary"],
+      capability: "security-reviewer",
+      description:
+        "Security review focused on the diff: injection, authn/authz, secrets, dependency risk.",
+    },
+    {
+      name: "approval",
+      artifact: "approval.md",
+      reads: ["plan", "changes", "build-review", "mutation", "security"],
+      required_fields: ["approved", "approver"],
+      capability: "human",
+      description:
+        "Human sign-off. Pulls every prior artifact for the approver to read; the approver writes the artifact.",
+    },
+  ],
+};
+
+export const DEFAULT_WORKFLOWS: Record<string, WorkflowDefinition> = {
+  [SECURE_BUILD_WORKFLOW.id]: SECURE_BUILD_WORKFLOW,
+};

--- a/scaffold/mcp/src/core/workflow/index.ts
+++ b/scaffold/mcp/src/core/workflow/index.ts
@@ -1,0 +1,4 @@
+export * from "./schemas.js";
+export * from "./artifact-io.js";
+export * from "./run-lifecycle.js";
+export * from "./default-workflows.js";

--- a/scaffold/mcp/src/core/workflow/run-lifecycle.ts
+++ b/scaffold/mcp/src/core/workflow/run-lifecycle.ts
@@ -1,0 +1,165 @@
+import {
+  readRunState,
+  writeRunState,
+  writeStageArtifact,
+} from "./artifact-io.js";
+import {
+  runStateSchema,
+  stageArtifactFrontmatterSchema,
+  workflowDefinitionSchema,
+  type RunState,
+  type StageRecord,
+  type StageStatus,
+  type WorkflowDefinition,
+} from "./schemas.js";
+
+/**
+ * Lifecycle helpers for one workflow run. The harness composes envelopes
+ * and invokes agents elsewhere; these primitives only manipulate the
+ * persisted state under .agents/<task-id>/. Pure functions on top of
+ * artifact-io.ts so unit tests can hit them without spawning agents.
+ */
+
+export type CreateRunOptions = {
+  cwd: string;
+  taskId: string;
+  workflow: WorkflowDefinition;
+  taskDescription: string;
+  now?: () => Date;
+};
+
+export function createRun(options: CreateRunOptions): RunState {
+  const workflow = workflowDefinitionSchema.parse(options.workflow);
+  const now = (options.now ?? (() => new Date()))();
+  const startedAt = now.toISOString();
+
+  const stages: StageRecord[] = workflow.stages.map((stage) => ({
+    name: stage.name,
+    status: "pending" as StageStatus,
+  }));
+
+  const state: RunState = {
+    schema_version: 1,
+    task_id: options.taskId,
+    workflow_id: workflow.id,
+    workflow_version: workflow.version,
+    task_description: options.taskDescription,
+    current_stage: workflow.stages[0].name,
+    outcome: "in_progress",
+    started_at: startedAt,
+    completed_at: null,
+    stages,
+  };
+
+  // Validate before write so a malformed input never reaches disk.
+  const validated = runStateSchema.parse(state);
+  writeRunState(options.cwd, validated);
+  return validated;
+}
+
+export function getRunState(cwd: string, taskId: string): RunState | null {
+  return readRunState(cwd, taskId);
+}
+
+export type AdvanceStageOptions = {
+  cwd: string;
+  taskId: string;
+  workflow: WorkflowDefinition;
+  /** The stage we just finished. Must equal state.current_stage. */
+  stageName: string;
+  /** Filename of the artifact to write (e.g. "plan.md"). */
+  artifactName: string;
+  /** Frontmatter for the artifact, minus the auto-injected `written_at`. */
+  frontmatter: Omit<
+    import("./schemas.js").StageArtifactFrontmatter,
+    "written_at"
+  > & { written_at?: string };
+  /** Markdown body of the artifact. */
+  body: string;
+  /** Per-stage outcome surfaced into state.json for fast lookup. */
+  outcome?: Record<string, unknown>;
+  /** Final status to record for this stage. Defaults to "complete". */
+  status?: StageStatus;
+  now?: () => Date;
+};
+
+/**
+ * Marks `stageName` as finished, writes its artifact under .agents/<task-id>/,
+ * and advances `current_stage` to the next stage (or marks the run complete
+ * if this was the final stage). Idempotent only at the artifact layer —
+ * calling twice for the same stage will overwrite the artifact and the
+ * state.json record.
+ */
+export function advanceStage(options: AdvanceStageOptions): RunState {
+  const workflow = workflowDefinitionSchema.parse(options.workflow);
+  const state = readRunState(options.cwd, options.taskId);
+  if (!state) {
+    throw new Error(
+      `No run state found for task ${options.taskId}. Call createRun() first.`,
+    );
+  }
+  if (state.workflow_id !== workflow.id) {
+    throw new Error(
+      `Workflow mismatch: run was started with ${state.workflow_id}, advance was called with ${workflow.id}`,
+    );
+  }
+  if (state.current_stage !== options.stageName) {
+    throw new Error(
+      `Cannot advance stage ${options.stageName}: run is currently at ${
+        state.current_stage ?? "<finished>"
+      }`,
+    );
+  }
+
+  const now = (options.now ?? (() => new Date()))();
+  const completedAt = now.toISOString();
+
+  const frontmatter = stageArtifactFrontmatterSchema.parse({
+    ...options.frontmatter,
+    stage: options.stageName,
+    written_at: options.frontmatter.written_at ?? completedAt,
+  });
+  writeStageArtifact(
+    options.cwd,
+    options.taskId,
+    options.artifactName,
+    frontmatter,
+    options.body,
+  );
+
+  const stageIndex = workflow.stages.findIndex((s) => s.name === options.stageName);
+  const nextStage = workflow.stages[stageIndex + 1] ?? null;
+  const finalStatus = options.status ?? "complete";
+
+  const updatedStages: StageRecord[] = state.stages.map((record) => {
+    if (record.name !== options.stageName) return record;
+    return {
+      ...record,
+      status: finalStatus,
+      artifact: options.artifactName,
+      started_at: record.started_at ?? state.started_at,
+      completed_at: completedAt,
+      outcome: options.outcome,
+    };
+  });
+
+  const runOutcome: RunState["outcome"] =
+    finalStatus === "blocked" || finalStatus === "failed"
+      ? finalStatus
+      : nextStage
+        ? "in_progress"
+        : "complete";
+
+  const next: RunState = {
+    ...state,
+    current_stage:
+      runOutcome === "in_progress" && nextStage ? nextStage.name : null,
+    outcome: runOutcome,
+    completed_at: runOutcome === "in_progress" ? null : completedAt,
+    stages: updatedStages,
+  };
+
+  const validated = runStateSchema.parse(next);
+  writeRunState(options.cwd, validated);
+  return validated;
+}

--- a/scaffold/mcp/src/core/workflow/schemas.ts
+++ b/scaffold/mcp/src/core/workflow/schemas.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+
+/**
+ * Schemas for the Cortex Harness workflow engine.
+ *
+ * See docs/harness-vision.md for the design. In short:
+ *
+ *   .agents/<task-id>/
+ *     plan.md            # frontmatter + body
+ *     review.md
+ *     changes.md
+ *     mutation-report.md
+ *     security-report.md
+ *     state.json         # current run state
+ *
+ * All artifacts are markdown with YAML frontmatter; state.json is the only
+ * JSON file. Both are tracked in git so a PR carries the evidence trail.
+ */
+
+const slugSchema = z
+  .string()
+  .min(1)
+  .max(80)
+  .regex(
+    /^[a-z0-9][a-z0-9-]*[a-z0-9]$/,
+    "Must be lowercase alphanumeric with hyphens (no leading/trailing hyphen)",
+  );
+
+/**
+ * Static definition of a single stage in a workflow. Authored at the
+ * organization level (in cortex-web later) and synced down to projects.
+ */
+export const stageDefinitionSchema = z.object({
+  name: slugSchema,
+  artifact: z.string().min(1).regex(/^[a-z0-9][a-z0-9-]*\.md$/),
+  /** Stage names this stage may read artifacts from. Empty = no inputs. */
+  reads: z.array(slugSchema).default([]),
+  /** Required frontmatter fields the produced artifact must populate. */
+  required_fields: z.array(z.string().min(1)).default([]),
+  /** Capability key the stage runs under. References a separate capability registry. */
+  capability: z.string().min(1).optional(),
+  /** Human-readable summary surfaced in dashboards and audit. */
+  description: z.string().min(1).max(500),
+});
+
+export type StageDefinition = z.infer<typeof stageDefinitionSchema>;
+
+/**
+ * A complete workflow: ordered stages plus a stable identifier.
+ */
+export const workflowDefinitionSchema = z.object({
+  id: slugSchema,
+  description: z.string().min(1).max(500),
+  version: z.number().int().min(1),
+  stages: z.array(stageDefinitionSchema).min(1),
+});
+
+export type WorkflowDefinition = z.infer<typeof workflowDefinitionSchema>;
+
+/**
+ * Status of a single stage inside a run.
+ */
+export const stageStatusSchema = z.enum([
+  "pending",
+  "in_progress",
+  "complete",
+  "blocked",
+  "failed",
+]);
+
+export type StageStatus = z.infer<typeof stageStatusSchema>;
+
+/**
+ * Per-stage record inside state.json. Holds outcome metadata that the next
+ * stage's envelope composer needs without re-parsing every artifact.
+ */
+export const stageRecordSchema = z.object({
+  name: slugSchema,
+  status: stageStatusSchema,
+  artifact: z.string().min(1).optional(),
+  started_at: z.string().datetime().optional(),
+  completed_at: z.string().datetime().optional(),
+  /** Frontmatter outcome surfaced for fast lookup (e.g. approved=true on review). */
+  outcome: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type StageRecord = z.infer<typeof stageRecordSchema>;
+
+/**
+ * The full state of one workflow run, persisted as
+ * .agents/<task-id>/state.json. Written only on stage boundaries so it
+ * never churns mid-tick.
+ */
+export const runStateSchema = z.object({
+  schema_version: z.literal(1),
+  task_id: slugSchema,
+  workflow_id: slugSchema,
+  workflow_version: z.number().int().min(1),
+  task_description: z.string().min(1).max(2000),
+  current_stage: slugSchema.nullable(),
+  outcome: z.enum(["in_progress", "complete", "failed", "blocked"]),
+  started_at: z.string().datetime(),
+  completed_at: z.string().datetime().nullable(),
+  stages: z.array(stageRecordSchema).min(1),
+});
+
+export type RunState = z.infer<typeof runStateSchema>;
+
+/**
+ * The required-by-convention frontmatter shape every stage artifact carries.
+ * Stages may add additional structured fields; these four are the ones the
+ * harness itself relies on.
+ */
+export const stageArtifactFrontmatterSchema = z
+  .object({
+    stage: slugSchema,
+    status: stageStatusSchema,
+    /** Sister-artifacts this artifact references (relative filenames). */
+    references: z.array(z.string().min(1)).default([]),
+    /** ISO 8601; injected by the harness, not the agent. */
+    written_at: z.string().datetime(),
+  })
+  .passthrough();
+
+export type StageArtifactFrontmatter = z.infer<typeof stageArtifactFrontmatterSchema>;

--- a/scaffold/mcp/tests/workflow.test.mjs
+++ b/scaffold/mcp/tests/workflow.test.mjs
@@ -1,0 +1,283 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  parseStageArtifact,
+  renderStageArtifact,
+  readRunState,
+  readStageArtifact,
+} from "../dist/core/workflow/artifact-io.js";
+import {
+  createRun,
+  advanceStage,
+  getRunState,
+} from "../dist/core/workflow/run-lifecycle.js";
+import {
+  workflowDefinitionSchema,
+  stageArtifactFrontmatterSchema,
+  runStateSchema,
+} from "../dist/core/workflow/schemas.js";
+import { SECURE_BUILD_WORKFLOW } from "../dist/core/workflow/default-workflows.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-workflow-"));
+}
+
+const TINY_WORKFLOW = {
+  id: "tiny",
+  description: "Two-stage workflow used for tests",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: [],
+      description: "Produce a plan",
+    },
+    {
+      name: "review",
+      artifact: "review.md",
+      reads: ["plan"],
+      required_fields: ["approved"],
+      description: "Review the plan",
+    },
+  ],
+};
+
+test("schemas: SECURE_BUILD_WORKFLOW validates against workflowDefinitionSchema", () => {
+  const parsed = workflowDefinitionSchema.parse(SECURE_BUILD_WORKFLOW);
+  assert.equal(parsed.id, "secure-build");
+  assert.ok(parsed.stages.length > 0);
+});
+
+test("schemas: stage names must be slug-cased", () => {
+  assert.throws(() =>
+    workflowDefinitionSchema.parse({
+      ...TINY_WORKFLOW,
+      stages: [
+        { ...TINY_WORKFLOW.stages[0], name: "Bad Name" },
+        TINY_WORKFLOW.stages[1],
+      ],
+    }),
+  );
+});
+
+test("schemas: stage artifact frontmatter requires status + stage", () => {
+  assert.throws(() =>
+    stageArtifactFrontmatterSchema.parse({
+      stage: "plan",
+      // status missing
+      written_at: new Date().toISOString(),
+    }),
+  );
+});
+
+test("artifact-io: render + parse round-trips frontmatter", () => {
+  const fm = stageArtifactFrontmatterSchema.parse({
+    stage: "plan",
+    status: "complete",
+    references: [],
+    written_at: "2026-05-06T19:00:00.000Z",
+  });
+  const text = renderStageArtifact(fm, "# Plan\n\nDo the thing.");
+  const parsed = parseStageArtifact(text);
+  assert.equal(parsed.frontmatter.stage, "plan");
+  assert.equal(parsed.frontmatter.status, "complete");
+  assert.equal(parsed.body, "# Plan\n\nDo the thing.");
+});
+
+test("artifact-io: parseStageArtifact rejects missing frontmatter", () => {
+  assert.throws(() => parseStageArtifact("# No frontmatter here\n"));
+});
+
+test("artifact-io: parseStageArtifact rejects unterminated frontmatter", () => {
+  assert.throws(() =>
+    parseStageArtifact("---\nstage: plan\nstatus: complete\n# no close marker\n"),
+  );
+});
+
+test("artifact-io: parseStageArtifact preserves passthrough fields", () => {
+  const text = `---
+stage: review
+status: complete
+references:
+  - plan.md
+written_at: "2026-05-06T19:00:00.000Z"
+approved: true
+blocking_comments: 0
+---
+
+# Review
+
+Looks good.
+`;
+  const parsed = parseStageArtifact(text);
+  assert.equal(parsed.frontmatter.stage, "review");
+  assert.deepEqual(parsed.frontmatter.references, ["plan.md"]);
+  assert.equal(parsed.frontmatter.approved, true);
+  assert.equal(parsed.frontmatter.blocking_comments, 0);
+});
+
+test("createRun: writes state.json with all stages pending and current_stage = first", () => {
+  const cwd = makeWorkspace();
+  const state = createRun({
+    cwd,
+    taskId: "2026-05-06-fixture",
+    workflow: TINY_WORKFLOW,
+    taskDescription: "Test run",
+  });
+
+  assert.equal(state.task_id, "2026-05-06-fixture");
+  assert.equal(state.current_stage, "plan");
+  assert.equal(state.outcome, "in_progress");
+  assert.deepEqual(
+    state.stages.map((s) => s.status),
+    ["pending", "pending"],
+  );
+
+  const persisted = readRunState(cwd, "2026-05-06-fixture");
+  assert.deepEqual(persisted, state);
+});
+
+test("advanceStage: writes artifact, updates state, advances current_stage", () => {
+  const cwd = makeWorkspace();
+  const taskId = "2026-05-06-advance";
+  createRun({ cwd, taskId, workflow: TINY_WORKFLOW, taskDescription: "Test" });
+
+  const after = advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "plan",
+    artifactName: "plan.md",
+    frontmatter: { stage: "plan", status: "complete", references: [] },
+    body: "# Plan\n\n- step 1\n- step 2",
+  });
+
+  assert.equal(after.current_stage, "review");
+  assert.equal(after.outcome, "in_progress");
+  assert.equal(after.stages[0].status, "complete");
+  assert.equal(after.stages[0].artifact, "plan.md");
+  assert.equal(after.stages[1].status, "pending");
+
+  // Artifact lives on disk under .agents/<taskId>/
+  const artifactPath = path.join(cwd, ".agents", taskId, "plan.md");
+  assert.ok(fs.existsSync(artifactPath));
+  const parsed = readStageArtifact(cwd, taskId, "plan.md");
+  assert.equal(parsed.frontmatter.stage, "plan");
+});
+
+test("advanceStage: marks run complete after final stage", () => {
+  const cwd = makeWorkspace();
+  const taskId = "2026-05-06-final";
+  createRun({ cwd, taskId, workflow: TINY_WORKFLOW, taskDescription: "Test" });
+
+  advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "plan",
+    artifactName: "plan.md",
+    frontmatter: { stage: "plan", status: "complete", references: [] },
+    body: "# Plan",
+  });
+
+  const after = advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "review",
+    artifactName: "review.md",
+    frontmatter: {
+      stage: "review",
+      status: "complete",
+      references: ["plan.md"],
+      approved: true,
+    },
+    body: "# Review\n\napproved",
+    outcome: { approved: true },
+  });
+
+  assert.equal(after.current_stage, null);
+  assert.equal(after.outcome, "complete");
+  assert.ok(after.completed_at);
+  assert.deepEqual(after.stages[1].outcome, { approved: true });
+});
+
+test("advanceStage: blocked status surfaces as run outcome", () => {
+  const cwd = makeWorkspace();
+  const taskId = "2026-05-06-blocked";
+  createRun({ cwd, taskId, workflow: TINY_WORKFLOW, taskDescription: "Test" });
+
+  const after = advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "plan",
+    artifactName: "plan.md",
+    frontmatter: { stage: "plan", status: "blocked", references: [] },
+    body: "# Plan blocked",
+    status: "blocked",
+  });
+
+  assert.equal(after.outcome, "blocked");
+  assert.equal(after.current_stage, null);
+});
+
+test("advanceStage: refuses to advance the wrong stage", () => {
+  const cwd = makeWorkspace();
+  const taskId = "2026-05-06-wrong";
+  createRun({ cwd, taskId, workflow: TINY_WORKFLOW, taskDescription: "Test" });
+
+  assert.throws(() =>
+    advanceStage({
+      cwd,
+      taskId,
+      workflow: TINY_WORKFLOW,
+      stageName: "review",
+      artifactName: "review.md",
+      frontmatter: { stage: "review", status: "complete", references: [] },
+      body: "# Out of order",
+    }),
+  );
+});
+
+test("getRunState: returns null for missing tasks", () => {
+  const cwd = makeWorkspace();
+  assert.equal(getRunState(cwd, "no-such-task"), null);
+});
+
+test("readRunState: validates persisted state against schema", () => {
+  const cwd = makeWorkspace();
+  const taskId = "2026-05-06-corrupt";
+  createRun({ cwd, taskId, workflow: TINY_WORKFLOW, taskDescription: "Test" });
+
+  // Corrupt the file: drop required field.
+  const statePath = path.join(cwd, ".agents", taskId, "state.json");
+  const raw = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  delete raw.workflow_id;
+  fs.writeFileSync(statePath, JSON.stringify(raw, null, 2));
+
+  assert.throws(() => readRunState(cwd, taskId));
+});
+
+test("runStateSchema: rejects unknown outcome", () => {
+  assert.throws(() =>
+    runStateSchema.parse({
+      schema_version: 1,
+      task_id: "x",
+      workflow_id: "tiny",
+      workflow_version: 1,
+      task_description: "y",
+      current_stage: null,
+      outcome: "totally-bogus",
+      started_at: new Date().toISOString(),
+      completed_at: null,
+      stages: [{ name: "plan", status: "complete" }],
+    }),
+  );
+});


### PR DESCRIPTION
First slice of the harness implementation, per [docs/harness-vision.md](https://github.com/DanielBlomma/cortex/blob/main/docs/harness-vision.md). Builds the data model and persistence primitives that later PRs (envelope composer, MCP tool surface, cortex-web sync) sit on top of.

## What lands here

\`scaffold/mcp/src/core/workflow/\`:

- **\`schemas.ts\`** — zod schemas for \`WorkflowDefinition\`, \`StageDefinition\`, \`RunState\`, \`StageRecord\`, \`StageArtifactFrontmatter\`. Slug-validated identifiers; frontmatter accepts arbitrary passthrough fields so individual stages can declare their own structured shape (e.g. \`approved: bool\` on review, \`score: number\` on mutation report).
- **\`artifact-io.ts\`** — read/write \`SKILL.md\`-style markdown files with YAML frontmatter via \`js-yaml\`, plus JSON read/write for \`state.json\`. All paths derived from a single \`.agents/<task-id>/\` root so tests target a tmp dir.
- **\`run-lifecycle.ts\`** — \`createRun\`, \`advanceStage\`, \`getRunState\`. Pure functions over \`artifact-io\`; the harness composes envelopes and invokes agents elsewhere.
- **\`default-workflows.ts\`** — ships the \`secure-build\` workflow (plan → plan-review → build → build-review → mutation → security → approval) as the out-of-the-box default.
- **\`index.ts\`** — re-exports the public surface.

Adds \`js-yaml\` as a dependency. Existing \`parseFrontmatter\` only handles flat \`key: value\`; workflow frontmatter uses arrays for \`references\` and arbitrary stage-specific fields, so a real YAML parser is the right tool.

## Tests
15 new cases under \`tests/workflow.test.mjs\`:
- schema validation (slug enforcement, required fields, unknown outcome)
- frontmatter round-trip render → parse
- frontmatter rejection (missing or unterminated)
- frontmatter passthrough fields preserved
- \`createRun\` writes initial state with all stages pending
- \`advanceStage\` writes artifact + updates state + advances pointer
- run completion after final stage
- \`blocked\` status surfacing as run outcome
- out-of-order \`advanceStage\` rejection
- \`getRunState\` returns null for missing tasks
- \`readRunState\` validates persisted state against schema

All 141 daemon tests pass.

## What's not in this PR (follow-up)
- Envelope composer (turns \`RunState\` + next stage def → agent prompt)
- MCP tool surface (\`cortex.workflow.start\`, \`cortex.workflow.advance\`, \`cortex.workflow.status\`)
- Hook integration so harness runs trigger pre-tool-use validation
- \`cortex-web\` side: org-level workflow config in DB + dashboard UI + sync to daemon

## Test plan
- [x] \`npm test\` in scaffold/mcp passes (141/141)
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual: import the public API in a scratch script, create a run, advance through all stages of \`secure-build\`, verify \`.agents/<task-id>/\` layout matches the spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)