### PR TITLE
Expose workflow engine as cortex.workflow.* MCP tools

### DIFF
--- a/scaffold/mcp/src/core/workflow/index.ts
+++ b/scaffold/mcp/src/core/workflow/index.ts
@@ -3,3 +3,4 @@ export * from "./artifact-io.js";
 export * from "./run-lifecycle.js";
 export * from "./envelope.js";
 export * from "./default-workflows.js";
+export * from "./mcp-tools.js";

--- a/scaffold/mcp/src/core/workflow/mcp-tools.ts
+++ b/scaffold/mcp/src/core/workflow/mcp-tools.ts
@@ -1,0 +1,208 @@
+import { z } from "zod";
+import { advanceStage, createRun, getRunState } from "./run-lifecycle.js";
+import { composeStageEnvelope } from "./envelope.js";
+import { DEFAULT_WORKFLOWS } from "./default-workflows.js";
+import {
+  stageStatusSchema,
+  type StageStatus,
+  type WorkflowDefinition,
+} from "./schemas.js";
+
+/**
+ * Pure runner functions that back the cortex.workflow.* MCP tools.
+ * Kept separate from server.ts so they can be unit-tested without spinning
+ * up an MCP server. server.ts is a thin shim that registers each runner
+ * under its tool name and serializes the result through buildToolResult.
+ */
+
+const slugSchema = z
+  .string()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+
+export const WorkflowStartInput = z.object({
+  task_id: slugSchema,
+  task_description: z.string().min(1).max(2000),
+  workflow_id: slugSchema.default("secure-build"),
+});
+export type WorkflowStartInputT = z.infer<typeof WorkflowStartInput>;
+
+export const WorkflowAdvanceInput = z.object({
+  task_id: slugSchema,
+  /** Required for safety: must equal the run's current_stage. */
+  stage: slugSchema,
+  /**
+   * Stage frontmatter as a free-form object. Stage / status / references /
+   * written_at are managed by the harness and may be omitted (or, if set,
+   * are overridden). Stage-specific fields like `approved` or `score` are
+   * passed through.
+   */
+  frontmatter: z.record(z.string(), z.unknown()).default({}),
+  body: z.string().min(1),
+  /** Final stage status. Defaults to "complete". Use "blocked" or "failed" to halt the run. */
+  status: stageStatusSchema.optional(),
+  /** Optional structured outcome surfaced into state.json for fast lookup by later stages. */
+  outcome: z.record(z.string(), z.unknown()).optional(),
+});
+export type WorkflowAdvanceInputT = z.infer<typeof WorkflowAdvanceInput>;
+
+export const WorkflowStatusInput = z.object({
+  task_id: slugSchema,
+});
+export type WorkflowStatusInputT = z.infer<typeof WorkflowStatusInput>;
+
+export const WorkflowEnvelopeInput = z.object({
+  task_id: slugSchema,
+  /** Defaults to the run's current stage. */
+  stage: slugSchema.optional(),
+});
+export type WorkflowEnvelopeInputT = z.infer<typeof WorkflowEnvelopeInput>;
+
+/**
+ * Resolves the project root. The MCP server is started with cwd =
+ * project root and CORTEX_PROJECT_ROOT set to the same value (see
+ * bin/cortex.mjs `mcp` command). Tests pass cwd explicitly.
+ */
+export function resolveProjectRoot(): string {
+  const fromEnv = process.env.CORTEX_PROJECT_ROOT?.trim();
+  if (fromEnv) return fromEnv;
+  return process.cwd();
+}
+
+export type WorkflowToolContext = {
+  cwd: string;
+  workflows?: Record<string, WorkflowDefinition>;
+};
+
+function resolveWorkflow(
+  workflowId: string,
+  registry: Record<string, WorkflowDefinition> | undefined,
+): WorkflowDefinition {
+  const workflows = registry ?? DEFAULT_WORKFLOWS;
+  const workflow = workflows[workflowId];
+  if (!workflow) {
+    throw new Error(
+      `Unknown workflow_id: ${workflowId}. Available: ${Object.keys(workflows).join(", ") || "<none>"}`,
+    );
+  }
+  return workflow;
+}
+
+export function runWorkflowStart(
+  input: WorkflowStartInputT,
+  ctx: WorkflowToolContext,
+) {
+  const workflow = resolveWorkflow(input.workflow_id, ctx.workflows);
+  const state = createRun({
+    cwd: ctx.cwd,
+    taskId: input.task_id,
+    workflow,
+    taskDescription: input.task_description,
+  });
+  const envelope = composeStageEnvelope({
+    cwd: ctx.cwd,
+    taskId: input.task_id,
+    workflow,
+  });
+  return {
+    state,
+    envelope,
+  };
+}
+
+export function runWorkflowAdvance(
+  input: WorkflowAdvanceInputT,
+  ctx: WorkflowToolContext,
+) {
+  const state = getRunState(ctx.cwd, input.task_id);
+  if (!state) {
+    throw new Error(
+      `No run state found for task ${input.task_id}. Call cortex.workflow.start first.`,
+    );
+  }
+  const workflow = resolveWorkflow(state.workflow_id, ctx.workflows);
+  const stage = workflow.stages.find((s) => s.name === input.stage);
+  if (!stage) {
+    throw new Error(`Stage ${input.stage} is not defined in workflow ${workflow.id}`);
+  }
+
+  const finalStatus: StageStatus = input.status ?? "complete";
+
+  const nextState = advanceStage({
+    cwd: ctx.cwd,
+    taskId: input.task_id,
+    workflow,
+    stageName: input.stage,
+    artifactName: stage.artifact,
+    frontmatter: {
+      ...input.frontmatter,
+      stage: input.stage,
+      status: finalStatus,
+      references:
+        (Array.isArray((input.frontmatter as Record<string, unknown>).references)
+          ? ((input.frontmatter as Record<string, unknown>).references as unknown[])
+              .filter((v): v is string => typeof v === "string")
+          : null) ?? deriveReferencesFromReads(stage.reads, workflow),
+    },
+    body: input.body,
+    outcome: input.outcome,
+    status: finalStatus,
+  });
+
+  // If the run is still going, also return the next envelope so the caller
+  // can immediately know what comes next without a follow-up status round-trip.
+  let nextEnvelope: ReturnType<typeof composeStageEnvelope> | null = null;
+  if (nextState.outcome === "in_progress" && nextState.current_stage) {
+    nextEnvelope = composeStageEnvelope({
+      cwd: ctx.cwd,
+      taskId: input.task_id,
+      workflow,
+    });
+  }
+
+  return {
+    state: nextState,
+    next_envelope: nextEnvelope,
+  };
+}
+
+function deriveReferencesFromReads(
+  reads: string[],
+  workflow: WorkflowDefinition,
+): string[] {
+  const refs: string[] = [];
+  for (const readName of reads) {
+    const stage = workflow.stages.find((s) => s.name === readName);
+    if (stage) refs.push(stage.artifact);
+  }
+  return refs;
+}
+
+export function runWorkflowStatus(
+  input: WorkflowStatusInputT,
+  ctx: WorkflowToolContext,
+) {
+  const state = getRunState(ctx.cwd, input.task_id);
+  return { state };
+}
+
+export function runWorkflowEnvelope(
+  input: WorkflowEnvelopeInputT,
+  ctx: WorkflowToolContext,
+) {
+  const state = getRunState(ctx.cwd, input.task_id);
+  if (!state) {
+    throw new Error(
+      `No run state found for task ${input.task_id}. Call cortex.workflow.start first.`,
+    );
+  }
+  const workflow = resolveWorkflow(state.workflow_id, ctx.workflows);
+  const envelope = composeStageEnvelope({
+    cwd: ctx.cwd,
+    taskId: input.task_id,
+    workflow,
+    stageName: input.stage,
+  });
+  return { envelope };
+}

--- a/scaffold/mcp/src/server.ts
+++ b/scaffold/mcp/src/server.ts
@@ -11,6 +11,17 @@ import {
   getSessionEventHook,
   loadPlugins,
 } from "./plugin.js";
+import {
+  WorkflowStartInput,
+  WorkflowAdvanceInput,
+  WorkflowStatusInput,
+  WorkflowEnvelopeInput,
+  resolveProjectRoot,
+  runWorkflowAdvance,
+  runWorkflowEnvelope,
+  runWorkflowStart,
+  runWorkflowStatus,
+} from "./core/workflow/mcp-tools.js";
 
 type ToolPayload = Record<string, unknown>;
 
@@ -321,6 +332,70 @@ function registerTools(server: McpServer): void {
       const parsed = ReloadInput.parse(input ?? {});
       return reloadContextGraph(parsed.force);
     })
+  );
+
+  server.registerTool(
+    "cortex.workflow.start",
+    {
+      description:
+        "Start a Cortex Harness workflow run for a task. Creates .agents/<task_id>/state.json and returns the first stage's envelope (the prompt the agent should answer).",
+      inputSchema: WorkflowStartInput,
+    },
+    async (input) => executeInstrumentedTool(
+      "cortex.workflow.start",
+      input,
+      async () => runWorkflowStart(WorkflowStartInput.parse(input ?? {}), {
+        cwd: resolveProjectRoot(),
+      }) as ToolPayload,
+    ),
+  );
+
+  server.registerTool(
+    "cortex.workflow.advance",
+    {
+      description:
+        "Complete the current stage of a workflow run by writing its artifact and advancing the run pointer. Returns the new run state plus the next stage's envelope (or null when the run is finished, blocked, or failed).",
+      inputSchema: WorkflowAdvanceInput,
+    },
+    async (input) => executeInstrumentedTool(
+      "cortex.workflow.advance",
+      input,
+      async () => runWorkflowAdvance(WorkflowAdvanceInput.parse(input ?? {}), {
+        cwd: resolveProjectRoot(),
+      }) as ToolPayload,
+    ),
+  );
+
+  server.registerTool(
+    "cortex.workflow.status",
+    {
+      description:
+        "Read the current run state for a task (current stage, completed stages, outcome). Returns null state when no run exists for the given task_id.",
+      inputSchema: WorkflowStatusInput,
+    },
+    async (input) => executeInstrumentedTool(
+      "cortex.workflow.status",
+      input,
+      async () => runWorkflowStatus(WorkflowStatusInput.parse(input ?? {}), {
+        cwd: resolveProjectRoot(),
+      }) as ToolPayload,
+    ),
+  );
+
+  server.registerTool(
+    "cortex.workflow.envelope",
+    {
+      description:
+        "Compose the prompt envelope for a workflow stage without advancing the run. Defaults to the run's current_stage; pass `stage` to dry-run a different stage.",
+      inputSchema: WorkflowEnvelopeInput,
+    },
+    async (input) => executeInstrumentedTool(
+      "cortex.workflow.envelope",
+      input,
+      async () => runWorkflowEnvelope(WorkflowEnvelopeInput.parse(input ?? {}), {
+        cwd: resolveProjectRoot(),
+      }) as ToolPayload,
+    ),
   );
 }
 

--- a/scaffold/mcp/tests/workflow-mcp-tools.test.mjs
+++ b/scaffold/mcp/tests/workflow-mcp-tools.test.mjs
@@ -1,0 +1,293 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  WorkflowStartInput,
+  WorkflowAdvanceInput,
+  WorkflowStatusInput,
+  WorkflowEnvelopeInput,
+  runWorkflowStart,
+  runWorkflowAdvance,
+  runWorkflowStatus,
+  runWorkflowEnvelope,
+} from "../dist/core/workflow/mcp-tools.js";
+import { SECURE_BUILD_WORKFLOW } from "../dist/core/workflow/default-workflows.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-mcp-tools-"));
+}
+
+const TINY_WORKFLOW = {
+  id: "tiny",
+  description: "Two-stage tests workflow",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: [],
+      capability: "planner",
+      description: "Produce a plan.",
+    },
+    {
+      name: "review",
+      artifact: "review.md",
+      reads: ["plan"],
+      required_fields: ["approved"],
+      capability: "reviewer",
+      description: "Review the plan.",
+    },
+  ],
+};
+
+const TINY_REGISTRY = { tiny: TINY_WORKFLOW };
+
+test("input schemas: workflow_id defaults to secure-build", () => {
+  const parsed = WorkflowStartInput.parse({
+    task_id: "abc",
+    task_description: "y",
+  });
+  assert.equal(parsed.workflow_id, "secure-build");
+});
+
+test("input schemas: advance requires stage + body", () => {
+  assert.throws(() => WorkflowAdvanceInput.parse({ task_id: "abc" }));
+  assert.throws(() =>
+    WorkflowAdvanceInput.parse({ task_id: "abc", stage: "plan", body: "" }),
+  );
+});
+
+test("input schemas: status accepts only task_id", () => {
+  const parsed = WorkflowStatusInput.parse({ task_id: "abc" });
+  assert.equal(parsed.task_id, "abc");
+});
+
+test("input schemas: envelope stage is optional", () => {
+  const parsed = WorkflowEnvelopeInput.parse({ task_id: "abc" });
+  assert.equal(parsed.stage, undefined);
+});
+
+test("runWorkflowStart: creates run and returns the first envelope", () => {
+  const cwd = makeWorkspace();
+  const result = runWorkflowStart(
+    {
+      task_id: "task-1",
+      task_description: "Add login flow",
+      workflow_id: "tiny",
+    },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  assert.equal(result.state.task_id, "task-1");
+  assert.equal(result.state.current_stage, "plan");
+  assert.equal(result.state.outcome, "in_progress");
+  assert.equal(result.envelope.expectedArtifact, "plan.md");
+  assert.match(result.envelope.prompt, /# STAGE: plan/);
+
+  // state.json persisted under .agents/<task-id>/
+  const statePath = path.join(cwd, ".agents", "task-1", "state.json");
+  assert.ok(fs.existsSync(statePath));
+});
+
+test("runWorkflowStart: rejects unknown workflow_id", () => {
+  const cwd = makeWorkspace();
+  assert.throws(
+    () =>
+      runWorkflowStart(
+        { task_id: "task-1", task_description: "x", workflow_id: "nope" },
+        { cwd, workflows: TINY_REGISTRY },
+      ),
+    /Unknown workflow_id/,
+  );
+});
+
+test("runWorkflowStart: defaults to bundled DEFAULT_WORKFLOWS when no registry given", () => {
+  const cwd = makeWorkspace();
+  const result = runWorkflowStart(
+    {
+      task_id: "task-1",
+      task_description: "Use the default workflow",
+      workflow_id: SECURE_BUILD_WORKFLOW.id,
+    },
+    { cwd },
+  );
+  assert.equal(result.state.workflow_id, "secure-build");
+  assert.equal(result.envelope.expectedArtifact, "plan.md");
+});
+
+test("runWorkflowAdvance: writes artifact + state, returns next envelope while in_progress", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-2", task_description: "Multi-stage", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const advance = runWorkflowAdvance(
+    {
+      task_id: "task-2",
+      stage: "plan",
+      frontmatter: {},
+      body: "# Plan\n\nDetailed plan body.",
+    },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  assert.equal(advance.state.current_stage, "review");
+  assert.equal(advance.state.outcome, "in_progress");
+  assert.equal(advance.state.stages[0].status, "complete");
+  assert.equal(advance.state.stages[0].artifact, "plan.md");
+  assert.ok(advance.next_envelope);
+  assert.equal(advance.next_envelope.expectedArtifact, "review.md");
+  // The handoff renders the plan artifact inline.
+  assert.match(advance.next_envelope.prompt, /--- handoff:plan \(plan\.md\) ---/);
+});
+
+test("runWorkflowAdvance: returns next_envelope=null when run completes", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-3", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+  runWorkflowAdvance(
+    { task_id: "task-3", stage: "plan", frontmatter: {}, body: "# Plan" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const finalAdvance = runWorkflowAdvance(
+    {
+      task_id: "task-3",
+      stage: "review",
+      frontmatter: { approved: true },
+      body: "# Review\n\nLooks good.",
+      outcome: { approved: true },
+    },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  assert.equal(finalAdvance.state.current_stage, null);
+  assert.equal(finalAdvance.state.outcome, "complete");
+  assert.equal(finalAdvance.next_envelope, null);
+});
+
+test("runWorkflowAdvance: blocked status halts the run and returns null envelope", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-4", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const result = runWorkflowAdvance(
+    {
+      task_id: "task-4",
+      stage: "plan",
+      frontmatter: {},
+      body: "# Plan blocked\n\nMissing context.",
+      status: "blocked",
+    },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  assert.equal(result.state.outcome, "blocked");
+  assert.equal(result.state.current_stage, null);
+  assert.equal(result.next_envelope, null);
+});
+
+test("runWorkflowAdvance: rejects when no run exists", () => {
+  const cwd = makeWorkspace();
+  assert.throws(
+    () =>
+      runWorkflowAdvance(
+        {
+          task_id: "ghost",
+          stage: "plan",
+          frontmatter: {},
+          body: "# Plan",
+        },
+        { cwd, workflows: TINY_REGISTRY },
+      ),
+    /No run state/,
+  );
+});
+
+test("runWorkflowAdvance: auto-derives references from stage.reads when caller omits them", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-5", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+  runWorkflowAdvance(
+    { task_id: "task-5", stage: "plan", frontmatter: {}, body: "# Plan" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+  runWorkflowAdvance(
+    {
+      task_id: "task-5",
+      stage: "review",
+      frontmatter: { approved: false },
+      body: "# Review",
+    },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const reviewArtifact = path.join(cwd, ".agents", "task-5", "review.md");
+  const text = fs.readFileSync(reviewArtifact, "utf8");
+  assert.match(text, /references:/);
+  assert.match(text, /- plan\.md/);
+});
+
+test("runWorkflowStatus: returns state for an active run", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-6", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const result = runWorkflowStatus({ task_id: "task-6" }, { cwd, workflows: TINY_REGISTRY });
+  assert.equal(result.state?.task_id, "task-6");
+  assert.equal(result.state?.current_stage, "plan");
+});
+
+test("runWorkflowStatus: returns null state when nothing exists", () => {
+  const cwd = makeWorkspace();
+  const result = runWorkflowStatus({ task_id: "no-run" }, { cwd, workflows: TINY_REGISTRY });
+  assert.equal(result.state, null);
+});
+
+test("runWorkflowEnvelope: returns current envelope without mutating state", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-7", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  const before = runWorkflowStatus({ task_id: "task-7" }, { cwd, workflows: TINY_REGISTRY });
+  const envelope = runWorkflowEnvelope(
+    { task_id: "task-7" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+  const after = runWorkflowStatus({ task_id: "task-7" }, { cwd, workflows: TINY_REGISTRY });
+
+  assert.equal(envelope.envelope.expectedArtifact, "plan.md");
+  assert.deepEqual(before.state, after.state);
+});
+
+test("runWorkflowEnvelope: explicit stage overrides current_stage for dry-run", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-8", task_description: "x", workflow_id: "tiny" },
+    { cwd, workflows: TINY_REGISTRY },
+  );
+
+  // Dry-run review even though we're at plan — should fail because review
+  // requires plan's artifact to exist.
+  assert.throws(() =>
+    runWorkflowEnvelope(
+      { task_id: "task-8", stage: "review" },
+      { cwd, workflows: TINY_REGISTRY },
+    ),
+  );
+});


### PR DESCRIPTION
Re-PR of #68 after rebase onto main. Same diff, just rebased after #66 + #71 merged and original PRs auto-closed.

Four MCP tools: cortex.workflow.start / advance / status / envelope. Pure runners in src/core/workflow/mcp-tools.ts; thin shim in src/server.ts. 16 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)