### PR TITLE
Workflow envelope composer

### DIFF
--- a/scaffold/mcp/src/core/workflow/envelope.ts
+++ b/scaffold/mcp/src/core/workflow/envelope.ts
@@ -1,0 +1,220 @@
+import { readFileSync } from "node:fs";
+import { artifactPath, readRunState } from "./artifact-io.js";
+import { workflowDefinitionSchema, type WorkflowDefinition } from "./schemas.js";
+
+/**
+ * Composes the prompt one stage's agent sees. Pure function over the
+ * persisted run state plus the workflow definition — no agent invocation,
+ * no MCP, no daemon. The harness later wraps this into an MCP call or a
+ * CLI invocation.
+ *
+ * Design: the agent gets four sections in a fixed order so it can anchor
+ * on them reliably:
+ *
+ *   TASK     — what the developer asked for, copied verbatim from RunState
+ *   STAGE    — what *this* stage is supposed to produce
+ *   HANDOFFS — every prior-stage artifact the new stage declared in `reads`,
+ *              inlined raw (frontmatter + body) so the agent sees structured
+ *              outcomes alongside the reasoning
+ *   OUTPUT   — exact frontmatter contract the agent must satisfy plus the
+ *              expected artifact filename
+ *
+ * Capability constraints (which files the agent may edit, which tools it
+ * may call) are NOT enforced by the prompt — they're enforced by hooks
+ * downstream. The capability key is surfaced in the prompt as a label so
+ * the agent knows under what role it's running, but the real gate is
+ * pre-tool-use.
+ */
+
+export type ComposedEnvelope = {
+  /** The full prompt the agent will receive. */
+  prompt: string;
+  /** Expected artifact filename the agent must produce. */
+  expectedArtifact: string;
+  /** Frontmatter keys the agent must populate (beyond stage/status/references). */
+  requiredFields: string[];
+  /** Capability key the stage runs under (informational). */
+  capability: string | null;
+};
+
+export type ComposeStageEnvelopeOptions = {
+  cwd: string;
+  taskId: string;
+  workflow: WorkflowDefinition;
+  /**
+   * Defaults to the run's current_stage. Pass an explicit stageName when
+   * dry-running an envelope without driving state forward.
+   */
+  stageName?: string;
+};
+
+export function composeStageEnvelope(
+  options: ComposeStageEnvelopeOptions,
+): ComposedEnvelope {
+  const workflow = workflowDefinitionSchema.parse(options.workflow);
+  const state = readRunState(options.cwd, options.taskId);
+  if (!state) {
+    throw new Error(
+      `No run state found for task ${options.taskId}. Call createRun() first.`,
+    );
+  }
+  if (state.workflow_id !== workflow.id) {
+    throw new Error(
+      `Workflow mismatch: run was started with ${state.workflow_id}, envelope was composed with ${workflow.id}`,
+    );
+  }
+
+  const stageName = options.stageName ?? state.current_stage;
+  if (!stageName) {
+    throw new Error(
+      `Run ${options.taskId} is not at any stage (outcome=${state.outcome}). Cannot compose envelope.`,
+    );
+  }
+  const stage = workflow.stages.find((s) => s.name === stageName);
+  if (!stage) {
+    throw new Error(
+      `Stage ${stageName} is not defined in workflow ${workflow.id}`,
+    );
+  }
+
+  const handoffs: string[] = [];
+  for (const readName of stage.reads) {
+    const priorStage = workflow.stages.find((s) => s.name === readName);
+    if (!priorStage) {
+      throw new Error(
+        `Stage ${stageName} declares reads from unknown stage ${readName}`,
+      );
+    }
+    const priorRecord = state.stages.find((r) => r.name === readName);
+    if (!priorRecord || priorRecord.status === "pending" || !priorRecord.artifact) {
+      throw new Error(
+        `Stage ${stageName} requires artifact from ${readName}, but it has not been produced yet`,
+      );
+    }
+    const path = artifactPath(options.cwd, options.taskId, priorRecord.artifact);
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf8");
+    } catch (err) {
+      throw new Error(
+        `Failed to read handoff artifact for ${readName} at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    handoffs.push(renderHandoff(readName, priorRecord.artifact, raw));
+  }
+
+  const requiredFields = stage.required_fields;
+  const capability = stage.capability ?? null;
+
+  const prompt = renderPrompt({
+    taskDescription: state.task_description,
+    workflowId: workflow.id,
+    workflowDescription: workflow.description,
+    stageName: stage.name,
+    stageDescription: stage.description,
+    expectedArtifact: stage.artifact,
+    requiredFields,
+    capability,
+    handoffs,
+  });
+
+  return {
+    prompt,
+    expectedArtifact: stage.artifact,
+    requiredFields,
+    capability,
+  };
+}
+
+function renderHandoff(
+  stageName: string,
+  artifactName: string,
+  rawArtifact: string,
+): string {
+  return [
+    `--- handoff:${stageName} (${artifactName}) ---`,
+    rawArtifact.trim(),
+    `--- end handoff:${stageName} ---`,
+  ].join("\n");
+}
+
+type RenderPromptOptions = {
+  taskDescription: string;
+  workflowId: string;
+  workflowDescription: string;
+  stageName: string;
+  stageDescription: string;
+  expectedArtifact: string;
+  requiredFields: string[];
+  capability: string | null;
+  handoffs: string[];
+};
+
+function renderPrompt(o: RenderPromptOptions): string {
+  const sections: string[] = [];
+
+  sections.push(
+    [
+      `# TASK`,
+      ``,
+      o.taskDescription.trim(),
+      ``,
+      `Workflow: ${o.workflowId} — ${o.workflowDescription}`,
+    ].join("\n"),
+  );
+
+  sections.push(
+    [
+      `# STAGE: ${o.stageName}`,
+      ``,
+      o.stageDescription.trim(),
+      ``,
+      o.capability
+        ? `Running under capability: \`${o.capability}\` (file and tool restrictions are enforced by Cortex hooks at tool-use time, not by you).`
+        : `No capability constraint declared for this stage.`,
+    ].join("\n"),
+  );
+
+  if (o.handoffs.length === 0) {
+    sections.push(
+      [`# HANDOFFS`, ``, `_No prior-stage artifacts; this is the first stage._`].join(
+        "\n",
+      ),
+    );
+  } else {
+    sections.push(
+      [
+        `# HANDOFFS`,
+        ``,
+        `The following stages have already run. Each artifact below is the complete file as it lives on disk; use the frontmatter for structured outcomes and the body for reasoning.`,
+        ``,
+        ...o.handoffs,
+      ].join("\n"),
+    );
+  }
+
+  const requiredLines =
+    o.requiredFields.length === 0
+      ? `_No additional required fields beyond the harness defaults._`
+      : o.requiredFields.map((f) => `- \`${f}\``).join("\n");
+
+  sections.push(
+    [
+      `# OUTPUT`,
+      ``,
+      `Produce a single markdown file named \`${o.expectedArtifact}\` with YAML frontmatter on top.`,
+      ``,
+      `Required frontmatter fields (in addition to \`stage\`, \`status\`, \`references\`, \`written_at\` which the harness manages):`,
+      ``,
+      requiredLines,
+      ``,
+      `Body: clear, well-structured markdown explaining your reasoning. Cite handoff artifacts by stage name when relevant.`,
+      ``,
+      `If you cannot complete this stage (missing context, blocking concern, conflicting prior decisions), set \`status: blocked\` in frontmatter and explain why in the body — do not fabricate work.`,
+    ].join("\n"),
+  );
+
+  return sections.join("\n\n");
+}

--- a/scaffold/mcp/src/core/workflow/index.ts
+++ b/scaffold/mcp/src/core/workflow/index.ts
@@ -1,4 +1,5 @@
 export * from "./schemas.js";
 export * from "./artifact-io.js";
 export * from "./run-lifecycle.js";
+export * from "./envelope.js";
 export * from "./default-workflows.js";

--- a/scaffold/mcp/tests/workflow-envelope.test.mjs
+++ b/scaffold/mcp/tests/workflow-envelope.test.mjs
@@ -1,0 +1,247 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { composeStageEnvelope } from "../dist/core/workflow/envelope.js";
+import { createRun, advanceStage } from "../dist/core/workflow/run-lifecycle.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-envelope-"));
+}
+
+const TINY_WORKFLOW = {
+  id: "tiny",
+  description: "Two-stage workflow used for tests",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: ["files_targeted"],
+      capability: "planner",
+      description: "Produce a step-by-step plan.",
+    },
+    {
+      name: "review",
+      artifact: "review.md",
+      reads: ["plan"],
+      required_fields: ["approved", "blocking_comments"],
+      capability: "reviewer",
+      description: "Review the plan for soundness.",
+    },
+  ],
+};
+
+function startRun(cwd, taskId) {
+  return createRun({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    taskDescription: "Wire up the new dashboard endpoint.",
+  });
+}
+
+function completePlanStage(cwd, taskId) {
+  return advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "plan",
+    artifactName: "plan.md",
+    frontmatter: {
+      stage: "plan",
+      status: "complete",
+      references: [],
+      files_targeted: ["src/foo.ts"],
+    },
+    body: "# Plan\n\n1. Add endpoint\n2. Wire route",
+  });
+}
+
+test("composeStageEnvelope: first stage has no handoffs and labels first-stage explicitly", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-first";
+  startRun(cwd, taskId);
+
+  const envelope = composeStageEnvelope({ cwd, taskId, workflow: TINY_WORKFLOW });
+
+  assert.equal(envelope.expectedArtifact, "plan.md");
+  assert.deepEqual(envelope.requiredFields, ["files_targeted"]);
+  assert.equal(envelope.capability, "planner");
+  assert.match(envelope.prompt, /# TASK/);
+  assert.match(envelope.prompt, /Wire up the new dashboard endpoint\./);
+  assert.match(envelope.prompt, /# STAGE: plan/);
+  assert.match(envelope.prompt, /Running under capability: `planner`/);
+  assert.match(envelope.prompt, /No prior-stage artifacts/);
+  assert.match(envelope.prompt, /# OUTPUT/);
+  assert.match(envelope.prompt, /`files_targeted`/);
+});
+
+test("composeStageEnvelope: mid-flow stage inlines prior artifact verbatim", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-mid";
+  startRun(cwd, taskId);
+  completePlanStage(cwd, taskId);
+
+  const envelope = composeStageEnvelope({ cwd, taskId, workflow: TINY_WORKFLOW });
+
+  assert.equal(envelope.expectedArtifact, "review.md");
+  assert.deepEqual(envelope.requiredFields, ["approved", "blocking_comments"]);
+  assert.match(envelope.prompt, /# STAGE: review/);
+  // Handoff section uses fenced markers and contains the planning frontmatter + body.
+  assert.match(envelope.prompt, /--- handoff:plan \(plan\.md\) ---/);
+  assert.match(envelope.prompt, /--- end handoff:plan ---/);
+  assert.match(envelope.prompt, /stage: plan/);
+  assert.match(envelope.prompt, /1\. Add endpoint/);
+});
+
+test("composeStageEnvelope: explicit stageName overrides current_stage for dry-run", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-explicit";
+  startRun(cwd, taskId);
+
+  const envelope = composeStageEnvelope({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "plan",
+  });
+  assert.match(envelope.prompt, /# STAGE: plan/);
+});
+
+test("composeStageEnvelope: throws when run hasn't been created", () => {
+  const cwd = makeWorkspace();
+  assert.throws(
+    () => composeStageEnvelope({ cwd, taskId: "ghost", workflow: TINY_WORKFLOW }),
+    /No run state/,
+  );
+});
+
+test("composeStageEnvelope: throws when stage not in workflow", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-unknown";
+  startRun(cwd, taskId);
+
+  assert.throws(
+    () =>
+      composeStageEnvelope({
+        cwd,
+        taskId,
+        workflow: TINY_WORKFLOW,
+        stageName: "nonexistent",
+      }),
+    /not defined in workflow/,
+  );
+});
+
+test("composeStageEnvelope: throws when prior handoff artifact hasn't been produced", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-missing";
+  startRun(cwd, taskId);
+  // Skip the plan stage — go straight to asking for a review envelope. Plan
+  // is still pending so its artifact doesn't exist.
+  assert.throws(
+    () =>
+      composeStageEnvelope({
+        cwd,
+        taskId,
+        workflow: TINY_WORKFLOW,
+        stageName: "review",
+      }),
+    /requires artifact from plan, but it has not been produced yet/,
+  );
+});
+
+test("composeStageEnvelope: throws when stage declares reads from unknown stage", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-bad-reads";
+  const broken = {
+    ...TINY_WORKFLOW,
+    stages: [
+      TINY_WORKFLOW.stages[0],
+      { ...TINY_WORKFLOW.stages[1], reads: ["does-not-exist"] },
+    ],
+  };
+  createRun({
+    cwd,
+    taskId,
+    workflow: broken,
+    taskDescription: "Test bad reads",
+  });
+  advanceStage({
+    cwd,
+    taskId,
+    workflow: broken,
+    stageName: "plan",
+    artifactName: "plan.md",
+    frontmatter: { stage: "plan", status: "complete", references: [] },
+    body: "# Plan",
+  });
+
+  assert.throws(
+    () =>
+      composeStageEnvelope({
+        cwd,
+        taskId,
+        workflow: broken,
+        stageName: "review",
+      }),
+    /declares reads from unknown stage/,
+  );
+});
+
+test("composeStageEnvelope: surfaces lack of capability gracefully", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-no-capability";
+  const noCapability = {
+    ...TINY_WORKFLOW,
+    stages: [
+      { ...TINY_WORKFLOW.stages[0], capability: undefined },
+      TINY_WORKFLOW.stages[1],
+    ],
+  };
+  createRun({
+    cwd,
+    taskId,
+    workflow: noCapability,
+    taskDescription: "Test no capability",
+  });
+
+  const envelope = composeStageEnvelope({
+    cwd,
+    taskId,
+    workflow: noCapability,
+  });
+  assert.equal(envelope.capability, null);
+  assert.match(envelope.prompt, /No capability constraint declared/);
+});
+
+test("composeStageEnvelope: throws when run is already finished", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-finished";
+  startRun(cwd, taskId);
+  completePlanStage(cwd, taskId);
+  advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "review",
+    artifactName: "review.md",
+    frontmatter: {
+      stage: "review",
+      status: "complete",
+      references: ["plan.md"],
+      approved: true,
+      blocking_comments: 0,
+    },
+    body: "# Review\n\nLooks good.",
+  });
+
+  assert.throws(
+    () => composeStageEnvelope({ cwd, taskId, workflow: TINY_WORKFLOW }),
+    /not at any stage/,
+  );
+});


### PR DESCRIPTION
Second slice of the harness implementation. Pure function over \`RunState\` + \`WorkflowDefinition\` that produces the prompt one stage's agent will see — no agent invocation, no MCP, no daemon, just text.

Stacks on **#66** (foundation). Merge that one first; the diff here will collapse cleanly once it lands.

## What lands
\`scaffold/mcp/src/core/workflow/envelope.ts\` — \`composeStageEnvelope({ cwd, taskId, workflow, stageName? })\` returns:

\`\`\`ts
{
  prompt: string;
  expectedArtifact: string;
  requiredFields: string[];
  capability: string | null;
}
\`\`\`

Prompt has four anchored sections in fixed order so an LLM can reliably address each one:

- **TASK** — verbatim \`task_description\` from the run + which workflow it's running
- **STAGE** — what this stage produces, plus the capability label (with explicit note that file/tool restrictions are enforced by hooks, not by the agent's good behaviour)
- **HANDOFFS** — every prior-stage artifact this stage's \`reads\` declares, inlined raw between fenced markers (\`--- handoff:plan (plan.md) ---\` ... \`--- end handoff:plan ---\`) so the agent sees structured outcomes alongside the reasoning
- **OUTPUT** — the expected artifact filename, the required frontmatter fields beyond the harness defaults, and an explicit "set \`status: blocked\` rather than fabricate" instruction

The composer's metadata return values let the harness validate the agent's response against the same contract the prompt describes.

## Tests
9 new cases under \`tests/workflow-envelope.test.mjs\`:
- first stage has no handoffs and labels the situation explicitly
- mid-flow stage inlines the prior artifact verbatim
- explicit \`stageName\` overrides \`current_stage\` (for dry-runs)
- throws when run hasn't been created
- throws when stage isn't in workflow
- throws when prior handoff hasn't been produced
- throws when stage declares \`reads\` from an unknown stage
- surfaces lack of capability gracefully (no crash)
- throws when run is already finished

150/150 daemon tests pass; \`tsc --noEmit\` clean.

## Not in this PR
- MCP tool surface (\`cortex.workflow.*\`) — next stack item
- Hook-side capability enforcement (pre-tool-use checks)
- cortex-web org-config sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)