### PR TITLE
Add cortex stage CLI surface for the harness

### DIFF
--- a/bin/cortex.mjs
+++ b/bin/cortex.mjs
@@ -89,6 +89,13 @@ function printHelp() {
   console.log(helpRow("hooks [install|uninstall|status] [--project]", "Claude Code hooks"));
   console.log(helpRow("telemetry test", "Smoke-test the push pipeline"));
 
+  console.log(helpSection("HARNESS"));
+  console.log(helpRow("stage start --task-id <id> --description \"...\"", "Start a workflow run for a task"));
+  console.log(helpRow("stage status --task-id <id>", "Print run state JSON"));
+  console.log(helpRow("stage envelope --task-id <id> [--stage <name>]", "Compose stage prompt envelope"));
+  console.log(helpRow("stage advance --task-id <id> --stage <name> --body-file <path>", "Write artifact, advance run"));
+  console.log(helpRow("stage run --task-id <id> -- <command>", "Exec a command with CORTEX_ACTIVE_TASK_ID set"));
+
   console.log(helpSection("MISC"));
   console.log(helpRow("mcp", "Run the MCP stdio server for the current project"));
   console.log(helpRow("version", "Print CLI version"));
@@ -1005,6 +1012,10 @@ async function run() {
     return runRunCommand(rest);
   }
 
+  if (command === "stage") {
+    return runStageCommandShim(rest);
+  }
+
   const passthrough = new Set([
     "bootstrap",
     "update",
@@ -1525,6 +1536,19 @@ async function runRunCommand(args) {
   const mod = await import(pathToFileURL(entry).href);
   const exitCode = await mod.runAiCli({ cli: sub, args: args.slice(1) });
   process.exit(exitCode);
+}
+
+async function runStageCommandShim(args) {
+  const target = process.env.CORTEX_PROJECT_ROOT?.trim() || process.cwd();
+  process.env.CORTEX_PROJECT_ROOT = path.resolve(target);
+  const entry = resolveCliEntry("stage");
+  if (!fs.existsSync(entry)) {
+    throw new Error(
+      `Build the project's MCP first (missing ${entry}). Run 'cortex bootstrap' in the project root.`,
+    );
+  }
+  const mod = await import(pathToFileURL(entry).href);
+  await mod.runStageCommand(args);
 }
 
 async function runTelemetryCommand(args) {

--- a/scaffold/mcp/package-lock.json
+++ b/scaffold/mcp/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@huggingface/transformers": "^4.1.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@types/js-yaml": "^4.0.9",
+        "js-yaml": "^4.1.1",
         "ryugraph": "^25.9.1",
         "zod": "^3.24.1"
       },
@@ -842,12 +844,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -988,6 +995,12 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -1760,7 +1773,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1859,6 +1871,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -2611,7 +2635,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2764,7 +2787,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scaffold/mcp/package-lock.json
+++ b/scaffold/mcp/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/js-yaml": "^4.0.9",
         "js-yaml": "^4.1.1",
+        "minimatch": "^10.2.5",
         "ryugraph": "^25.9.1",
         "zod": "^3.24.1"
       },
@@ -1002,6 +1003,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1032,6 +1042,18 @@
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1962,6 +1984,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {

--- a/scaffold/mcp/package.json
+++ b/scaffold/mcp/package.json
@@ -12,8 +12,10 @@
     "test": "npm run build --silent && node --test tests/*.test.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
     "@huggingface/transformers": "^4.1.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@types/js-yaml": "^4.0.9",
+    "js-yaml": "^4.1.1",
     "ryugraph": "^25.9.1",
     "zod": "^3.24.1"
   },

--- a/scaffold/mcp/package.json
+++ b/scaffold/mcp/package.json
@@ -16,6 +16,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/js-yaml": "^4.0.9",
     "js-yaml": "^4.1.1",
+    "minimatch": "^10.2.5",
     "ryugraph": "^25.9.1",
     "zod": "^3.24.1"
   },

--- a/scaffold/mcp/src/cli/stage.ts
+++ b/scaffold/mcp/src/cli/stage.ts
@@ -1,0 +1,325 @@
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import {
+  composeStageEnvelope,
+  createRun,
+  advanceStage,
+  getRunState,
+  type StageStatus,
+  type WorkflowDefinition,
+} from "../core/workflow/index.js";
+import { DEFAULT_WORKFLOWS } from "../core/workflow/default-workflows.js";
+
+/**
+ * `cortex stage` CLI surface. Each subcommand is a thin shell wrapper
+ * around the workflow primitives, mirroring the cortex.workflow.* MCP
+ * tools so shell scripts and CI can drive the harness without an MCP
+ * client.
+ *
+ * Subcommands:
+ *   start --task-id <id> --description "..." [--workflow <id>]
+ *   status --task-id <id>
+ *   envelope --task-id <id> [--stage <name>]
+ *   advance --task-id <id> --stage <name> --body-file <path>
+ *           [--frontmatter-file <path>] [--status <complete|blocked|failed>]
+ *   run --task-id <id> -- <command> [args...]
+ *     Sets CORTEX_ACTIVE_TASK_ID and execs the command. Use this to
+ *     spawn an agent that runs under the harness's pre-tool-use gate.
+ *
+ * All commands resolve cwd from CORTEX_PROJECT_ROOT (preferred) or
+ * process.cwd() so they work both inside an MCP server context and as
+ * standalone shell calls.
+ */
+
+export async function runStageCommand(args: string[]): Promise<void> {
+  const sub = args[0] ?? "help";
+  const rest = args.slice(1);
+
+  switch (sub) {
+    case "start":
+      return runStart(rest);
+    case "status":
+      return runStatus(rest);
+    case "envelope":
+      return runEnvelope(rest);
+    case "advance":
+      return runAdvance(rest);
+    case "run":
+      return runRun(rest);
+    case "help":
+    case "--help":
+    case "-h":
+      printHelp();
+      return;
+    default:
+      printHelp();
+      throw new Error(`Unknown stage subcommand: ${sub}`);
+  }
+}
+
+function printHelp(): void {
+  const lines = [
+    "Usage:",
+    "  cortex stage start    --task-id <id> --description \"...\" [--workflow <id>]",
+    "  cortex stage status   --task-id <id>",
+    "  cortex stage envelope --task-id <id> [--stage <name>]",
+    "  cortex stage advance  --task-id <id> --stage <name> --body-file <path>",
+    "                        [--frontmatter-file <path>] [--status <s>] [--outcome-file <path>]",
+    "  cortex stage run      --task-id <id> -- <command> [args...]",
+    "",
+    "Status values: complete (default) | blocked | failed",
+    "All commands operate on .agents/<task-id>/ in the current project root.",
+  ];
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+function projectRoot(): string {
+  return process.env.CORTEX_PROJECT_ROOT?.trim() || process.cwd();
+}
+
+function resolveWorkflow(workflowId: string): WorkflowDefinition {
+  const wf = DEFAULT_WORKFLOWS[workflowId];
+  if (!wf) {
+    throw new Error(
+      `Unknown workflow_id: ${workflowId}. Available: ${
+        Object.keys(DEFAULT_WORKFLOWS).join(", ") || "<none>"
+      }`,
+    );
+  }
+  return wf;
+}
+
+type Flags = Record<string, string | boolean>;
+
+function parseFlags(args: string[]): { flags: Flags; rest: string[] } {
+  const flags: Flags = {};
+  const rest: string[] = [];
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === "--") {
+      rest.push(...args.slice(i + 1));
+      break;
+    }
+    if (arg.startsWith("--")) {
+      const next = args[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        flags[arg.slice(2)] = true;
+        i += 1;
+      } else {
+        flags[arg.slice(2)] = next;
+        i += 2;
+      }
+      continue;
+    }
+    rest.push(arg);
+    i += 1;
+  }
+  return { flags, rest };
+}
+
+function requireFlag(flags: Flags, name: string): string {
+  const value = flags[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing required flag: --${name}`);
+  }
+  return value;
+}
+
+function emitJson(data: unknown): void {
+  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+}
+
+async function runStart(args: string[]): Promise<void> {
+  const { flags } = parseFlags(args);
+  const taskId = requireFlag(flags, "task-id");
+  const description = requireFlag(flags, "description");
+  const workflowId =
+    typeof flags.workflow === "string" ? flags.workflow : "secure-build";
+
+  const workflow = resolveWorkflow(workflowId);
+  const state = createRun({
+    cwd: projectRoot(),
+    taskId,
+    workflow,
+    taskDescription: description,
+  });
+  const envelope = composeStageEnvelope({
+    cwd: projectRoot(),
+    taskId,
+    workflow,
+  });
+  emitJson({ state, envelope });
+}
+
+async function runStatus(args: string[]): Promise<void> {
+  const { flags } = parseFlags(args);
+  const taskId = requireFlag(flags, "task-id");
+  const state = getRunState(projectRoot(), taskId);
+  emitJson({ state });
+}
+
+async function runEnvelope(args: string[]): Promise<void> {
+  const { flags } = parseFlags(args);
+  const taskId = requireFlag(flags, "task-id");
+  const stageName = typeof flags.stage === "string" ? flags.stage : undefined;
+
+  const state = getRunState(projectRoot(), taskId);
+  if (!state) {
+    throw new Error(
+      `No run state for task ${taskId}. Start one with 'cortex stage start'.`,
+    );
+  }
+  const workflow = resolveWorkflow(state.workflow_id);
+  const envelope = composeStageEnvelope({
+    cwd: projectRoot(),
+    taskId,
+    workflow,
+    stageName,
+  });
+  emitJson({ envelope });
+}
+
+async function runAdvance(args: string[]): Promise<void> {
+  const { flags } = parseFlags(args);
+  const taskId = requireFlag(flags, "task-id");
+  const stageName = requireFlag(flags, "stage");
+  const bodyPath = requireFlag(flags, "body-file");
+  const frontmatterPath =
+    typeof flags["frontmatter-file"] === "string"
+      ? flags["frontmatter-file"]
+      : null;
+  const outcomePath =
+    typeof flags["outcome-file"] === "string" ? flags["outcome-file"] : null;
+  const statusFlag =
+    typeof flags.status === "string" ? (flags.status as StageStatus) : undefined;
+
+  const body = readFileSync(bodyPath, "utf8");
+  const frontmatter: Record<string, unknown> = frontmatterPath
+    ? parseJsonObject(frontmatterPath)
+    : {};
+  const outcome = outcomePath ? parseJsonObject(outcomePath) : undefined;
+
+  const state = getRunState(projectRoot(), taskId);
+  if (!state) {
+    throw new Error(
+      `No run state for task ${taskId}. Start one with 'cortex stage start'.`,
+    );
+  }
+  const workflow = resolveWorkflow(state.workflow_id);
+  const stage = workflow.stages.find((s) => s.name === stageName);
+  if (!stage) {
+    throw new Error(
+      `Stage ${stageName} is not defined in workflow ${workflow.id}`,
+    );
+  }
+
+  const finalStatus: StageStatus = statusFlag ?? "complete";
+  const next = advanceStage({
+    cwd: projectRoot(),
+    taskId,
+    workflow,
+    stageName,
+    artifactName: stage.artifact,
+    frontmatter: {
+      ...frontmatter,
+      stage: stageName,
+      status: finalStatus,
+      references:
+        (Array.isArray((frontmatter as Record<string, unknown>).references)
+          ? ((frontmatter as Record<string, unknown>).references as unknown[])
+              .filter((v): v is string => typeof v === "string")
+          : null) ?? deriveReferencesFromReads(stage.reads, workflow),
+    },
+    body,
+    status: finalStatus,
+    outcome,
+  });
+
+  let nextEnvelope = null;
+  if (next.outcome === "in_progress" && next.current_stage) {
+    nextEnvelope = composeStageEnvelope({
+      cwd: projectRoot(),
+      taskId,
+      workflow,
+    });
+  }
+  emitJson({ state: next, next_envelope: nextEnvelope });
+}
+
+function parseJsonObject(filePath: string): Record<string, unknown> {
+  const raw = readFileSync(filePath, "utf8");
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse JSON in ${filePath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Expected JSON object in ${filePath}, got ${typeof value}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function deriveReferencesFromReads(
+  reads: string[],
+  workflow: WorkflowDefinition,
+): string[] {
+  const refs: string[] = [];
+  for (const readName of reads) {
+    const stage = workflow.stages.find((s) => s.name === readName);
+    if (stage) refs.push(stage.artifact);
+  }
+  return refs;
+}
+
+async function runRun(args: string[]): Promise<void> {
+  const { flags, rest } = parseFlags(args);
+  const taskId = requireFlag(flags, "task-id");
+  if (rest.length === 0) {
+    throw new Error(
+      "cortex stage run requires a command after --, e.g. 'cortex stage run --task-id task-1 -- claude'",
+    );
+  }
+
+  const state = getRunState(projectRoot(), taskId);
+  if (!state) {
+    throw new Error(
+      `No run state for task ${taskId}. Start one with 'cortex stage start'.`,
+    );
+  }
+  if (state.outcome !== "in_progress" || !state.current_stage) {
+    throw new Error(
+      `Run ${taskId} is not in progress (outcome=${state.outcome}). Cannot spawn agent.`,
+    );
+  }
+
+  const [command, ...commandArgs] = rest;
+
+  const child = spawn(command, commandArgs, {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      CORTEX_ACTIVE_TASK_ID: taskId,
+    },
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`spawned process terminated by signal ${signal}`));
+        return;
+      }
+      if (code !== 0) {
+        reject(new Error(`spawned process exited with code ${code}`));
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/scaffold/mcp/src/core/workflow/artifact-io.ts
+++ b/scaffold/mcp/src/core/workflow/artifact-io.ts
@@ -1,0 +1,156 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import * as yaml from "js-yaml";
+import {
+  runStateSchema,
+  stageArtifactFrontmatterSchema,
+  type RunState,
+  type StageArtifactFrontmatter,
+} from "./schemas.js";
+
+/**
+ * Filesystem layout for one workflow run:
+ *
+ *   <cwd>/.agents/<task-id>/
+ *     plan.md
+ *     review.md
+ *     ...
+ *     state.json
+ *
+ * All paths in this module are relative to the project's <cwd>. The caller
+ * is responsible for choosing cwd; we never assume process.cwd() here so
+ * tests can target a tmp directory.
+ */
+
+export const AGENTS_DIR = ".agents";
+export const STATE_FILENAME = "state.json";
+
+export function runDir(cwd: string, taskId: string): string {
+  return join(cwd, AGENTS_DIR, taskId);
+}
+
+export function stateFilePath(cwd: string, taskId: string): string {
+  return join(runDir(cwd, taskId), STATE_FILENAME);
+}
+
+export function artifactPath(
+  cwd: string,
+  taskId: string,
+  artifactName: string,
+): string {
+  return join(runDir(cwd, taskId), artifactName);
+}
+
+const FRONTMATTER_OPEN = /^---\s*\r?\n/;
+const FRONTMATTER_CLOSE = /\r?\n---\s*\r?\n/;
+
+export type ParsedArtifact = {
+  frontmatter: StageArtifactFrontmatter;
+  body: string;
+};
+
+export function parseStageArtifact(text: string): ParsedArtifact {
+  if (!FRONTMATTER_OPEN.test(text)) {
+    throw new Error("Stage artifact is missing YAML frontmatter (--- ... ---)");
+  }
+  const afterOpen = text.replace(FRONTMATTER_OPEN, "");
+  const closeMatch = afterOpen.match(FRONTMATTER_CLOSE);
+  if (!closeMatch || closeMatch.index === undefined) {
+    throw new Error("Stage artifact frontmatter is not terminated (--- ... ---)");
+  }
+  const yamlText = afterOpen.slice(0, closeMatch.index);
+  const body = afterOpen
+    .slice(closeMatch.index + closeMatch[0].length)
+    .replace(/^\s+/, "")
+    .replace(/\s+$/, "");
+
+  let raw: unknown;
+  try {
+    raw = yaml.load(yamlText);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse stage artifact frontmatter as YAML: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  const parsed = stageArtifactFrontmatterSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `Stage artifact frontmatter does not match schema: ${parsed.error.message}`,
+    );
+  }
+  return { frontmatter: parsed.data, body };
+}
+
+export function readStageArtifact(
+  cwd: string,
+  taskId: string,
+  artifactName: string,
+): ParsedArtifact {
+  const path = artifactPath(cwd, taskId, artifactName);
+  const text = readFileSync(path, "utf8");
+  return parseStageArtifact(text);
+}
+
+export function renderStageArtifact(
+  frontmatter: StageArtifactFrontmatter,
+  body: string,
+): string {
+  const yamlText = yaml.dump(frontmatter, {
+    lineWidth: 100,
+    noRefs: true,
+    sortKeys: false,
+  });
+  const trimmedBody = body.trim();
+  return `---\n${yamlText}---\n\n${trimmedBody}\n`;
+}
+
+export function writeStageArtifact(
+  cwd: string,
+  taskId: string,
+  artifactName: string,
+  frontmatter: StageArtifactFrontmatter,
+  body: string,
+): string {
+  const dir = runDir(cwd, taskId);
+  mkdirSync(dir, { recursive: true });
+  const path = artifactPath(cwd, taskId, artifactName);
+  writeFileSync(path, renderStageArtifact(frontmatter, body), "utf8");
+  return path;
+}
+
+export function readRunState(cwd: string, taskId: string): RunState | null {
+  const path = stateFilePath(cwd, taskId);
+  if (!existsSync(path)) return null;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new Error(
+      `Failed to parse run state at ${path}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  const parsed = runStateSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Run state at ${path} does not match schema: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+export function writeRunState(cwd: string, state: RunState): string {
+  const validated = runStateSchema.parse(state);
+  const dir = runDir(cwd, validated.task_id);
+  mkdirSync(dir, { recursive: true });
+  const path = stateFilePath(cwd, validated.task_id);
+  writeFileSync(path, JSON.stringify(validated, null, 2) + "\n", "utf8");
+  return path;
+}

--- a/scaffold/mcp/src/core/workflow/capabilities.ts
+++ b/scaffold/mcp/src/core/workflow/capabilities.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+
+/**
+ * Capability registry for the harness. A capability is a least-privilege
+ * profile referenced by a workflow stage's `capability` field. The
+ * pre-tool-use hook reads the active stage's capability and uses it to
+ * gate the agent's tool calls.
+ *
+ * The capability defines:
+ *   - read_globs    paths the agent may read (empty = no restriction)
+ *   - write_globs   paths the agent may modify (empty = read-only)
+ *   - tools_allowed which tool names the agent may call (empty = all)
+ *
+ * Glob patterns use minimatch syntax. The harness ships a default set
+ * keyed by the names referenced in default-workflows.ts; orgs can ship
+ * additional capabilities later via cortex-web sync.
+ */
+
+const slugSchema = z
+  .string()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+
+export const capabilityDefinitionSchema = z.object({
+  name: slugSchema,
+  description: z.string().min(1).max(500),
+  read_globs: z.array(z.string().min(1)).default([]),
+  write_globs: z.array(z.string().min(1)).default([]),
+  tools_allowed: z.array(z.string().min(1)).default([]),
+});
+
+export type CapabilityDefinition = z.infer<typeof capabilityDefinitionSchema>;
+
+/**
+ * Default capability profiles that ship with Cortex. Names match the
+ * `capability` fields referenced by SECURE_BUILD_WORKFLOW.
+ *
+ * tools_allowed is intentionally empty for most profiles to mean
+ * "no per-tool restriction beyond what the file globs already imply".
+ * The hook layer checks file paths first, tool name second.
+ */
+export const DEFAULT_CAPABILITIES: Record<string, CapabilityDefinition> = {
+  planner: {
+    name: "planner",
+    description:
+      "Read-only profile for stages that produce planning artifacts. " +
+      "Can read the whole repo and call context tools, cannot modify any files.",
+    read_globs: ["**"],
+    write_globs: [],
+    tools_allowed: [],
+  },
+  reviewer: {
+    name: "reviewer",
+    description:
+      "Read-only profile for review stages. Same access as planner; the " +
+      "review artifact itself is written by the harness, not by an Edit tool.",
+    read_globs: ["**"],
+    write_globs: [],
+    tools_allowed: [],
+  },
+  builder: {
+    name: "builder",
+    description:
+      "Build profile. May edit source and test files but not config, " +
+      "lockfiles, CI workflows, or anything outside the obvious app surface.",
+    read_globs: ["**"],
+    write_globs: ["src/**", "tests/**", "test/**", "lib/**", "app/**", "components/**"],
+    tools_allowed: [],
+  },
+  tester: {
+    name: "tester",
+    description:
+      "Mutation/test profile. Read-only on production code, may edit only " +
+      "test files. Used by mutation-testing or coverage-improvement stages.",
+    read_globs: ["**"],
+    write_globs: ["tests/**", "test/**", "**/*.test.ts", "**/*.test.tsx", "**/*.test.mjs", "**/*.spec.ts"],
+    tools_allowed: [],
+  },
+  "security-reviewer": {
+    name: "security-reviewer",
+    description:
+      "Security review profile. Read-only across the repo. Produces a " +
+      "report artifact; no source modifications allowed.",
+    read_globs: ["**"],
+    write_globs: [],
+    tools_allowed: [],
+  },
+  human: {
+    name: "human",
+    description:
+      "Sentinel capability for human approval stages. The harness does not " +
+      "invoke an agent for this stage; the human writes the artifact directly. " +
+      "If a tool call somehow reaches the hook under this capability, it is " +
+      "blocked because no automation should be running.",
+    read_globs: [],
+    write_globs: [],
+    tools_allowed: [],
+  },
+};

--- a/scaffold/mcp/src/core/workflow/default-workflows.ts
+++ b/scaffold/mcp/src/core/workflow/default-workflows.ts
@@ -1,0 +1,83 @@
+import type { WorkflowDefinition } from "./schemas.js";
+
+/**
+ * The default secure-build workflow that ships with Cortex. Organizations
+ * can override this from cortex-web later (Phase 2 of the harness rollout);
+ * until then this is the workflow every project gets out of the box.
+ */
+export const SECURE_BUILD_WORKFLOW: WorkflowDefinition = {
+  id: "secure-build",
+  description:
+    "Plan → Review → Build → Review → Mutation Tests → Security Review → Human Approval. " +
+    "The default Cortex Harness workflow for AI-driven development on production code.",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: ["files_targeted", "constraints"],
+      capability: "planner",
+      description:
+        "Produce a step-by-step implementation plan grounded in the repo's rules and memory.",
+    },
+    {
+      name: "plan-review",
+      artifact: "plan-review.md",
+      reads: ["plan"],
+      required_fields: ["approved", "blocking_comments"],
+      capability: "reviewer",
+      description:
+        "Review the plan for architectural fit and rule compliance before any code is written.",
+    },
+    {
+      name: "build",
+      artifact: "changes.md",
+      reads: ["plan", "plan-review"],
+      required_fields: ["files_changed"],
+      capability: "builder",
+      description:
+        "Implement the approved plan. Produces the diff manifest used by the downstream reviewers.",
+    },
+    {
+      name: "build-review",
+      artifact: "build-review.md",
+      reads: ["plan", "changes"],
+      required_fields: ["approved", "blocking_comments"],
+      capability: "reviewer",
+      description:
+        "Review the implementation against the plan and the project's rules.",
+    },
+    {
+      name: "mutation",
+      artifact: "mutation-report.md",
+      reads: ["changes"],
+      required_fields: ["score", "survived"],
+      capability: "tester",
+      description:
+        "Run mutation tests on the changed files. Report score + surviving mutants.",
+    },
+    {
+      name: "security",
+      artifact: "security-report.md",
+      reads: ["changes"],
+      required_fields: ["findings", "severity_summary"],
+      capability: "security-reviewer",
+      description:
+        "Security review focused on the diff: injection, authn/authz, secrets, dependency risk.",
+    },
+    {
+      name: "approval",
+      artifact: "approval.md",
+      reads: ["plan", "changes", "build-review", "mutation", "security"],
+      required_fields: ["approved", "approver"],
+      capability: "human",
+      description:
+        "Human sign-off. Pulls every prior artifact for the approver to read; the approver writes the artifact.",
+    },
+  ],
+};
+
+export const DEFAULT_WORKFLOWS: Record<string, WorkflowDefinition> = {
+  [SECURE_BUILD_WORKFLOW.id]: SECURE_BUILD_WORKFLOW,
+};

--- a/scaffold/mcp/src/core/workflow/enforcement.ts
+++ b/scaffold/mcp/src/core/workflow/enforcement.ts
@@ -1,0 +1,206 @@
+import { isAbsolute, relative } from "node:path";
+import { minimatch } from "minimatch";
+import { readRunState } from "./artifact-io.js";
+import { DEFAULT_CAPABILITIES, type CapabilityDefinition } from "./capabilities.js";
+import { workflowDefinitionSchema, type WorkflowDefinition } from "./schemas.js";
+import { DEFAULT_WORKFLOWS } from "./default-workflows.js";
+
+/**
+ * Pre-tool-use enforcement for the harness. Pure function: takes the tool
+ * call shape Claude Code emits, looks up the active workflow stage's
+ * capability, returns allow/deny + reason. The hook wires this into the
+ * stdin/exit-code dance.
+ *
+ * "Active task" is identified by env var CORTEX_ACTIVE_TASK_ID. The
+ * harness sets this when invoking an agent for a stage; outside the
+ * harness, the env var is unset and this evaluator is a no-op (returns
+ * { allowed: true }).
+ */
+
+export type ToolCall = {
+  toolName: string;
+  toolInput: Record<string, unknown>;
+};
+
+export type EnforcementResult =
+  | { allowed: true; reason?: string }
+  | { allowed: false; reason: string };
+
+export type EvaluateOptions = {
+  cwd: string;
+  taskId: string;
+  call: ToolCall;
+  workflows?: Record<string, WorkflowDefinition>;
+  capabilities?: Record<string, CapabilityDefinition>;
+};
+
+/**
+ * Tool names that are pure mutations of the file system. Edits and writes
+ * gate against `write_globs`. Bash is treated as a mutation by default
+ * because we cannot reliably extract paths from arbitrary shell — agents
+ * running in restricted-write capabilities lose Bash unless the
+ * capability explicitly allow-lists it.
+ */
+const MUTATING_TOOLS = new Set(["Edit", "Write", "MultiEdit", "NotebookEdit"]);
+
+/**
+ * Tool names that read but do not mutate. Gate against `read_globs`.
+ */
+const READING_TOOLS = new Set(["Read", "Grep", "Glob", "NotebookRead"]);
+
+export function evaluateToolCall(options: EvaluateOptions): EnforcementResult {
+  const state = readRunState(options.cwd, options.taskId);
+  if (!state) {
+    return { allowed: true, reason: "no run state — harness not active" };
+  }
+  if (state.outcome !== "in_progress" || !state.current_stage) {
+    return {
+      allowed: true,
+      reason: `run not in progress (outcome=${state.outcome}) — no capability gate to apply`,
+    };
+  }
+
+  const workflows = options.workflows ?? DEFAULT_WORKFLOWS;
+  const workflow = workflows[state.workflow_id];
+  if (!workflow) {
+    return {
+      allowed: false,
+      reason: `unknown workflow_id ${state.workflow_id}; cannot resolve capability for current stage`,
+    };
+  }
+  // Validate so corrupt input doesn't slip through.
+  workflowDefinitionSchema.parse(workflow);
+
+  const stage = workflow.stages.find((s) => s.name === state.current_stage);
+  if (!stage) {
+    return {
+      allowed: false,
+      reason: `current stage ${state.current_stage} is not defined in workflow ${workflow.id}`,
+    };
+  }
+
+  if (!stage.capability) {
+    return { allowed: true, reason: "stage has no capability declared" };
+  }
+
+  const capabilities = options.capabilities ?? DEFAULT_CAPABILITIES;
+  const capability = capabilities[stage.capability];
+  if (!capability) {
+    return {
+      allowed: false,
+      reason: `capability ${stage.capability} (referenced by stage ${stage.name}) is not in the registry`,
+    };
+  }
+
+  return evaluateAgainstCapability(capability, options.call, options.cwd);
+}
+
+function evaluateAgainstCapability(
+  capability: CapabilityDefinition,
+  call: ToolCall,
+  cwd: string,
+): EnforcementResult {
+  // 1. tools_allowed: empty = no restriction; otherwise tool must be in the list.
+  if (
+    capability.tools_allowed.length > 0 &&
+    !capability.tools_allowed.includes(call.toolName)
+  ) {
+    return {
+      allowed: false,
+      reason: `capability ${capability.name} does not allow tool ${call.toolName}`,
+    };
+  }
+
+  const isMutation = MUTATING_TOOLS.has(call.toolName);
+  const isRead = READING_TOOLS.has(call.toolName);
+
+  // Bash is special: with restricted write_globs we have to assume the
+  // worst (since the shell can write anywhere). Block unless capability
+  // explicitly allow-lists Bash via tools_allowed.
+  if (call.toolName === "Bash") {
+    const isAllowedViaToolList = capability.tools_allowed.includes("Bash");
+    const writesUnrestricted = capability.write_globs.length === 0;
+    if (writesUnrestricted && !isAllowedViaToolList) {
+      return {
+        allowed: false,
+        reason: `capability ${capability.name} is read-only; Bash can mutate the filesystem and is not allow-listed`,
+      };
+    }
+    return { allowed: true };
+  }
+
+  if (isMutation) {
+    if (capability.write_globs.length === 0) {
+      return {
+        allowed: false,
+        reason: `capability ${capability.name} is read-only; ${call.toolName} cannot run`,
+      };
+    }
+    const targetPath = extractFilePath(call.toolInput);
+    if (!targetPath) {
+      return {
+        allowed: false,
+        reason: `${call.toolName} did not include a file_path; cannot verify against capability ${capability.name}`,
+      };
+    }
+    const relPath = toRepoRelative(cwd, targetPath);
+    if (!matchesAnyGlob(relPath, capability.write_globs)) {
+      return {
+        allowed: false,
+        reason: `path ${relPath} is outside capability ${capability.name}'s write_globs (${capability.write_globs.join(", ")})`,
+      };
+    }
+    return { allowed: true };
+  }
+
+  if (isRead) {
+    if (capability.read_globs.length === 0) {
+      // No reads allowed at all — only the human capability lands here.
+      return {
+        allowed: false,
+        reason: `capability ${capability.name} does not permit any read operations`,
+      };
+    }
+    const targetPath = extractFilePath(call.toolInput);
+    if (!targetPath) {
+      // Some read tools (Grep, Glob) operate on the whole repo; allow
+      // through if the capability has any read access at all.
+      return { allowed: true };
+    }
+    const relPath = toRepoRelative(cwd, targetPath);
+    if (!matchesAnyGlob(relPath, capability.read_globs)) {
+      return {
+        allowed: false,
+        reason: `path ${relPath} is outside capability ${capability.name}'s read_globs (${capability.read_globs.join(", ")})`,
+      };
+    }
+    return { allowed: true };
+  }
+
+  // Unknown tool — fall through to allow if not explicitly restricted.
+  return { allowed: true };
+}
+
+function extractFilePath(toolInput: Record<string, unknown>): string | null {
+  const candidates = ["file_path", "path", "notebook_path"];
+  for (const key of candidates) {
+    const value = toolInput[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return null;
+}
+
+function toRepoRelative(cwd: string, targetPath: string): string {
+  if (!isAbsolute(targetPath)) return targetPath;
+  const rel = relative(cwd, targetPath);
+  // If the path is outside the repo, return the absolute form so glob
+  // matches (which expect repo-relative) reliably miss.
+  if (rel.startsWith("..")) return targetPath;
+  return rel;
+}
+
+function matchesAnyGlob(path: string, globs: string[]): boolean {
+  return globs.some((pattern) =>
+    minimatch(path, pattern, { dot: true, nocase: false }),
+  );
+}

--- a/scaffold/mcp/src/core/workflow/envelope.ts
+++ b/scaffold/mcp/src/core/workflow/envelope.ts
@@ -1,0 +1,220 @@
+import { readFileSync } from "node:fs";
+import { artifactPath, readRunState } from "./artifact-io.js";
+import { workflowDefinitionSchema, type WorkflowDefinition } from "./schemas.js";
+
+/**
+ * Composes the prompt one stage's agent sees. Pure function over the
+ * persisted run state plus the workflow definition — no agent invocation,
+ * no MCP, no daemon. The harness later wraps this into an MCP call or a
+ * CLI invocation.
+ *
+ * Design: the agent gets four sections in a fixed order so it can anchor
+ * on them reliably:
+ *
+ *   TASK     — what the developer asked for, copied verbatim from RunState
+ *   STAGE    — what *this* stage is supposed to produce
+ *   HANDOFFS — every prior-stage artifact the new stage declared in `reads`,
+ *              inlined raw (frontmatter + body) so the agent sees structured
+ *              outcomes alongside the reasoning
+ *   OUTPUT   — exact frontmatter contract the agent must satisfy plus the
+ *              expected artifact filename
+ *
+ * Capability constraints (which files the agent may edit, which tools it
+ * may call) are NOT enforced by the prompt — they're enforced by hooks
+ * downstream. The capability key is surfaced in the prompt as a label so
+ * the agent knows under what role it's running, but the real gate is
+ * pre-tool-use.
+ */
+
+export type ComposedEnvelope = {
+  /** The full prompt the agent will receive. */
+  prompt: string;
+  /** Expected artifact filename the agent must produce. */
+  expectedArtifact: string;
+  /** Frontmatter keys the agent must populate (beyond stage/status/references). */
+  requiredFields: string[];
+  /** Capability key the stage runs under (informational). */
+  capability: string | null;
+};
+
+export type ComposeStageEnvelopeOptions = {
+  cwd: string;
+  taskId: string;
+  workflow: WorkflowDefinition;
+  /**
+   * Defaults to the run's current_stage. Pass an explicit stageName when
+   * dry-running an envelope without driving state forward.
+   */
+  stageName?: string;
+};
+
+export function composeStageEnvelope(
+  options: ComposeStageEnvelopeOptions,
+): ComposedEnvelope {
+  const workflow = workflowDefinitionSchema.parse(options.workflow);
+  const state = readRunState(options.cwd, options.taskId);
+  if (!state) {
+    throw new Error(
+      `No run state found for task ${options.taskId}. Call createRun() first.`,
+    );
+  }
+  if (state.workflow_id !== workflow.id) {
+    throw new Error(
+      `Workflow mismatch: run was started with ${state.workflow_id}, envelope was composed with ${workflow.id}`,
+    );
+  }
+
+  const stageName = options.stageName ?? state.current_stage;
+  if (!stageName) {
+    throw new Error(
+      `Run ${options.taskId} is not at any stage (outcome=${state.outcome}). Cannot compose envelope.`,
+    );
+  }
+  const stage = workflow.stages.find((s) => s.name === stageName);
+  if (!stage) {
+    throw new Error(
+      `Stage ${stageName} is not defined in workflow ${workflow.id}`,
+    );
+  }
+
+  const handoffs: string[] = [];
+  for (const readName of stage.reads) {
+    const priorStage = workflow.stages.find((s) => s.name === readName);
+    if (!priorStage) {
+      throw new Error(
+        `Stage ${stageName} declares reads from unknown stage ${readName}`,
+      );
+    }
+    const priorRecord = state.stages.find((r) => r.name === readName);
+    if (!priorRecord || priorRecord.status === "pending" || !priorRecord.artifact) {
+      throw new Error(
+        `Stage ${stageName} requires artifact from ${readName}, but it has not been produced yet`,
+      );
+    }
+    const path = artifactPath(options.cwd, options.taskId, priorRecord.artifact);
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf8");
+    } catch (err) {
+      throw new Error(
+        `Failed to read handoff artifact for ${readName} at ${path}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    handoffs.push(renderHandoff(readName, priorRecord.artifact, raw));
+  }
+
+  const requiredFields = stage.required_fields;
+  const capability = stage.capability ?? null;
+
+  const prompt = renderPrompt({
+    taskDescription: state.task_description,
+    workflowId: workflow.id,
+    workflowDescription: workflow.description,
+    stageName: stage.name,
+    stageDescription: stage.description,
+    expectedArtifact: stage.artifact,
+    requiredFields,
+    capability,
+    handoffs,
+  });
+
+  return {
+    prompt,
+    expectedArtifact: stage.artifact,
+    requiredFields,
+    capability,
+  };
+}
+
+function renderHandoff(
+  stageName: string,
+  artifactName: string,
+  rawArtifact: string,
+): string {
+  return [
+    `--- handoff:${stageName} (${artifactName}) ---`,
+    rawArtifact.trim(),
+    `--- end handoff:${stageName} ---`,
+  ].join("\n");
+}
+
+type RenderPromptOptions = {
+  taskDescription: string;
+  workflowId: string;
+  workflowDescription: string;
+  stageName: string;
+  stageDescription: string;
+  expectedArtifact: string;
+  requiredFields: string[];
+  capability: string | null;
+  handoffs: string[];
+};
+
+function renderPrompt(o: RenderPromptOptions): string {
+  const sections: string[] = [];
+
+  sections.push(
+    [
+      `# TASK`,
+      ``,
+      o.taskDescription.trim(),
+      ``,
+      `Workflow: ${o.workflowId} — ${o.workflowDescription}`,
+    ].join("\n"),
+  );
+
+  sections.push(
+    [
+      `# STAGE: ${o.stageName}`,
+      ``,
+      o.stageDescription.trim(),
+      ``,
+      o.capability
+        ? `Running under capability: \`${o.capability}\` (file and tool restrictions are enforced by Cortex hooks at tool-use time, not by you).`
+        : `No capability constraint declared for this stage.`,
+    ].join("\n"),
+  );
+
+  if (o.handoffs.length === 0) {
+    sections.push(
+      [`# HANDOFFS`, ``, `_No prior-stage artifacts; this is the first stage._`].join(
+        "\n",
+      ),
+    );
+  } else {
+    sections.push(
+      [
+        `# HANDOFFS`,
+        ``,
+        `The following stages have already run. Each artifact below is the complete file as it lives on disk; use the frontmatter for structured outcomes and the body for reasoning.`,
+        ``,
+        ...o.handoffs,
+      ].join("\n"),
+    );
+  }
+
+  const requiredLines =
+    o.requiredFields.length === 0
+      ? `_No additional required fields beyond the harness defaults._`
+      : o.requiredFields.map((f) => `- \`${f}\``).join("\n");
+
+  sections.push(
+    [
+      `# OUTPUT`,
+      ``,
+      `Produce a single markdown file named \`${o.expectedArtifact}\` with YAML frontmatter on top.`,
+      ``,
+      `Required frontmatter fields (in addition to \`stage\`, \`status\`, \`references\`, \`written_at\` which the harness manages):`,
+      ``,
+      requiredLines,
+      ``,
+      `Body: clear, well-structured markdown explaining your reasoning. Cite handoff artifacts by stage name when relevant.`,
+      ``,
+      `If you cannot complete this stage (missing context, blocking concern, conflicting prior decisions), set \`status: blocked\` in frontmatter and explain why in the body — do not fabricate work.`,
+    ].join("\n"),
+  );
+
+  return sections.join("\n\n");
+}

--- a/scaffold/mcp/src/core/workflow/index.ts
+++ b/scaffold/mcp/src/core/workflow/index.ts
@@ -1,0 +1,4 @@
+export * from "./schemas.js";
+export * from "./artifact-io.js";
+export * from "./run-lifecycle.js";
+export * from "./default-workflows.js";

--- a/scaffold/mcp/src/core/workflow/index.ts
+++ b/scaffold/mcp/src/core/workflow/index.ts
@@ -3,3 +3,4 @@ export * from "./artifact-io.js";
 export * from "./run-lifecycle.js";
 export * from "./envelope.js";
 export * from "./default-workflows.js";
+export * from "./mcp-tools.js";

--- a/scaffold/mcp/src/core/workflow/index.ts
+++ b/scaffold/mcp/src/core/workflow/index.ts
@@ -4,3 +4,5 @@ export * from "./run-lifecycle.js";
 export * from "./envelope.js";
 export * from "./default-workflows.js";
 export * from "./mcp-tools.js";
+export * from "./capabilities.js";
+export * from "./enforcement.js";

--- a/scaffold/mcp/src/core/workflow/index.ts
+++ b/scaffold/mcp/src/core/workflow/index.ts
@@ -1,4 +1,5 @@
 export * from "./schemas.js";
 export * from "./artifact-io.js";
 export * from "./run-lifecycle.js";
+export * from "./envelope.js";
 export * from "./default-workflows.js";

--- a/scaffold/mcp/src/core/workflow/mcp-tools.ts
+++ b/scaffold/mcp/src/core/workflow/mcp-tools.ts
@@ -1,0 +1,208 @@
+import { z } from "zod";
+import { advanceStage, createRun, getRunState } from "./run-lifecycle.js";
+import { composeStageEnvelope } from "./envelope.js";
+import { DEFAULT_WORKFLOWS } from "./default-workflows.js";
+import {
+  stageStatusSchema,
+  type StageStatus,
+  type WorkflowDefinition,
+} from "./schemas.js";
+
+/**
+ * Pure runner functions that back the cortex.workflow.* MCP tools.
+ * Kept separate from server.ts so they can be unit-tested without spinning
+ * up an MCP server. server.ts is a thin shim that registers each runner
+ * under its tool name and serializes the result through buildToolResult.
+ */
+
+const slugSchema = z
+  .string()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+
+export const WorkflowStartInput = z.object({
+  task_id: slugSchema,
+  task_description: z.string().min(1).max(2000),
+  workflow_id: slugSchema.default("secure-build"),
+});
+export type WorkflowStartInputT = z.infer<typeof WorkflowStartInput>;
+
+export const WorkflowAdvanceInput = z.object({
+  task_id: slugSchema,
+  /** Required for safety: must equal the run's current_stage. */
+  stage: slugSchema,
+  /**
+   * Stage frontmatter as a free-form object. Stage / status / references /
+   * written_at are managed by the harness and may be omitted (or, if set,
+   * are overridden). Stage-specific fields like `approved` or `score` are
+   * passed through.
+   */
+  frontmatter: z.record(z.string(), z.unknown()).default({}),
+  body: z.string().min(1),
+  /** Final stage status. Defaults to "complete". Use "blocked" or "failed" to halt the run. */
+  status: stageStatusSchema.optional(),
+  /** Optional structured outcome surfaced into state.json for fast lookup by later stages. */
+  outcome: z.record(z.string(), z.unknown()).optional(),
+});
+export type WorkflowAdvanceInputT = z.infer<typeof WorkflowAdvanceInput>;
+
+export const WorkflowStatusInput = z.object({
+  task_id: slugSchema,
+});
+export type WorkflowStatusInputT = z.infer<typeof WorkflowStatusInput>;
+
+export const WorkflowEnvelopeInput = z.object({
+  task_id: slugSchema,
+  /** Defaults to the run's current stage. */
+  stage: slugSchema.optional(),
+});
+export type WorkflowEnvelopeInputT = z.infer<typeof WorkflowEnvelopeInput>;
+
+/**
+ * Resolves the project root. The MCP server is started with cwd =
+ * project root and CORTEX_PROJECT_ROOT set to the same value (see
+ * bin/cortex.mjs `mcp` command). Tests pass cwd explicitly.
+ */
+export function resolveProjectRoot(): string {
+  const fromEnv = process.env.CORTEX_PROJECT_ROOT?.trim();
+  if (fromEnv) return fromEnv;
+  return process.cwd();
+}
+
+export type WorkflowToolContext = {
+  cwd: string;
+  workflows?: Record<string, WorkflowDefinition>;
+};
+
+function resolveWorkflow(
+  workflowId: string,
+  registry: Record<string, WorkflowDefinition> | undefined,
+): WorkflowDefinition {
+  const workflows = registry ?? DEFAULT_WORKFLOWS;
+  const workflow = workflows[workflowId];
+  if (!workflow) {
+    throw new Error(
+      `Unknown workflow_id: ${workflowId}. Available: ${Object.keys(workflows).join(", ") || "<none>"}`,
+    );
+  }
+  return workflow;
+}
+
+export function runWorkflowStart(
+  input: WorkflowStartInputT,
+  ctx: WorkflowToolContext,
+) {
+  const workflow = resolveWorkflow(input.workflow_id, ctx.workflows);
+  const state = createRun({
+    cwd: ctx.cwd,
+    taskId: input.task_id,
+    workflow,
+    taskDescription: input.task_description,
+  });
+  const envelope = composeStageEnvelope({
+    cwd: ctx.cwd,
+    taskId: input.task_id,
+    workflow,
+  });
+  return {
+    state,
+    envelope,
+  };
+}
+
+export function runWorkflowAdvance(
+  input: WorkflowAdvanceInputT,
+  ctx: WorkflowToolContext,
+) {
+  const state = getRunState(ctx.cwd, input.task_id);
+  if (!state) {
+    throw new Error(
+      `No run state found for task ${input.task_id}. Call cortex.workflow.start first.`,
+    );
+  }
+  const workflow = resolveWorkflow(state.workflow_id, ctx.workflows);
+  const stage = workflow.stages.find((s) => s.name === input.stage);
+  if (!stage) {
+    throw new Error(`Stage ${input.stage} is not defined in workflow ${workflow.id}`);
+  }
+
+  const finalStatus: StageStatus = input.status ?? "complete";
+
+  const nextState = advanceStage({
+    cwd: ctx.cwd,
+    taskId: input.task_id,
+    workflow,
+    stageName: input.stage,
+    artifactName: stage.artifact,
+    frontmatter: {
+      ...input.frontmatter,
+      stage: input.stage,
+      status: finalStatus,
+      references:
+        (Array.isArray((input.frontmatter as Record<string, unknown>).references)
+          ? ((input.frontmatter as Record<string, unknown>).references as unknown[])
+              .filter((v): v is string => typeof v === "string")
+          : null) ?? deriveReferencesFromReads(stage.reads, workflow),
+    },
+    body: input.body,
+    outcome: input.outcome,
+    status: finalStatus,
+  });
+
+  // If the run is still going, also return the next envelope so the caller
+  // can immediately know what comes next without a follow-up status round-trip.
+  let nextEnvelope: ReturnType<typeof composeStageEnvelope> | null = null;
+  if (nextState.outcome === "in_progress" && nextState.current_stage) {
+    nextEnvelope = composeStageEnvelope({
+      cwd: ctx.cwd,
+      taskId: input.task_id,
+      workflow,
+    });
+  }
+
+  return {
+    state: nextState,
+    next_envelope: nextEnvelope,
+  };
+}
+
+function deriveReferencesFromReads(
+  reads: string[],
+  workflow: WorkflowDefinition,
+): string[] {
+  const refs: string[] = [];
+  for (const readName of reads) {
+    const stage = workflow.stages.find((s) => s.name === readName);
+    if (stage) refs.push(stage.artifact);
+  }
+  return refs;
+}
+
+export function runWorkflowStatus(
+  input: WorkflowStatusInputT,
+  ctx: WorkflowToolContext,
+) {
+  const state = getRunState(ctx.cwd, input.task_id);
+  return { state };
+}
+
+export function runWorkflowEnvelope(
+  input: WorkflowEnvelopeInputT,
+  ctx: WorkflowToolContext,
+) {
+  const state = getRunState(ctx.cwd, input.task_id);
+  if (!state) {
+    throw new Error(
+      `No run state found for task ${input.task_id}. Call cortex.workflow.start first.`,
+    );
+  }
+  const workflow = resolveWorkflow(state.workflow_id, ctx.workflows);
+  const envelope = composeStageEnvelope({
+    cwd: ctx.cwd,
+    taskId: input.task_id,
+    workflow,
+    stageName: input.stage,
+  });
+  return { envelope };
+}

--- a/scaffold/mcp/src/core/workflow/run-lifecycle.ts
+++ b/scaffold/mcp/src/core/workflow/run-lifecycle.ts
@@ -1,0 +1,165 @@
+import {
+  readRunState,
+  writeRunState,
+  writeStageArtifact,
+} from "./artifact-io.js";
+import {
+  runStateSchema,
+  stageArtifactFrontmatterSchema,
+  workflowDefinitionSchema,
+  type RunState,
+  type StageRecord,
+  type StageStatus,
+  type WorkflowDefinition,
+} from "./schemas.js";
+
+/**
+ * Lifecycle helpers for one workflow run. The harness composes envelopes
+ * and invokes agents elsewhere; these primitives only manipulate the
+ * persisted state under .agents/<task-id>/. Pure functions on top of
+ * artifact-io.ts so unit tests can hit them without spawning agents.
+ */
+
+export type CreateRunOptions = {
+  cwd: string;
+  taskId: string;
+  workflow: WorkflowDefinition;
+  taskDescription: string;
+  now?: () => Date;
+};
+
+export function createRun(options: CreateRunOptions): RunState {
+  const workflow = workflowDefinitionSchema.parse(options.workflow);
+  const now = (options.now ?? (() => new Date()))();
+  const startedAt = now.toISOString();
+
+  const stages: StageRecord[] = workflow.stages.map((stage) => ({
+    name: stage.name,
+    status: "pending" as StageStatus,
+  }));
+
+  const state: RunState = {
+    schema_version: 1,
+    task_id: options.taskId,
+    workflow_id: workflow.id,
+    workflow_version: workflow.version,
+    task_description: options.taskDescription,
+    current_stage: workflow.stages[0].name,
+    outcome: "in_progress",
+    started_at: startedAt,
+    completed_at: null,
+    stages,
+  };
+
+  // Validate before write so a malformed input never reaches disk.
+  const validated = runStateSchema.parse(state);
+  writeRunState(options.cwd, validated);
+  return validated;
+}
+
+export function getRunState(cwd: string, taskId: string): RunState | null {
+  return readRunState(cwd, taskId);
+}
+
+export type AdvanceStageOptions = {
+  cwd: string;
+  taskId: string;
+  workflow: WorkflowDefinition;
+  /** The stage we just finished. Must equal state.current_stage. */
+  stageName: string;
+  /** Filename of the artifact to write (e.g. "plan.md"). */
+  artifactName: string;
+  /** Frontmatter for the artifact, minus the auto-injected `written_at`. */
+  frontmatter: Omit<
+    import("./schemas.js").StageArtifactFrontmatter,
+    "written_at"
+  > & { written_at?: string };
+  /** Markdown body of the artifact. */
+  body: string;
+  /** Per-stage outcome surfaced into state.json for fast lookup. */
+  outcome?: Record<string, unknown>;
+  /** Final status to record for this stage. Defaults to "complete". */
+  status?: StageStatus;
+  now?: () => Date;
+};
+
+/**
+ * Marks `stageName` as finished, writes its artifact under .agents/<task-id>/,
+ * and advances `current_stage` to the next stage (or marks the run complete
+ * if this was the final stage). Idempotent only at the artifact layer —
+ * calling twice for the same stage will overwrite the artifact and the
+ * state.json record.
+ */
+export function advanceStage(options: AdvanceStageOptions): RunState {
+  const workflow = workflowDefinitionSchema.parse(options.workflow);
+  const state = readRunState(options.cwd, options.taskId);
+  if (!state) {
+    throw new Error(
+      `No run state found for task ${options.taskId}. Call createRun() first.`,
+    );
+  }
+  if (state.workflow_id !== workflow.id) {
+    throw new Error(
+      `Workflow mismatch: run was started with ${state.workflow_id}, advance was called with ${workflow.id}`,
+    );
+  }
+  if (state.current_stage !== options.stageName) {
+    throw new Error(
+      `Cannot advance stage ${options.stageName}: run is currently at ${
+        state.current_stage ?? "<finished>"
+      }`,
+    );
+  }
+
+  const now = (options.now ?? (() => new Date()))();
+  const completedAt = now.toISOString();
+
+  const frontmatter = stageArtifactFrontmatterSchema.parse({
+    ...options.frontmatter,
+    stage: options.stageName,
+    written_at: options.frontmatter.written_at ?? completedAt,
+  });
+  writeStageArtifact(
+    options.cwd,
+    options.taskId,
+    options.artifactName,
+    frontmatter,
+    options.body,
+  );
+
+  const stageIndex = workflow.stages.findIndex((s) => s.name === options.stageName);
+  const nextStage = workflow.stages[stageIndex + 1] ?? null;
+  const finalStatus = options.status ?? "complete";
+
+  const updatedStages: StageRecord[] = state.stages.map((record) => {
+    if (record.name !== options.stageName) return record;
+    return {
+      ...record,
+      status: finalStatus,
+      artifact: options.artifactName,
+      started_at: record.started_at ?? state.started_at,
+      completed_at: completedAt,
+      outcome: options.outcome,
+    };
+  });
+
+  const runOutcome: RunState["outcome"] =
+    finalStatus === "blocked" || finalStatus === "failed"
+      ? finalStatus
+      : nextStage
+        ? "in_progress"
+        : "complete";
+
+  const next: RunState = {
+    ...state,
+    current_stage:
+      runOutcome === "in_progress" && nextStage ? nextStage.name : null,
+    outcome: runOutcome,
+    completed_at: runOutcome === "in_progress" ? null : completedAt,
+    stages: updatedStages,
+  };
+
+  const validated = runStateSchema.parse(next);
+  writeRunState(options.cwd, validated);
+  return validated;
+}

--- a/scaffold/mcp/src/core/workflow/schemas.ts
+++ b/scaffold/mcp/src/core/workflow/schemas.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+
+/**
+ * Schemas for the Cortex Harness workflow engine.
+ *
+ * See docs/harness-vision.md for the design. In short:
+ *
+ *   .agents/<task-id>/
+ *     plan.md            # frontmatter + body
+ *     review.md
+ *     changes.md
+ *     mutation-report.md
+ *     security-report.md
+ *     state.json         # current run state
+ *
+ * All artifacts are markdown with YAML frontmatter; state.json is the only
+ * JSON file. Both are tracked in git so a PR carries the evidence trail.
+ */
+
+const slugSchema = z
+  .string()
+  .min(1)
+  .max(80)
+  .regex(
+    /^[a-z0-9][a-z0-9-]*[a-z0-9]$/,
+    "Must be lowercase alphanumeric with hyphens (no leading/trailing hyphen)",
+  );
+
+/**
+ * Static definition of a single stage in a workflow. Authored at the
+ * organization level (in cortex-web later) and synced down to projects.
+ */
+export const stageDefinitionSchema = z.object({
+  name: slugSchema,
+  artifact: z.string().min(1).regex(/^[a-z0-9][a-z0-9-]*\.md$/),
+  /** Stage names this stage may read artifacts from. Empty = no inputs. */
+  reads: z.array(slugSchema).default([]),
+  /** Required frontmatter fields the produced artifact must populate. */
+  required_fields: z.array(z.string().min(1)).default([]),
+  /** Capability key the stage runs under. References a separate capability registry. */
+  capability: z.string().min(1).optional(),
+  /** Human-readable summary surfaced in dashboards and audit. */
+  description: z.string().min(1).max(500),
+});
+
+export type StageDefinition = z.infer<typeof stageDefinitionSchema>;
+
+/**
+ * A complete workflow: ordered stages plus a stable identifier.
+ */
+export const workflowDefinitionSchema = z.object({
+  id: slugSchema,
+  description: z.string().min(1).max(500),
+  version: z.number().int().min(1),
+  stages: z.array(stageDefinitionSchema).min(1),
+});
+
+export type WorkflowDefinition = z.infer<typeof workflowDefinitionSchema>;
+
+/**
+ * Status of a single stage inside a run.
+ */
+export const stageStatusSchema = z.enum([
+  "pending",
+  "in_progress",
+  "complete",
+  "blocked",
+  "failed",
+]);
+
+export type StageStatus = z.infer<typeof stageStatusSchema>;
+
+/**
+ * Per-stage record inside state.json. Holds outcome metadata that the next
+ * stage's envelope composer needs without re-parsing every artifact.
+ */
+export const stageRecordSchema = z.object({
+  name: slugSchema,
+  status: stageStatusSchema,
+  artifact: z.string().min(1).optional(),
+  started_at: z.string().datetime().optional(),
+  completed_at: z.string().datetime().optional(),
+  /** Frontmatter outcome surfaced for fast lookup (e.g. approved=true on review). */
+  outcome: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type StageRecord = z.infer<typeof stageRecordSchema>;
+
+/**
+ * The full state of one workflow run, persisted as
+ * .agents/<task-id>/state.json. Written only on stage boundaries so it
+ * never churns mid-tick.
+ */
+export const runStateSchema = z.object({
+  schema_version: z.literal(1),
+  task_id: slugSchema,
+  workflow_id: slugSchema,
+  workflow_version: z.number().int().min(1),
+  task_description: z.string().min(1).max(2000),
+  current_stage: slugSchema.nullable(),
+  outcome: z.enum(["in_progress", "complete", "failed", "blocked"]),
+  started_at: z.string().datetime(),
+  completed_at: z.string().datetime().nullable(),
+  stages: z.array(stageRecordSchema).min(1),
+});
+
+export type RunState = z.infer<typeof runStateSchema>;
+
+/**
+ * The required-by-convention frontmatter shape every stage artifact carries.
+ * Stages may add additional structured fields; these four are the ones the
+ * harness itself relies on.
+ */
+export const stageArtifactFrontmatterSchema = z
+  .object({
+    stage: slugSchema,
+    status: stageStatusSchema,
+    /** Sister-artifacts this artifact references (relative filenames). */
+    references: z.array(z.string().min(1)).default([]),
+    /** ISO 8601; injected by the harness, not the agent. */
+    written_at: z.string().datetime(),
+  })
+  .passthrough();
+
+export type StageArtifactFrontmatter = z.infer<typeof stageArtifactFrontmatterSchema>;

--- a/scaffold/mcp/src/hooks/pre-tool-use.ts
+++ b/scaffold/mcp/src/hooks/pre-tool-use.ts
@@ -8,6 +8,7 @@ import {
   resolveDaemonEntry,
   sendHeartbeat,
 } from "./shared.js";
+import { evaluateToolCall } from "../core/workflow/enforcement.js";
 
 /**
  * PreToolUse hook for Claude Code.
@@ -44,6 +45,35 @@ async function main(): Promise<void> {
       session_id: input.session_id,
       cwd,
     });
+  }
+
+  // Workflow capability gate. Runs before policy.check so harness-level
+  // restrictions block before the daemon's general policy machinery sees
+  // the call. No-op when CORTEX_ACTIVE_TASK_ID is unset.
+  const activeTaskId = process.env.CORTEX_ACTIVE_TASK_ID?.trim();
+  if (activeTaskId) {
+    try {
+      const verdict = evaluateToolCall({
+        cwd,
+        taskId: activeTaskId,
+        call: { toolName: tool, toolInput: input.tool_input ?? {} },
+      });
+      if (!verdict.allowed) {
+        process.stderr.write(
+          `[cortex] Blocked by harness capability: ${verdict.reason}\n`,
+        );
+        process.exit(2);
+      }
+    } catch (err) {
+      // Capability evaluation should never crash the hook — if it does,
+      // log and fall through to the existing policy.check rather than
+      // accidentally blocking a legitimate tool.
+      process.stderr.write(
+        `[cortex] capability evaluation failed (${
+          err instanceof Error ? err.message : String(err)
+        }); deferring to policy.check\n`,
+      );
+    }
   }
 
   const payload: PolicyCheckPayload = {

--- a/scaffold/mcp/src/server.ts
+++ b/scaffold/mcp/src/server.ts
@@ -11,6 +11,17 @@ import {
   getSessionEventHook,
   loadPlugins,
 } from "./plugin.js";
+import {
+  WorkflowStartInput,
+  WorkflowAdvanceInput,
+  WorkflowStatusInput,
+  WorkflowEnvelopeInput,
+  resolveProjectRoot,
+  runWorkflowAdvance,
+  runWorkflowEnvelope,
+  runWorkflowStart,
+  runWorkflowStatus,
+} from "./core/workflow/mcp-tools.js";
 
 type ToolPayload = Record<string, unknown>;
 
@@ -321,6 +332,70 @@ function registerTools(server: McpServer): void {
       const parsed = ReloadInput.parse(input ?? {});
       return reloadContextGraph(parsed.force);
     })
+  );
+
+  server.registerTool(
+    "cortex.workflow.start",
+    {
+      description:
+        "Start a Cortex Harness workflow run for a task. Creates .agents/<task_id>/state.json and returns the first stage's envelope (the prompt the agent should answer).",
+      inputSchema: WorkflowStartInput,
+    },
+    async (input) => executeInstrumentedTool(
+      "cortex.workflow.start",
+      input,
+      async () => runWorkflowStart(WorkflowStartInput.parse(input ?? {}), {
+        cwd: resolveProjectRoot(),
+      }) as ToolPayload,
+    ),
+  );
+
+  server.registerTool(
+    "cortex.workflow.advance",
+    {
+      description:
+        "Complete the current stage of a workflow run by writing its artifact and advancing the run pointer. Returns the new run state plus the next stage's envelope (or null when the run is finished, blocked, or failed).",
+      inputSchema: WorkflowAdvanceInput,
+    },
+    async (input) => executeInstrumentedTool(
+      "cortex.workflow.advance",
+      input,
+      async () => runWorkflowAdvance(WorkflowAdvanceInput.parse(input ?? {}), {
+        cwd: resolveProjectRoot(),
+      }) as ToolPayload,
+    ),
+  );
+
+  server.registerTool(
+    "cortex.workflow.status",
+    {
+      description:
+        "Read the current run state for a task (current stage, completed stages, outcome). Returns null state when no run exists for the given task_id.",
+      inputSchema: WorkflowStatusInput,
+    },
+    async (input) => executeInstrumentedTool(
+      "cortex.workflow.status",
+      input,
+      async () => runWorkflowStatus(WorkflowStatusInput.parse(input ?? {}), {
+        cwd: resolveProjectRoot(),
+      }) as ToolPayload,
+    ),
+  );
+
+  server.registerTool(
+    "cortex.workflow.envelope",
+    {
+      description:
+        "Compose the prompt envelope for a workflow stage without advancing the run. Defaults to the run's current_stage; pass `stage` to dry-run a different stage.",
+      inputSchema: WorkflowEnvelopeInput,
+    },
+    async (input) => executeInstrumentedTool(
+      "cortex.workflow.envelope",
+      input,
+      async () => runWorkflowEnvelope(WorkflowEnvelopeInput.parse(input ?? {}), {
+        cwd: resolveProjectRoot(),
+      }) as ToolPayload,
+    ),
   );
 }
 

--- a/scaffold/mcp/tests/workflow-cli.test.mjs
+++ b/scaffold/mcp/tests/workflow-cli.test.mjs
@@ -1,0 +1,293 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { runStageCommand } from "../dist/cli/stage.js";
+
+function makeWorkspace() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-stage-cli-"));
+  process.env.CORTEX_PROJECT_ROOT = dir;
+  return dir;
+}
+
+function captureStdout(run) {
+  const original = process.stdout.write.bind(process.stdout);
+  let captured = "";
+  process.stdout.write = (chunk) => {
+    captured += String(chunk);
+    return true;
+  };
+  return run()
+    .then((value) => ({ value, captured }))
+    .finally(() => {
+      process.stdout.write = original;
+    });
+}
+
+test.afterEach(() => {
+  delete process.env.CORTEX_PROJECT_ROOT;
+});
+
+test("stage start: creates run + returns first envelope as JSON on stdout", async () => {
+  const cwd = makeWorkspace();
+  const { captured } = await captureStdout(() =>
+    runStageCommand([
+      "start",
+      "--task-id",
+      "task-1",
+      "--description",
+      "Add login flow",
+      "--workflow",
+      "secure-build",
+    ]),
+  );
+  const parsed = JSON.parse(captured);
+  assert.equal(parsed.state.task_id, "task-1");
+  assert.equal(parsed.state.current_stage, "plan");
+  assert.equal(parsed.envelope.expectedArtifact, "plan.md");
+  assert.ok(fs.existsSync(path.join(cwd, ".agents", "task-1", "state.json")));
+});
+
+test("stage start: rejects unknown workflow", async () => {
+  makeWorkspace();
+  await assert.rejects(
+    runStageCommand([
+      "start",
+      "--task-id",
+      "task-1",
+      "--description",
+      "x",
+      "--workflow",
+      "no-such",
+    ]),
+    /Unknown workflow_id/,
+  );
+});
+
+test("stage start: rejects missing required flags", async () => {
+  makeWorkspace();
+  await assert.rejects(
+    runStageCommand(["start", "--task-id", "task-1"]),
+    /Missing required flag: --description/,
+  );
+});
+
+test("stage status: prints state when run exists", async () => {
+  makeWorkspace();
+  await runStageCommand([
+    "start",
+    "--task-id",
+    "task-1",
+    "--description",
+    "x",
+  ]);
+  const { captured } = await captureStdout(() =>
+    runStageCommand(["status", "--task-id", "task-1"]),
+  );
+  const parsed = JSON.parse(captured);
+  assert.equal(parsed.state.task_id, "task-1");
+  assert.equal(parsed.state.outcome, "in_progress");
+});
+
+test("stage status: returns null state when no run exists", async () => {
+  makeWorkspace();
+  const { captured } = await captureStdout(() =>
+    runStageCommand(["status", "--task-id", "ghost"]),
+  );
+  const parsed = JSON.parse(captured);
+  assert.equal(parsed.state, null);
+});
+
+test("stage envelope: returns current envelope without mutating state", async () => {
+  makeWorkspace();
+  await runStageCommand([
+    "start",
+    "--task-id",
+    "task-1",
+    "--description",
+    "x",
+  ]);
+  const { captured } = await captureStdout(() =>
+    runStageCommand(["envelope", "--task-id", "task-1"]),
+  );
+  const parsed = JSON.parse(captured);
+  assert.equal(parsed.envelope.expectedArtifact, "plan.md");
+});
+
+test("stage advance: writes artifact + advances run via body file", async () => {
+  const cwd = makeWorkspace();
+  await runStageCommand([
+    "start",
+    "--task-id",
+    "task-1",
+    "--description",
+    "x",
+  ]);
+
+  const bodyPath = path.join(cwd, "plan-body.md");
+  fs.writeFileSync(bodyPath, "# Plan\n\n1. Step\n2. Step", "utf8");
+  const fmPath = path.join(cwd, "plan-fm.json");
+  fs.writeFileSync(
+    fmPath,
+    JSON.stringify({ files_targeted: ["src/login.ts"], constraints: [] }),
+    "utf8",
+  );
+
+  const { captured } = await captureStdout(() =>
+    runStageCommand([
+      "advance",
+      "--task-id",
+      "task-1",
+      "--stage",
+      "plan",
+      "--body-file",
+      bodyPath,
+      "--frontmatter-file",
+      fmPath,
+    ]),
+  );
+  const parsed = JSON.parse(captured);
+  assert.equal(parsed.state.current_stage, "plan-review");
+  assert.ok(parsed.next_envelope, "next_envelope present while run is in_progress");
+  assert.equal(parsed.next_envelope.expectedArtifact, "plan-review.md");
+  assert.ok(fs.existsSync(path.join(cwd, ".agents", "task-1", "plan.md")));
+});
+
+test("stage advance: blocked status halts the run and returns null next envelope", async () => {
+  const cwd = makeWorkspace();
+  await runStageCommand([
+    "start",
+    "--task-id",
+    "task-1",
+    "--description",
+    "x",
+  ]);
+
+  const bodyPath = path.join(cwd, "blocked.md");
+  fs.writeFileSync(bodyPath, "# Plan blocked\n\nMissing context.", "utf8");
+
+  const { captured } = await captureStdout(() =>
+    runStageCommand([
+      "advance",
+      "--task-id",
+      "task-1",
+      "--stage",
+      "plan",
+      "--body-file",
+      bodyPath,
+      "--status",
+      "blocked",
+    ]),
+  );
+  const parsed = JSON.parse(captured);
+  assert.equal(parsed.state.outcome, "blocked");
+  assert.equal(parsed.next_envelope, null);
+});
+
+test("stage advance: rejects malformed frontmatter file", async () => {
+  const cwd = makeWorkspace();
+  await runStageCommand([
+    "start",
+    "--task-id",
+    "task-1",
+    "--description",
+    "x",
+  ]);
+
+  const bodyPath = path.join(cwd, "body.md");
+  fs.writeFileSync(bodyPath, "# Body", "utf8");
+  const badFm = path.join(cwd, "bad-fm.json");
+  fs.writeFileSync(badFm, "[1, 2, 3]", "utf8");
+
+  await assert.rejects(
+    runStageCommand([
+      "advance",
+      "--task-id",
+      "task-1",
+      "--stage",
+      "plan",
+      "--body-file",
+      bodyPath,
+      "--frontmatter-file",
+      badFm,
+    ]),
+    /Expected JSON object/,
+  );
+});
+
+test("stage run: rejects when no command after --", async () => {
+  makeWorkspace();
+  await runStageCommand([
+    "start",
+    "--task-id",
+    "task-1",
+    "--description",
+    "x",
+  ]);
+  await assert.rejects(
+    runStageCommand(["run", "--task-id", "task-1"]),
+    /requires a command after --/,
+  );
+});
+
+test("stage run: rejects when run is not in progress", async () => {
+  const cwd = makeWorkspace();
+  await runStageCommand([
+    "start",
+    "--task-id",
+    "task-1",
+    "--description",
+    "x",
+  ]);
+  // Corrupt state to simulate a finished run.
+  const statePath = path.join(cwd, ".agents", "task-1", "state.json");
+  const raw = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  raw.outcome = "complete";
+  raw.current_stage = null;
+  raw.completed_at = new Date().toISOString();
+  fs.writeFileSync(statePath, JSON.stringify(raw, null, 2));
+
+  await assert.rejects(
+    runStageCommand(["run", "--task-id", "task-1", "--", "echo", "hello"]),
+    /not in progress/,
+  );
+});
+
+test("stage run: spawns subprocess with CORTEX_ACTIVE_TASK_ID set", async () => {
+  const cwd = makeWorkspace();
+  await runStageCommand([
+    "start",
+    "--task-id",
+    "task-1",
+    "--description",
+    "x",
+  ]);
+
+  const outPath = path.join(cwd, "env-dump.txt");
+  // Use node -e to write CORTEX_ACTIVE_TASK_ID into a file we can inspect.
+  await runStageCommand([
+    "run",
+    "--task-id",
+    "task-1",
+    "--",
+    "node",
+    "-e",
+    `require("fs").writeFileSync(${JSON.stringify(outPath)}, process.env.CORTEX_ACTIVE_TASK_ID || "<unset>")`,
+  ]);
+
+  const written = fs.readFileSync(outPath, "utf8");
+  assert.equal(written, "task-1");
+});
+
+test("stage help: prints help text and returns without throwing", async () => {
+  const { captured } = await captureStdout(() => runStageCommand(["help"]));
+  assert.match(captured, /Usage:/);
+  assert.match(captured, /cortex stage start/);
+  assert.match(captured, /cortex stage run/);
+});
+
+test("stage <unknown>: throws with help text", async () => {
+  await assert.rejects(runStageCommand(["frobnicate"]), /Unknown stage subcommand/);
+});

--- a/scaffold/mcp/tests/workflow-enforcement.test.mjs
+++ b/scaffold/mcp/tests/workflow-enforcement.test.mjs
@@ -1,0 +1,370 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { evaluateToolCall } from "../dist/core/workflow/enforcement.js";
+import { createRun } from "../dist/core/workflow/run-lifecycle.js";
+import { capabilityDefinitionSchema, DEFAULT_CAPABILITIES } from "../dist/core/workflow/capabilities.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-enforcement-"));
+}
+
+const WORKFLOW_PLANNER = {
+  id: "planner-only",
+  description: "Single planner stage",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: [],
+      capability: "planner",
+      description: "Plan",
+    },
+  ],
+};
+
+const WORKFLOW_BUILDER = {
+  id: "builder-only",
+  description: "Single builder stage",
+  version: 1,
+  stages: [
+    {
+      name: "build",
+      artifact: "changes.md",
+      reads: [],
+      required_fields: [],
+      capability: "builder",
+      description: "Build",
+    },
+  ],
+};
+
+const WORKFLOWS = {
+  "planner-only": WORKFLOW_PLANNER,
+  "builder-only": WORKFLOW_BUILDER,
+};
+
+function startPlannerRun(cwd, taskId = "task-1") {
+  return createRun({
+    cwd,
+    taskId,
+    workflow: WORKFLOW_PLANNER,
+    taskDescription: "x",
+  });
+}
+
+function startBuilderRun(cwd, taskId = "task-1") {
+  return createRun({
+    cwd,
+    taskId,
+    workflow: WORKFLOW_BUILDER,
+    taskDescription: "x",
+  });
+}
+
+test("capabilities: default registry validates against schema", () => {
+  for (const cap of Object.values(DEFAULT_CAPABILITIES)) {
+    capabilityDefinitionSchema.parse(cap);
+  }
+});
+
+test("evaluator: allows everything when no run state exists", () => {
+  const cwd = makeWorkspace();
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "ghost",
+    call: { toolName: "Edit", toolInput: { file_path: "src/foo.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("planner: blocks Edit (read-only capability)", () => {
+  const cwd = makeWorkspace();
+  startPlannerRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "src/foo.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /read-only/);
+});
+
+test("planner: blocks Bash (could mutate filesystem under read-only)", () => {
+  const cwd = makeWorkspace();
+  startPlannerRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Bash", toolInput: { command: "rm -rf /" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /Bash/);
+});
+
+test("planner: allows Read on any path", () => {
+  const cwd = makeWorkspace();
+  startPlannerRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Read", toolInput: { file_path: "src/anything.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("planner: allows Grep without explicit path", () => {
+  const cwd = makeWorkspace();
+  startPlannerRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Grep", toolInput: { pattern: "TODO" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("builder: allows Edit on src/", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "src/foo.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("builder: allows Edit on tests/", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "tests/foo.test.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("builder: blocks Edit on package.json (outside write_globs)", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "package.json" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /outside capability builder/);
+});
+
+test("builder: blocks Edit on .github/workflows (CI file)", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: {
+      toolName: "Edit",
+      toolInput: { file_path: ".github/workflows/release.yml" },
+    },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+});
+
+test("builder: handles absolute path inside cwd", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const abs = path.join(cwd, "src", "foo.ts");
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: abs } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("builder: blocks absolute path outside cwd", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "/etc/passwd" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+});
+
+test("builder: blocks Edit without file_path", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: {} },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /did not include a file_path/);
+});
+
+test("evaluator: tools_allowed list restricts tools by name", () => {
+  const cwd = makeWorkspace();
+  const customCapabilities = {
+    ...DEFAULT_CAPABILITIES,
+    "search-only": {
+      name: "search-only",
+      description: "Only Read + Grep allowed",
+      read_globs: ["**"],
+      write_globs: [],
+      tools_allowed: ["Read", "Grep"],
+    },
+  };
+  const customWorkflow = {
+    id: "search-only",
+    description: "Search only",
+    version: 1,
+    stages: [
+      {
+        name: "scan",
+        artifact: "scan.md",
+        reads: [],
+        required_fields: [],
+        capability: "search-only",
+        description: "Scan",
+      },
+    ],
+  };
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: customWorkflow,
+    taskDescription: "x",
+  });
+
+  const grep = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Grep", toolInput: { pattern: "x" } },
+    workflows: { "search-only": customWorkflow },
+    capabilities: customCapabilities,
+  });
+  assert.equal(grep.allowed, true);
+
+  const glob = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Glob", toolInput: { pattern: "*.ts" } },
+    workflows: { "search-only": customWorkflow },
+    capabilities: customCapabilities,
+  });
+  assert.equal(glob.allowed, false);
+  assert.match(glob.reason, /does not allow tool Glob/);
+});
+
+test("evaluator: human capability blocks all tool calls", () => {
+  const cwd = makeWorkspace();
+  const humanWorkflow = {
+    id: "human-only",
+    description: "Human-only stage",
+    version: 1,
+    stages: [
+      {
+        name: "approval",
+        artifact: "approval.md",
+        reads: [],
+        required_fields: [],
+        capability: "human",
+        description: "Approve",
+      },
+    ],
+  };
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: humanWorkflow,
+    taskDescription: "x",
+  });
+
+  const read = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Read", toolInput: { file_path: "src/foo.ts" } },
+    workflows: { "human-only": humanWorkflow },
+  });
+  assert.equal(read.allowed, false);
+});
+
+test("evaluator: stage without capability is unrestricted", () => {
+  const cwd = makeWorkspace();
+  const noCapabilityWorkflow = {
+    id: "free",
+    description: "No capability",
+    version: 1,
+    stages: [
+      {
+        name: "free-stage",
+        artifact: "out.md",
+        reads: [],
+        required_fields: [],
+        description: "No restriction",
+      },
+    ],
+  };
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: noCapabilityWorkflow,
+    taskDescription: "x",
+  });
+
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Bash", toolInput: { command: "ls" } },
+    workflows: { free: noCapabilityWorkflow },
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("evaluator: completed run does not gate any tool calls", () => {
+  const cwd = makeWorkspace();
+  const completed = createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW_PLANNER,
+    taskDescription: "x",
+  });
+  // Manually corrupt to "complete" without going through advanceStage —
+  // simulates a run that finished before the hook fires.
+  const statePath = path.join(cwd, ".agents", "task-1", "state.json");
+  const raw = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  raw.outcome = "complete";
+  raw.current_stage = null;
+  raw.completed_at = new Date().toISOString();
+  fs.writeFileSync(statePath, JSON.stringify(raw, null, 2));
+
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "src/foo.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});

--- a/scaffold/mcp/tests/workflow-envelope.test.mjs
+++ b/scaffold/mcp/tests/workflow-envelope.test.mjs
@@ -1,0 +1,247 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { composeStageEnvelope } from "../dist/core/workflow/envelope.js";
+import { createRun, advanceStage } from "../dist/core/workflow/run-lifecycle.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-envelope-"));
+}
+
+const TINY_WORKFLOW = {
+  id: "tiny",
+  description: "Two-stage workflow used for tests",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: ["files_targeted"],
+      capability: "planner",
+      description: "Produce a step-by-step plan.",
+    },
+    {
+      name: "review",
+      artifact: "review.md",
+      reads: ["plan"],
+      required_fields: ["approved", "blocking_comments"],
+      capability: "reviewer",
+      description: "Review the plan for soundness.",
+    },
+  ],
+};
+
+function startRun(cwd, taskId) {
+  return createRun({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    taskDescription: "Wire up the new dashboard endpoint.",
+  });
+}
+
+function completePlanStage(cwd, taskId) {
+  return advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "plan",
+    artifactName: "plan.md",
+    frontmatter: {
+      stage: "plan",
+      status: "complete",
+      references: [],
+      files_targeted: ["src/foo.ts"],
+    },
+    body: "# Plan\n\n1. Add endpoint\n2. Wire route",
+  });
+}
+
+test("composeStageEnvelope: first stage has no handoffs and labels first-stage explicitly", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-first";
+  startRun(cwd, taskId);
+
+  const envelope = composeStageEnvelope({ cwd, taskId, workflow: TINY_WORKFLOW });
+
+  assert.equal(envelope.expectedArtifact, "plan.md");
+  assert.deepEqual(envelope.requiredFields, ["files_targeted"]);
+  assert.equal(envelope.capability, "planner");
+  assert.match(envelope.prompt, /# TASK/);
+  assert.match(envelope.prompt, /Wire up the new dashboard endpoint\./);
+  assert.match(envelope.prompt, /# STAGE: plan/);
+  assert.match(envelope.prompt, /Running under capability: `planner`/);
+  assert.match(envelope.prompt, /No prior-stage artifacts/);
+  assert.match(envelope.prompt, /# OUTPUT/);
+  assert.match(envelope.prompt, /`files_targeted`/);
+});
+
+test("composeStageEnvelope: mid-flow stage inlines prior artifact verbatim", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-mid";
+  startRun(cwd, taskId);
+  completePlanStage(cwd, taskId);
+
+  const envelope = composeStageEnvelope({ cwd, taskId, workflow: TINY_WORKFLOW });
+
+  assert.equal(envelope.expectedArtifact, "review.md");
+  assert.deepEqual(envelope.requiredFields, ["approved", "blocking_comments"]);
+  assert.match(envelope.prompt, /# STAGE: review/);
+  // Handoff section uses fenced markers and contains the planning frontmatter + body.
+  assert.match(envelope.prompt, /--- handoff:plan \(plan\.md\) ---/);
+  assert.match(envelope.prompt, /--- end handoff:plan ---/);
+  assert.match(envelope.prompt, /stage: plan/);
+  assert.match(envelope.prompt, /1\. Add endpoint/);
+});
+
+test("composeStageEnvelope: explicit stageName overrides current_stage for dry-run", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-explicit";
+  startRun(cwd, taskId);
+
+  const envelope = composeStageEnvelope({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "plan",
+  });
+  assert.match(envelope.prompt, /# STAGE: plan/);
+});
+
+test("composeStageEnvelope: throws when run hasn't been created", () => {
+  const cwd = makeWorkspace();
+  assert.throws(
+    () => composeStageEnvelope({ cwd, taskId: "ghost", workflow: TINY_WORKFLOW }),
+    /No run state/,
+  );
+});
+
+test("composeStageEnvelope: throws when stage not in workflow", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-unknown";
+  startRun(cwd, taskId);
+
+  assert.throws(
+    () =>
+      composeStageEnvelope({
+        cwd,
+        taskId,
+        workflow: TINY_WORKFLOW,
+        stageName: "nonexistent",
+      }),
+    /not defined in workflow/,
+  );
+});
+
+test("composeStageEnvelope: throws when prior handoff artifact hasn't been produced", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-missing";
+  startRun(cwd, taskId);
+  // Skip the plan stage — go straight to asking for a review envelope. Plan
+  // is still pending so its artifact doesn't exist.
+  assert.throws(
+    () =>
+      composeStageEnvelope({
+        cwd,
+        taskId,
+        workflow: TINY_WORKFLOW,
+        stageName: "review",
+      }),
+    /requires artifact from plan, but it has not been produced yet/,
+  );
+});
+
+test("composeStageEnvelope: throws when stage declares reads from unknown stage", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-bad-reads";
+  const broken = {
+    ...TINY_WORKFLOW,
+    stages: [
+      TINY_WORKFLOW.stages[0],
+      { ...TINY_WORKFLOW.stages[1], reads: ["does-not-exist"] },
+    ],
+  };
+  createRun({
+    cwd,
+    taskId,
+    workflow: broken,
+    taskDescription: "Test bad reads",
+  });
+  advanceStage({
+    cwd,
+    taskId,
+    workflow: broken,
+    stageName: "plan",
+    artifactName: "plan.md",
+    frontmatter: { stage: "plan", status: "complete", references: [] },
+    body: "# Plan",
+  });
+
+  assert.throws(
+    () =>
+      composeStageEnvelope({
+        cwd,
+        taskId,
+        workflow: broken,
+        stageName: "review",
+      }),
+    /declares reads from unknown stage/,
+  );
+});
+
+test("composeStageEnvelope: surfaces lack of capability gracefully", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-no-capability";
+  const noCapability = {
+    ...TINY_WORKFLOW,
+    stages: [
+      { ...TINY_WORKFLOW.stages[0], capability: undefined },
+      TINY_WORKFLOW.stages[1],
+    ],
+  };
+  createRun({
+    cwd,
+    taskId,
+    workflow: noCapability,
+    taskDescription: "Test no capability",
+  });
+
+  const envelope = composeStageEnvelope({
+    cwd,
+    taskId,
+    workflow: noCapability,
+  });
+  assert.equal(envelope.capability, null);
+  assert.match(envelope.prompt, /No capability constraint declared/);
+});
+
+test("composeStageEnvelope: throws when run is already finished", () => {
+  const cwd = makeWorkspace();
+  const taskId = "envelope-finished";
+  startRun(cwd, taskId);
+  completePlanStage(cwd, taskId);
+  advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "review",
+    artifactName: "review.md",
+    frontmatter: {
+      stage: "review",
+      status: "complete",
+      references: ["plan.md"],
+      approved: true,
+      blocking_comments: 0,
+    },
+    body: "# Review\n\nLooks good.",
+  });
+
+  assert.throws(
+    () => composeStageEnvelope({ cwd, taskId, workflow: TINY_WORKFLOW }),
+    /not at any stage/,
+  );
+});

--- a/scaffold/mcp/tests/workflow-mcp-tools.test.mjs
+++ b/scaffold/mcp/tests/workflow-mcp-tools.test.mjs
@@ -1,0 +1,293 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  WorkflowStartInput,
+  WorkflowAdvanceInput,
+  WorkflowStatusInput,
+  WorkflowEnvelopeInput,
+  runWorkflowStart,
+  runWorkflowAdvance,
+  runWorkflowStatus,
+  runWorkflowEnvelope,
+} from "../dist/core/workflow/mcp-tools.js";
+import { SECURE_BUILD_WORKFLOW } from "../dist/core/workflow/default-workflows.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-mcp-tools-"));
+}
+
+const TINY_WORKFLOW = {
+  id: "tiny",
+  description: "Two-stage tests workflow",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: [],
+      capability: "planner",
+      description: "Produce a plan.",
+    },
+    {
+      name: "review",
+      artifact: "review.md",
+      reads: ["plan"],
+      required_fields: ["approved"],
+      capability: "reviewer",
+      description: "Review the plan.",
+    },
+  ],
+};
+
+const TINY_REGISTRY = { tiny: TINY_WORKFLOW };
+
+test("input schemas: workflow_id defaults to secure-build", () => {
+  const parsed = WorkflowStartInput.parse({
+    task_id: "abc",
+    task_description: "y",
+  });
+  assert.equal(parsed.workflow_id, "secure-build");
+});
+
+test("input schemas: advance requires stage + body", () => {
+  assert.throws(() => WorkflowAdvanceInput.parse({ task_id: "abc" }));
+  assert.throws(() =>
+    WorkflowAdvanceInput.parse({ task_id: "abc", stage: "plan", body: "" }),
+  );
+});
+
+test("input schemas: status accepts only task_id", () => {
+  const parsed = WorkflowStatusInput.parse({ task_id: "abc" });
+  assert.equal(parsed.task_id, "abc");
+});
+
+test("input schemas: envelope stage is optional", () => {
+  const parsed = WorkflowEnvelopeInput.parse({ task_id: "abc" });
+  assert.equal(parsed.stage, undefined);
+});
+
+test("runWorkflowStart: creates run and returns the first envelope", () => {
+  const cwd = makeWorkspace();
+  const result = runWorkflowStart(
+    {
+      task_id: "task-1",
+      task_description: "Add login flow",
+      workflow_id: "tiny",
+    },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  assert.equal(result.state.task_id, "task-1");
+  assert.equal(result.state.current_stage, "plan");
+  assert.equal(result.state.outcome, "in_progress");
+  assert.equal(result.envelope.expectedArtifact, "plan.md");
+  assert.match(result.envelope.prompt, /# STAGE: plan/);
+
+  // state.json persisted under .agents/<task-id>/
+  const statePath = path.join(cwd, ".agents", "task-1", "state.json");
+  assert.ok(fs.existsSync(statePath));
+});
+
+test("runWorkflowStart: rejects unknown workflow_id", () => {
+  const cwd = makeWorkspace();
+  assert.throws(
+    () =>
+      runWorkflowStart(
+        { task_id: "task-1", task_description: "x", workflow_id: "nope" },
+        { cwd, workflows: TINY_REGISTRY },
+      ),
+    /Unknown workflow_id/,
+  );
+});
+
+test("runWorkflowStart: defaults to bundled DEFAULT_WORKFLOWS when no registry given", () => {
+  const cwd = makeWorkspace();
+  const result = runWorkflowStart(
+    {
+      task_id: "task-1",
+      task_description: "Use the default workflow",
+      workflow_id: SECURE_BUILD_WORKFLOW.id,
+    },
+    { cwd },
+  );
+  assert.equal(result.state.workflow_id, "secure-build");
+  assert.equal(result.envelope.expectedArtifact, "plan.md");
+});
+
+test("runWorkflowAdvance: writes artifact + state, returns next envelope while in_progress", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-2", task_description: "Multi-stage", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const advance = runWorkflowAdvance(
+    {
+      task_id: "task-2",
+      stage: "plan",
+      frontmatter: {},
+      body: "# Plan\n\nDetailed plan body.",
+    },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  assert.equal(advance.state.current_stage, "review");
+  assert.equal(advance.state.outcome, "in_progress");
+  assert.equal(advance.state.stages[0].status, "complete");
+  assert.equal(advance.state.stages[0].artifact, "plan.md");
+  assert.ok(advance.next_envelope);
+  assert.equal(advance.next_envelope.expectedArtifact, "review.md");
+  // The handoff renders the plan artifact inline.
+  assert.match(advance.next_envelope.prompt, /--- handoff:plan \(plan\.md\) ---/);
+});
+
+test("runWorkflowAdvance: returns next_envelope=null when run completes", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-3", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+  runWorkflowAdvance(
+    { task_id: "task-3", stage: "plan", frontmatter: {}, body: "# Plan" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const finalAdvance = runWorkflowAdvance(
+    {
+      task_id: "task-3",
+      stage: "review",
+      frontmatter: { approved: true },
+      body: "# Review\n\nLooks good.",
+      outcome: { approved: true },
+    },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  assert.equal(finalAdvance.state.current_stage, null);
+  assert.equal(finalAdvance.state.outcome, "complete");
+  assert.equal(finalAdvance.next_envelope, null);
+});
+
+test("runWorkflowAdvance: blocked status halts the run and returns null envelope", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-4", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const result = runWorkflowAdvance(
+    {
+      task_id: "task-4",
+      stage: "plan",
+      frontmatter: {},
+      body: "# Plan blocked\n\nMissing context.",
+      status: "blocked",
+    },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  assert.equal(result.state.outcome, "blocked");
+  assert.equal(result.state.current_stage, null);
+  assert.equal(result.next_envelope, null);
+});
+
+test("runWorkflowAdvance: rejects when no run exists", () => {
+  const cwd = makeWorkspace();
+  assert.throws(
+    () =>
+      runWorkflowAdvance(
+        {
+          task_id: "ghost",
+          stage: "plan",
+          frontmatter: {},
+          body: "# Plan",
+        },
+        { cwd, workflows: TINY_REGISTRY },
+      ),
+    /No run state/,
+  );
+});
+
+test("runWorkflowAdvance: auto-derives references from stage.reads when caller omits them", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-5", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+  runWorkflowAdvance(
+    { task_id: "task-5", stage: "plan", frontmatter: {}, body: "# Plan" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+  runWorkflowAdvance(
+    {
+      task_id: "task-5",
+      stage: "review",
+      frontmatter: { approved: false },
+      body: "# Review",
+    },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const reviewArtifact = path.join(cwd, ".agents", "task-5", "review.md");
+  const text = fs.readFileSync(reviewArtifact, "utf8");
+  assert.match(text, /references:/);
+  assert.match(text, /- plan\.md/);
+});
+
+test("runWorkflowStatus: returns state for an active run", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-6", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const result = runWorkflowStatus({ task_id: "task-6" }, { cwd, workflows: TINY_REGISTRY });
+  assert.equal(result.state?.task_id, "task-6");
+  assert.equal(result.state?.current_stage, "plan");
+});
+
+test("runWorkflowStatus: returns null state when nothing exists", () => {
+  const cwd = makeWorkspace();
+  const result = runWorkflowStatus({ task_id: "no-run" }, { cwd, workflows: TINY_REGISTRY });
+  assert.equal(result.state, null);
+});
+
+test("runWorkflowEnvelope: returns current envelope without mutating state", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-7", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const before = runWorkflowStatus({ task_id: "task-7" }, { cwd, workflows: TINY_REGISTRY });
+  const envelope = runWorkflowEnvelope(
+    { task_id: "task-7" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+  const after = runWorkflowStatus({ task_id: "task-7" }, { cwd, workflows: TINY_REGISTRY });
+
+  assert.equal(envelope.envelope.expectedArtifact, "plan.md");
+  assert.deepEqual(before.state, after.state);
+});
+
+test("runWorkflowEnvelope: explicit stage overrides current_stage for dry-run", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-8", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  // Dry-run review even though we're at plan — should fail because review
+  // requires plan's artifact to exist.
+  assert.throws(() =>
+    runWorkflowEnvelope(
+      { task_id: "task-8", stage: "review" },
+      { cwd, workflows: TINY_REGISTRY },
+    ),
+  );
+});

--- a/scaffold/mcp/tests/workflow.test.mjs
+++ b/scaffold/mcp/tests/workflow.test.mjs
@@ -1,0 +1,283 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  parseStageArtifact,
+  renderStageArtifact,
+  readRunState,
+  readStageArtifact,
+} from "../dist/core/workflow/artifact-io.js";
+import {
+  createRun,
+  advanceStage,
+  getRunState,
+} from "../dist/core/workflow/run-lifecycle.js";
+import {
+  workflowDefinitionSchema,
+  stageArtifactFrontmatterSchema,
+  runStateSchema,
+} from "../dist/core/workflow/schemas.js";
+import { SECURE_BUILD_WORKFLOW } from "../dist/core/workflow/default-workflows.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-workflow-"));
+}
+
+const TINY_WORKFLOW = {
+  id: "tiny",
+  description: "Two-stage workflow used for tests",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: [],
+      description: "Produce a plan",
+    },
+    {
+      name: "review",
+      artifact: "review.md",
+      reads: ["plan"],
+      required_fields: ["approved"],
+      description: "Review the plan",
+    },
+  ],
+};
+
+test("schemas: SECURE_BUILD_WORKFLOW validates against workflowDefinitionSchema", () => {
+  const parsed = workflowDefinitionSchema.parse(SECURE_BUILD_WORKFLOW);
+  assert.equal(parsed.id, "secure-build");
+  assert.ok(parsed.stages.length > 0);
+});
+
+test("schemas: stage names must be slug-cased", () => {
+  assert.throws(() =>
+    workflowDefinitionSchema.parse({
+      ...TINY_WORKFLOW,
+      stages: [
+        { ...TINY_WORKFLOW.stages[0], name: "Bad Name" },
+        TINY_WORKFLOW.stages[1],
+      ],
+    }),
+  );
+});
+
+test("schemas: stage artifact frontmatter requires status + stage", () => {
+  assert.throws(() =>
+    stageArtifactFrontmatterSchema.parse({
+      stage: "plan",
+      // status missing
+      written_at: new Date().toISOString(),
+    }),
+  );
+});
+
+test("artifact-io: render + parse round-trips frontmatter", () => {
+  const fm = stageArtifactFrontmatterSchema.parse({
+    stage: "plan",
+    status: "complete",
+    references: [],
+    written_at: "2026-05-06T19:00:00.000Z",
+  });
+  const text = renderStageArtifact(fm, "# Plan\n\nDo the thing.");
+  const parsed = parseStageArtifact(text);
+  assert.equal(parsed.frontmatter.stage, "plan");
+  assert.equal(parsed.frontmatter.status, "complete");
+  assert.equal(parsed.body, "# Plan\n\nDo the thing.");
+});
+
+test("artifact-io: parseStageArtifact rejects missing frontmatter", () => {
+  assert.throws(() => parseStageArtifact("# No frontmatter here\n"));
+});
+
+test("artifact-io: parseStageArtifact rejects unterminated frontmatter", () => {
+  assert.throws(() =>
+    parseStageArtifact("---\nstage: plan\nstatus: complete\n# no close marker\n"),
+  );
+});
+
+test("artifact-io: parseStageArtifact preserves passthrough fields", () => {
+  const text = `---
+stage: review
+status: complete
+references:
+  - plan.md
+written_at: "2026-05-06T19:00:00.000Z"
+approved: true
+blocking_comments: 0
+---
+
+# Review
+
+Looks good.
+`;
+  const parsed = parseStageArtifact(text);
+  assert.equal(parsed.frontmatter.stage, "review");
+  assert.deepEqual(parsed.frontmatter.references, ["plan.md"]);
+  assert.equal(parsed.frontmatter.approved, true);
+  assert.equal(parsed.frontmatter.blocking_comments, 0);
+});
+
+test("createRun: writes state.json with all stages pending and current_stage = first", () => {
+  const cwd = makeWorkspace();
+  const state = createRun({
+    cwd,
+    taskId: "2026-05-06-fixture",
+    workflow: TINY_WORKFLOW,
+    taskDescription: "Test run",
+  });
+
+  assert.equal(state.task_id, "2026-05-06-fixture");
+  assert.equal(state.current_stage, "plan");
+  assert.equal(state.outcome, "in_progress");
+  assert.deepEqual(
+    state.stages.map((s) => s.status),
+    ["pending", "pending"],
+  );
+
+  const persisted = readRunState(cwd, "2026-05-06-fixture");
+  assert.deepEqual(persisted, state);
+});
+
+test("advanceStage: writes artifact, updates state, advances current_stage", () => {
+  const cwd = makeWorkspace();
+  const taskId = "2026-05-06-advance";
+  createRun({ cwd, taskId, workflow: TINY_WORKFLOW, taskDescription: "Test" });
+
+  const after = advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "plan",
+    artifactName: "plan.md",
+    frontmatter: { stage: "plan", status: "complete", references: [] },
+    body: "# Plan\n\n- step 1\n- step 2",
+  });
+
+  assert.equal(after.current_stage, "review");
+  assert.equal(after.outcome, "in_progress");
+  assert.equal(after.stages[0].status, "complete");
+  assert.equal(after.stages[0].artifact, "plan.md");
+  assert.equal(after.stages[1].status, "pending");
+
+  // Artifact lives on disk under .agents/<taskId>/
+  const artifactPath = path.join(cwd, ".agents", taskId, "plan.md");
+  assert.ok(fs.existsSync(artifactPath));
+  const parsed = readStageArtifact(cwd, taskId, "plan.md");
+  assert.equal(parsed.frontmatter.stage, "plan");
+});
+
+test("advanceStage: marks run complete after final stage", () => {
+  const cwd = makeWorkspace();
+  const taskId = "2026-05-06-final";
+  createRun({ cwd, taskId, workflow: TINY_WORKFLOW, taskDescription: "Test" });
+
+  advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "plan",
+    artifactName: "plan.md",
+    frontmatter: { stage: "plan", status: "complete", references: [] },
+    body: "# Plan",
+  });
+
+  const after = advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "review",
+    artifactName: "review.md",
+    frontmatter: {
+      stage: "review",
+      status: "complete",
+      references: ["plan.md"],
+      approved: true,
+    },
+    body: "# Review\n\napproved",
+    outcome: { approved: true },
+  });
+
+  assert.equal(after.current_stage, null);
+  assert.equal(after.outcome, "complete");
+  assert.ok(after.completed_at);
+  assert.deepEqual(after.stages[1].outcome, { approved: true });
+});
+
+test("advanceStage: blocked status surfaces as run outcome", () => {
+  const cwd = makeWorkspace();
+  const taskId = "2026-05-06-blocked";
+  createRun({ cwd, taskId, workflow: TINY_WORKFLOW, taskDescription: "Test" });
+
+  const after = advanceStage({
+    cwd,
+    taskId,
+    workflow: TINY_WORKFLOW,
+    stageName: "plan",
+    artifactName: "plan.md",
+    frontmatter: { stage: "plan", status: "blocked", references: [] },
+    body: "# Plan blocked",
+    status: "blocked",
+  });
+
+  assert.equal(after.outcome, "blocked");
+  assert.equal(after.current_stage, null);
+});
+
+test("advanceStage: refuses to advance the wrong stage", () => {
+  const cwd = makeWorkspace();
+  const taskId = "2026-05-06-wrong";
+  createRun({ cwd, taskId, workflow: TINY_WORKFLOW, taskDescription: "Test" });
+
+  assert.throws(() =>
+    advanceStage({
+      cwd,
+      taskId,
+      workflow: TINY_WORKFLOW,
+      stageName: "review",
+      artifactName: "review.md",
+      frontmatter: { stage: "review", status: "complete", references: [] },
+      body: "# Out of order",
+    }),
+  );
+});
+
+test("getRunState: returns null for missing tasks", () => {
+  const cwd = makeWorkspace();
+  assert.equal(getRunState(cwd, "no-such-task"), null);
+});
+
+test("readRunState: validates persisted state against schema", () => {
+  const cwd = makeWorkspace();
+  const taskId = "2026-05-06-corrupt";
+  createRun({ cwd, taskId, workflow: TINY_WORKFLOW, taskDescription: "Test" });
+
+  // Corrupt the file: drop required field.
+  const statePath = path.join(cwd, ".agents", taskId, "state.json");
+  const raw = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  delete raw.workflow_id;
+  fs.writeFileSync(statePath, JSON.stringify(raw, null, 2));
+
+  assert.throws(() => readRunState(cwd, taskId));
+});
+
+test("runStateSchema: rejects unknown outcome", () => {
+  assert.throws(() =>
+    runStateSchema.parse({
+      schema_version: 1,
+      task_id: "x",
+      workflow_id: "tiny",
+      workflow_version: 1,
+      task_description: "y",
+      current_stage: null,
+      outcome: "totally-bogus",
+      started_at: new Date().toISOString(),
+      completed_at: null,
+      stages: [{ name: "plan", status: "complete" }],
+    }),
+  );
+});


### PR DESCRIPTION
Fifth slice of the harness. Exposes the workflow primitives as shell subcommands so scripts and CI can drive the harness without an MCP client, and provides the env-setting wrapper needed to spawn agents under the pre-tool-use capability gate.

Stacked on **#69** (capability enforcement). Merge order: #66 → #67 → #68 → #69 → this.

## Subcommands

\`\`\`
cortex stage start    --task-id <id> --description "..." [--workflow <id>]
cortex stage status   --task-id <id>
cortex stage envelope --task-id <id> [--stage <name>]
cortex stage advance  --task-id <id> --stage <name> --body-file <path>
                      [--frontmatter-file <path>] [--outcome-file <path>]
                      [--status complete|blocked|failed]
cortex stage run      --task-id <id> -- <command> [args...]
\`\`\`

\`stage run\` is the key piece: it sets \`CORTEX_ACTIVE_TASK_ID\` in the spawned subprocess so the pre-tool-use hook from #69 applies the active stage's capability gate. Refuses to spawn when the run is not \`in_progress\` or the task has no state — fail-loud rather than silently fire an agent under the wrong capability.

## Example end-to-end run

\`\`\`sh
cortex stage start --task-id add-login --description "Add password login flow"
cortex stage envelope --task-id add-login | jq -r '.envelope.prompt' > prompt.txt
cortex stage run --task-id add-login -- claude --print < prompt.txt
# Claude produces a plan body, write it out as plan.md, then:
cortex stage advance --task-id add-login --stage plan --body-file plan-body.md
# Repeat for each stage…
\`\`\`

## Implementation

- \`src/cli/stage.ts\` — pure subcommand dispatcher with a tiny flag parser (no commander/yargs dep). Reads body and frontmatter from files so callers don't have to inline shell-quoted markdown. Frontmatter must be a JSON object; arrays / scalars rejected with a clear error.
- \`bin/cortex.mjs\` — adds \`if (command === "stage") return runStageCommandShim(rest)\` plus the shim that resolves the built CLI module and invokes \`runStageCommand\`. Help text gains a HARNESS section listing all subcommands.

## Tests
14 new cases under \`tests/workflow-cli.test.mjs\`:
- start: happy path, unknown workflow, missing required flags
- status: active run, missing run
- envelope: read-only (doesn't mutate state)
- advance: happy path, blocked status, malformed frontmatter file
- run: rejects no command, rejects when not in_progress, actually sets \`CORTEX_ACTIVE_TASK_ID\` in the subprocess
- help: prints usage
- unknown subcommand: throws

197/197 daemon tests pass; \`tsc --noEmit\` clean.

## What's needed to call this end-to-end "done"
With this PR merged, the harness is functionally complete:
- workflow defined ✓
- runs created and persisted ✓
- agent prompts composed ✓
- agents driven via MCP or CLI ✓
- capability-gated tool calls ✓
- agent spawning with correct env ✓ (via \`stage run\`)

What we still don't have (deferred):
- \`cortex-web\` org-config sync (currently locked to bundled \`secure-build\` workflow + \`DEFAULT_CAPABILITIES\`)
- Auto-orchestrator that loops "envelope → claude --print → advance" without a human in the loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)