### PR TITLE
Capability registry + pre-tool-use enforcement

### DIFF
--- a/scaffold/mcp/package-lock.json
+++ b/scaffold/mcp/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/js-yaml": "^4.0.9",
         "js-yaml": "^4.1.1",
+        "minimatch": "^10.2.5",
         "ryugraph": "^25.9.1",
         "zod": "^3.24.1"
       },
@@ -1002,6 +1003,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -1032,6 +1042,18 @@
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1962,6 +1984,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {

--- a/scaffold/mcp/package.json
+++ b/scaffold/mcp/package.json
@@ -16,6 +16,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/js-yaml": "^4.0.9",
     "js-yaml": "^4.1.1",
+    "minimatch": "^10.2.5",
     "ryugraph": "^25.9.1",
     "zod": "^3.24.1"
   },

--- a/scaffold/mcp/src/core/workflow/capabilities.ts
+++ b/scaffold/mcp/src/core/workflow/capabilities.ts
@@ -1,0 +1,100 @@
+import { z } from "zod";
+
+/**
+ * Capability registry for the harness. A capability is a least-privilege
+ * profile referenced by a workflow stage's `capability` field. The
+ * pre-tool-use hook reads the active stage's capability and uses it to
+ * gate the agent's tool calls.
+ *
+ * The capability defines:
+ *   - read_globs    paths the agent may read (empty = no restriction)
+ *   - write_globs   paths the agent may modify (empty = read-only)
+ *   - tools_allowed which tool names the agent may call (empty = all)
+ *
+ * Glob patterns use minimatch syntax. The harness ships a default set
+ * keyed by the names referenced in default-workflows.ts; orgs can ship
+ * additional capabilities later via cortex-web sync.
+ */
+
+const slugSchema = z
+  .string()
+  .min(1)
+  .max(80)
+  .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+
+export const capabilityDefinitionSchema = z.object({
+  name: slugSchema,
+  description: z.string().min(1).max(500),
+  read_globs: z.array(z.string().min(1)).default([]),
+  write_globs: z.array(z.string().min(1)).default([]),
+  tools_allowed: z.array(z.string().min(1)).default([]),
+});
+
+export type CapabilityDefinition = z.infer<typeof capabilityDefinitionSchema>;
+
+/**
+ * Default capability profiles that ship with Cortex. Names match the
+ * `capability` fields referenced by SECURE_BUILD_WORKFLOW.
+ *
+ * tools_allowed is intentionally empty for most profiles to mean
+ * "no per-tool restriction beyond what the file globs already imply".
+ * The hook layer checks file paths first, tool name second.
+ */
+export const DEFAULT_CAPABILITIES: Record<string, CapabilityDefinition> = {
+  planner: {
+    name: "planner",
+    description:
+      "Read-only profile for stages that produce planning artifacts. " +
+      "Can read the whole repo and call context tools, cannot modify any files.",
+    read_globs: ["**"],
+    write_globs: [],
+    tools_allowed: [],
+  },
+  reviewer: {
+    name: "reviewer",
+    description:
+      "Read-only profile for review stages. Same access as planner; the " +
+      "review artifact itself is written by the harness, not by an Edit tool.",
+    read_globs: ["**"],
+    write_globs: [],
+    tools_allowed: [],
+  },
+  builder: {
+    name: "builder",
+    description:
+      "Build profile. May edit source and test files but not config, " +
+      "lockfiles, CI workflows, or anything outside the obvious app surface.",
+    read_globs: ["**"],
+    write_globs: ["src/**", "tests/**", "test/**", "lib/**", "app/**", "components/**"],
+    tools_allowed: [],
+  },
+  tester: {
+    name: "tester",
+    description:
+      "Mutation/test profile. Read-only on production code, may edit only " +
+      "test files. Used by mutation-testing or coverage-improvement stages.",
+    read_globs: ["**"],
+    write_globs: ["tests/**", "test/**", "**/*.test.ts", "**/*.test.tsx", "**/*.test.mjs", "**/*.spec.ts"],
+    tools_allowed: [],
+  },
+  "security-reviewer": {
+    name: "security-reviewer",
+    description:
+      "Security review profile. Read-only across the repo. Produces a " +
+      "report artifact; no source modifications allowed.",
+    read_globs: ["**"],
+    write_globs: [],
+    tools_allowed: [],
+  },
+  human: {
+    name: "human",
+    description:
+      "Sentinel capability for human approval stages. The harness does not " +
+      "invoke an agent for this stage; the human writes the artifact directly. " +
+      "If a tool call somehow reaches the hook under this capability, it is " +
+      "blocked because no automation should be running.",
+    read_globs: [],
+    write_globs: [],
+    tools_allowed: [],
+  },
+};

--- a/scaffold/mcp/src/core/workflow/enforcement.ts
+++ b/scaffold/mcp/src/core/workflow/enforcement.ts
@@ -1,0 +1,206 @@
+import { isAbsolute, relative } from "node:path";
+import { minimatch } from "minimatch";
+import { readRunState } from "./artifact-io.js";
+import { DEFAULT_CAPABILITIES, type CapabilityDefinition } from "./capabilities.js";
+import { workflowDefinitionSchema, type WorkflowDefinition } from "./schemas.js";
+import { DEFAULT_WORKFLOWS } from "./default-workflows.js";
+
+/**
+ * Pre-tool-use enforcement for the harness. Pure function: takes the tool
+ * call shape Claude Code emits, looks up the active workflow stage's
+ * capability, returns allow/deny + reason. The hook wires this into the
+ * stdin/exit-code dance.
+ *
+ * "Active task" is identified by env var CORTEX_ACTIVE_TASK_ID. The
+ * harness sets this when invoking an agent for a stage; outside the
+ * harness, the env var is unset and this evaluator is a no-op (returns
+ * { allowed: true }).
+ */
+
+export type ToolCall = {
+  toolName: string;
+  toolInput: Record<string, unknown>;
+};
+
+export type EnforcementResult =
+  | { allowed: true; reason?: string }
+  | { allowed: false; reason: string };
+
+export type EvaluateOptions = {
+  cwd: string;
+  taskId: string;
+  call: ToolCall;
+  workflows?: Record<string, WorkflowDefinition>;
+  capabilities?: Record<string, CapabilityDefinition>;
+};
+
+/**
+ * Tool names that are pure mutations of the file system. Edits and writes
+ * gate against `write_globs`. Bash is treated as a mutation by default
+ * because we cannot reliably extract paths from arbitrary shell — agents
+ * running in restricted-write capabilities lose Bash unless the
+ * capability explicitly allow-lists it.
+ */
+const MUTATING_TOOLS = new Set(["Edit", "Write", "MultiEdit", "NotebookEdit"]);
+
+/**
+ * Tool names that read but do not mutate. Gate against `read_globs`.
+ */
+const READING_TOOLS = new Set(["Read", "Grep", "Glob", "NotebookRead"]);
+
+export function evaluateToolCall(options: EvaluateOptions): EnforcementResult {
+  const state = readRunState(options.cwd, options.taskId);
+  if (!state) {
+    return { allowed: true, reason: "no run state — harness not active" };
+  }
+  if (state.outcome !== "in_progress" || !state.current_stage) {
+    return {
+      allowed: true,
+      reason: `run not in progress (outcome=${state.outcome}) — no capability gate to apply`,
+    };
+  }
+
+  const workflows = options.workflows ?? DEFAULT_WORKFLOWS;
+  const workflow = workflows[state.workflow_id];
+  if (!workflow) {
+    return {
+      allowed: false,
+      reason: `unknown workflow_id ${state.workflow_id}; cannot resolve capability for current stage`,
+    };
+  }
+  // Validate so corrupt input doesn't slip through.
+  workflowDefinitionSchema.parse(workflow);
+
+  const stage = workflow.stages.find((s) => s.name === state.current_stage);
+  if (!stage) {
+    return {
+      allowed: false,
+      reason: `current stage ${state.current_stage} is not defined in workflow ${workflow.id}`,
+    };
+  }
+
+  if (!stage.capability) {
+    return { allowed: true, reason: "stage has no capability declared" };
+  }
+
+  const capabilities = options.capabilities ?? DEFAULT_CAPABILITIES;
+  const capability = capabilities[stage.capability];
+  if (!capability) {
+    return {
+      allowed: false,
+      reason: `capability ${stage.capability} (referenced by stage ${stage.name}) is not in the registry`,
+    };
+  }
+
+  return evaluateAgainstCapability(capability, options.call, options.cwd);
+}
+
+function evaluateAgainstCapability(
+  capability: CapabilityDefinition,
+  call: ToolCall,
+  cwd: string,
+): EnforcementResult {
+  // 1. tools_allowed: empty = no restriction; otherwise tool must be in the list.
+  if (
+    capability.tools_allowed.length > 0 &&
+    !capability.tools_allowed.includes(call.toolName)
+  ) {
+    return {
+      allowed: false,
+      reason: `capability ${capability.name} does not allow tool ${call.toolName}`,
+    };
+  }
+
+  const isMutation = MUTATING_TOOLS.has(call.toolName);
+  const isRead = READING_TOOLS.has(call.toolName);
+
+  // Bash is special: with restricted write_globs we have to assume the
+  // worst (since the shell can write anywhere). Block unless capability
+  // explicitly allow-lists Bash via tools_allowed.
+  if (call.toolName === "Bash") {
+    const isAllowedViaToolList = capability.tools_allowed.includes("Bash");
+    const writesUnrestricted = capability.write_globs.length === 0;
+    if (writesUnrestricted && !isAllowedViaToolList) {
+      return {
+        allowed: false,
+        reason: `capability ${capability.name} is read-only; Bash can mutate the filesystem and is not allow-listed`,
+      };
+    }
+    return { allowed: true };
+  }
+
+  if (isMutation) {
+    if (capability.write_globs.length === 0) {
+      return {
+        allowed: false,
+        reason: `capability ${capability.name} is read-only; ${call.toolName} cannot run`,
+      };
+    }
+    const targetPath = extractFilePath(call.toolInput);
+    if (!targetPath) {
+      return {
+        allowed: false,
+        reason: `${call.toolName} did not include a file_path; cannot verify against capability ${capability.name}`,
+      };
+    }
+    const relPath = toRepoRelative(cwd, targetPath);
+    if (!matchesAnyGlob(relPath, capability.write_globs)) {
+      return {
+        allowed: false,
+        reason: `path ${relPath} is outside capability ${capability.name}'s write_globs (${capability.write_globs.join(", ")})`,
+      };
+    }
+    return { allowed: true };
+  }
+
+  if (isRead) {
+    if (capability.read_globs.length === 0) {
+      // No reads allowed at all — only the human capability lands here.
+      return {
+        allowed: false,
+        reason: `capability ${capability.name} does not permit any read operations`,
+      };
+    }
+    const targetPath = extractFilePath(call.toolInput);
+    if (!targetPath) {
+      // Some read tools (Grep, Glob) operate on the whole repo; allow
+      // through if the capability has any read access at all.
+      return { allowed: true };
+    }
+    const relPath = toRepoRelative(cwd, targetPath);
+    if (!matchesAnyGlob(relPath, capability.read_globs)) {
+      return {
+        allowed: false,
+        reason: `path ${relPath} is outside capability ${capability.name}'s read_globs (${capability.read_globs.join(", ")})`,
+      };
+    }
+    return { allowed: true };
+  }
+
+  // Unknown tool — fall through to allow if not explicitly restricted.
+  return { allowed: true };
+}
+
+function extractFilePath(toolInput: Record<string, unknown>): string | null {
+  const candidates = ["file_path", "path", "notebook_path"];
+  for (const key of candidates) {
+    const value = toolInput[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return null;
+}
+
+function toRepoRelative(cwd: string, targetPath: string): string {
+  if (!isAbsolute(targetPath)) return targetPath;
+  const rel = relative(cwd, targetPath);
+  // If the path is outside the repo, return the absolute form so glob
+  // matches (which expect repo-relative) reliably miss.
+  if (rel.startsWith("..")) return targetPath;
+  return rel;
+}
+
+function matchesAnyGlob(path: string, globs: string[]): boolean {
+  return globs.some((pattern) =>
+    minimatch(path, pattern, { dot: true, nocase: false }),
+  );
+}

--- a/scaffold/mcp/src/core/workflow/index.ts
+++ b/scaffold/mcp/src/core/workflow/index.ts
@@ -4,3 +4,5 @@ export * from "./run-lifecycle.js";
 export * from "./envelope.js";
 export * from "./default-workflows.js";
 export * from "./mcp-tools.js";
+export * from "./capabilities.js";
+export * from "./enforcement.js";

--- a/scaffold/mcp/src/hooks/pre-tool-use.ts
+++ b/scaffold/mcp/src/hooks/pre-tool-use.ts
@@ -8,6 +8,7 @@ import {
   resolveDaemonEntry,
   sendHeartbeat,
 } from "./shared.js";
+import { evaluateToolCall } from "../core/workflow/enforcement.js";
 
 /**
  * PreToolUse hook for Claude Code.
@@ -44,6 +45,35 @@ async function main(): Promise<void> {
       session_id: input.session_id,
       cwd,
     });
+  }
+
+  // Workflow capability gate. Runs before policy.check so harness-level
+  // restrictions block before the daemon's general policy machinery sees
+  // the call. No-op when CORTEX_ACTIVE_TASK_ID is unset.
+  const activeTaskId = process.env.CORTEX_ACTIVE_TASK_ID?.trim();
+  if (activeTaskId) {
+    try {
+      const verdict = evaluateToolCall({
+        cwd,
+        taskId: activeTaskId,
+        call: { toolName: tool, toolInput: input.tool_input ?? {} },
+      });
+      if (!verdict.allowed) {
+        process.stderr.write(
+          `[cortex] Blocked by harness capability: ${verdict.reason}\n`,
+        );
+        process.exit(2);
+      }
+    } catch (err) {
+      // Capability evaluation should never crash the hook — if it does,
+      // log and fall through to the existing policy.check rather than
+      // accidentally blocking a legitimate tool.
+      process.stderr.write(
+        `[cortex] capability evaluation failed (${
+          err instanceof Error ? err.message : String(err)
+        }); deferring to policy.check\n`,
+      );
+    }
   }
 
   const payload: PolicyCheckPayload = {

--- a/scaffold/mcp/tests/workflow-enforcement.test.mjs
+++ b/scaffold/mcp/tests/workflow-enforcement.test.mjs
@@ -1,0 +1,370 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { evaluateToolCall } from "../dist/core/workflow/enforcement.js";
+import { createRun } from "../dist/core/workflow/run-lifecycle.js";
+import { capabilityDefinitionSchema, DEFAULT_CAPABILITIES } from "../dist/core/workflow/capabilities.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-enforcement-"));
+}
+
+const WORKFLOW_PLANNER = {
+  id: "planner-only",
+  description: "Single planner stage",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: [],
+      capability: "planner",
+      description: "Plan",
+    },
+  ],
+};
+
+const WORKFLOW_BUILDER = {
+  id: "builder-only",
+  description: "Single builder stage",
+  version: 1,
+  stages: [
+    {
+      name: "build",
+      artifact: "changes.md",
+      reads: [],
+      required_fields: [],
+      capability: "builder",
+      description: "Build",
+    },
+  ],
+};
+
+const WORKFLOWS = {
+  "planner-only": WORKFLOW_PLANNER,
+  "builder-only": WORKFLOW_BUILDER,
+};
+
+function startPlannerRun(cwd, taskId = "task-1") {
+  return createRun({
+    cwd,
+    taskId,
+    workflow: WORKFLOW_PLANNER,
+    taskDescription: "x",
+  });
+}
+
+function startBuilderRun(cwd, taskId = "task-1") {
+  return createRun({
+    cwd,
+    taskId,
+    workflow: WORKFLOW_BUILDER,
+    taskDescription: "x",
+  });
+}
+
+test("capabilities: default registry validates against schema", () => {
+  for (const cap of Object.values(DEFAULT_CAPABILITIES)) {
+    capabilityDefinitionSchema.parse(cap);
+  }
+});
+
+test("evaluator: allows everything when no run state exists", () => {
+  const cwd = makeWorkspace();
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "ghost",
+    call: { toolName: "Edit", toolInput: { file_path: "src/foo.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("planner: blocks Edit (read-only capability)", () => {
+  const cwd = makeWorkspace();
+  startPlannerRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "src/foo.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /read-only/);
+});
+
+test("planner: blocks Bash (could mutate filesystem under read-only)", () => {
+  const cwd = makeWorkspace();
+  startPlannerRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Bash", toolInput: { command: "rm -rf /" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /Bash/);
+});
+
+test("planner: allows Read on any path", () => {
+  const cwd = makeWorkspace();
+  startPlannerRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Read", toolInput: { file_path: "src/anything.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("planner: allows Grep without explicit path", () => {
+  const cwd = makeWorkspace();
+  startPlannerRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Grep", toolInput: { pattern: "TODO" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("builder: allows Edit on src/", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "src/foo.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("builder: allows Edit on tests/", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "tests/foo.test.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("builder: blocks Edit on package.json (outside write_globs)", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "package.json" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /outside capability builder/);
+});
+
+test("builder: blocks Edit on .github/workflows (CI file)", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: {
+      toolName: "Edit",
+      toolInput: { file_path: ".github/workflows/release.yml" },
+    },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+});
+
+test("builder: handles absolute path inside cwd", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const abs = path.join(cwd, "src", "foo.ts");
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: abs } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("builder: blocks absolute path outside cwd", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "/etc/passwd" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+});
+
+test("builder: blocks Edit without file_path", () => {
+  const cwd = makeWorkspace();
+  startBuilderRun(cwd);
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: {} },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /did not include a file_path/);
+});
+
+test("evaluator: tools_allowed list restricts tools by name", () => {
+  const cwd = makeWorkspace();
+  const customCapabilities = {
+    ...DEFAULT_CAPABILITIES,
+    "search-only": {
+      name: "search-only",
+      description: "Only Read + Grep allowed",
+      read_globs: ["**"],
+      write_globs: [],
+      tools_allowed: ["Read", "Grep"],
+    },
+  };
+  const customWorkflow = {
+    id: "search-only",
+    description: "Search only",
+    version: 1,
+    stages: [
+      {
+        name: "scan",
+        artifact: "scan.md",
+        reads: [],
+        required_fields: [],
+        capability: "search-only",
+        description: "Scan",
+      },
+    ],
+  };
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: customWorkflow,
+    taskDescription: "x",
+  });
+
+  const grep = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Grep", toolInput: { pattern: "x" } },
+    workflows: { "search-only": customWorkflow },
+    capabilities: customCapabilities,
+  });
+  assert.equal(grep.allowed, true);
+
+  const glob = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Glob", toolInput: { pattern: "*.ts" } },
+    workflows: { "search-only": customWorkflow },
+    capabilities: customCapabilities,
+  });
+  assert.equal(glob.allowed, false);
+  assert.match(glob.reason, /does not allow tool Glob/);
+});
+
+test("evaluator: human capability blocks all tool calls", () => {
+  const cwd = makeWorkspace();
+  const humanWorkflow = {
+    id: "human-only",
+    description: "Human-only stage",
+    version: 1,
+    stages: [
+      {
+        name: "approval",
+        artifact: "approval.md",
+        reads: [],
+        required_fields: [],
+        capability: "human",
+        description: "Approve",
+      },
+    ],
+  };
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: humanWorkflow,
+    taskDescription: "x",
+  });
+
+  const read = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Read", toolInput: { file_path: "src/foo.ts" } },
+    workflows: { "human-only": humanWorkflow },
+  });
+  assert.equal(read.allowed, false);
+});
+
+test("evaluator: stage without capability is unrestricted", () => {
+  const cwd = makeWorkspace();
+  const noCapabilityWorkflow = {
+    id: "free",
+    description: "No capability",
+    version: 1,
+    stages: [
+      {
+        name: "free-stage",
+        artifact: "out.md",
+        reads: [],
+        required_fields: [],
+        description: "No restriction",
+      },
+    ],
+  };
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: noCapabilityWorkflow,
+    taskDescription: "x",
+  });
+
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Bash", toolInput: { command: "ls" } },
+    workflows: { free: noCapabilityWorkflow },
+  });
+  assert.equal(result.allowed, true);
+});
+
+test("evaluator: completed run does not gate any tool calls", () => {
+  const cwd = makeWorkspace();
+  const completed = createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW_PLANNER,
+    taskDescription: "x",
+  });
+  // Manually corrupt to "complete" without going through advanceStage —
+  // simulates a run that finished before the hook fires.
+  const statePath = path.join(cwd, ".agents", "task-1", "state.json");
+  const raw = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  raw.outcome = "complete";
+  raw.current_stage = null;
+  raw.completed_at = new Date().toISOString();
+  fs.writeFileSync(statePath, JSON.stringify(raw, null, 2));
+
+  const result = evaluateToolCall({
+    cwd,
+    taskId: "task-1",
+    call: { toolName: "Edit", toolInput: { file_path: "src/foo.ts" } },
+    workflows: WORKFLOWS,
+  });
+  assert.equal(result.allowed, true);
+});


### PR DESCRIPTION
Re-PR of #69 after rebase. capabilities.ts + enforcement.ts + pre-tool-use hook integration. 17 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)