### PR TITLE
Add cortex stage drive auto-orchestrator

### DIFF
--- a/bin/cortex.mjs
+++ b/bin/cortex.mjs
@@ -95,6 +95,7 @@ function printHelp() {
   console.log(helpRow("stage envelope --task-id <id> [--stage <name>]", "Compose stage prompt envelope"));
   console.log(helpRow("stage advance --task-id <id> --stage <name> --body-file <path>", "Write artifact, advance run"));
   console.log(helpRow("stage run --task-id <id> -- <command>", "Exec a command with CORTEX_ACTIVE_TASK_ID set"));
+  console.log(helpRow("stage drive --task-id <id> -- <agent>", "Auto-loop envelope→agent→advance until run finishes"));
 
   console.log(helpSection("MISC"));
   console.log(helpRow("mcp", "Run the MCP stdio server for the current project"));

--- a/scaffold/mcp/src/cli/stage-drive.ts
+++ b/scaffold/mcp/src/cli/stage-drive.ts
@@ -1,0 +1,197 @@
+import { spawn } from "node:child_process";
+import {
+  composeStageEnvelope,
+  createRun,
+  getRunState,
+  loadSyncedWorkflows,
+} from "../core/workflow/index.js";
+import { DEFAULT_WORKFLOWS } from "../core/workflow/default-workflows.js";
+import type { RunState, WorkflowDefinition } from "../core/workflow/schemas.js";
+
+/**
+ * Orchestrator for `cortex stage drive`. Loops through every stage of a
+ * workflow run until the run reaches a terminal state. For each stage:
+ *
+ *   1. Compose the stage envelope (prompt + expected artifact + capability).
+ *   2. Spawn the user-supplied agent command with:
+ *        - the envelope text written to stdin
+ *        - CORTEX_ACTIVE_TASK_ID set so the pre-tool-use hook applies the
+ *          stage's capability gate
+ *   3. Wait for the agent to exit. The agent is expected to call
+ *      cortex.workflow.advance (via MCP) before terminating.
+ *   4. Re-read the run state. If current_stage advanced, loop. If the
+ *      stage didn't advance, fail loud — a missing advance is a contract
+ *      violation, not a transient.
+ *
+ * The orchestrator never *itself* writes artifacts or advances the run.
+ * That keeps the trust model simple: every state transition is owned by
+ * a validated MCP/CLI call, never by orchestrator implicit behaviour.
+ */
+
+export type DriveOptions = {
+  cwd: string;
+  taskId: string;
+  /** Used only when no run exists yet. Ignored for resumption. */
+  description?: string;
+  /** Used only when no run exists yet. Defaults to "secure-build". */
+  workflowId?: string;
+  maxStages: number;
+  agentCommand: string;
+  agentArgs: string[];
+  /** Hook for tests / progress UI. Called once per stage transition. */
+  onStageStart?: (stage: string, envelopePrompt: string) => void;
+  onStageEnd?: (stage: string, nextState: RunState) => void;
+  /**
+   * Defaults to spawning a real subprocess. Tests pass a mock that
+   * mutates the run state directly (see workflow-drive.test.mjs).
+   */
+  spawnAgent?: SpawnAgentFn;
+  /** Optional registry override; tests pass an explicit one. */
+  workflows?: Record<string, WorkflowDefinition>;
+};
+
+export type DriveResult = {
+  state: RunState;
+  /** Number of stages this invocation drove (not the run's total). */
+  stagesDriven: number;
+};
+
+export type SpawnAgentArgs = {
+  cwd: string;
+  taskId: string;
+  envelopePrompt: string;
+  command: string;
+  args: string[];
+};
+
+export type SpawnAgentFn = (args: SpawnAgentArgs) => Promise<void>;
+
+function resolveRegistry(
+  override?: Record<string, WorkflowDefinition>,
+): Record<string, WorkflowDefinition> {
+  if (override) return override;
+  return { ...DEFAULT_WORKFLOWS, ...loadSyncedWorkflows() };
+}
+
+function ensureWorkflow(
+  workflowId: string,
+  registry: Record<string, WorkflowDefinition>,
+): WorkflowDefinition {
+  const workflow = registry[workflowId];
+  if (!workflow) {
+    throw new Error(
+      `Unknown workflow_id: ${workflowId}. Available: ${
+        Object.keys(registry).join(", ") || "<none>"
+      }`,
+    );
+  }
+  return workflow;
+}
+
+const defaultSpawnAgent: SpawnAgentFn = ({ cwd, taskId, envelopePrompt, command, args }) =>
+  new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ["pipe", "inherit", "inherit"],
+      env: {
+        ...process.env,
+        CORTEX_ACTIVE_TASK_ID: taskId,
+      },
+      cwd,
+    });
+
+    child.on("error", (err) => reject(err));
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`agent terminated by signal ${signal}`));
+        return;
+      }
+      if (code !== 0) {
+        reject(new Error(`agent exited with code ${code}`));
+        return;
+      }
+      resolve();
+    });
+
+    if (!child.stdin) {
+      reject(new Error("agent stdin is unavailable"));
+      return;
+    }
+    child.stdin.write(envelopePrompt);
+    child.stdin.end();
+  });
+
+export async function runDrive(options: DriveOptions): Promise<DriveResult> {
+  const registry = resolveRegistry(options.workflows);
+  const spawnAgent = options.spawnAgent ?? defaultSpawnAgent;
+
+  // Step 1: ensure a run exists. Resume or start.
+  let state = getRunState(options.cwd, options.taskId);
+  if (!state) {
+    if (!options.description) {
+      throw new Error(
+        `No run exists for task ${options.taskId} and --description was not provided. ` +
+          "Pass --description \"...\" to start a new run, or call cortex stage start first.",
+      );
+    }
+    const workflowId = options.workflowId ?? "secure-build";
+    const workflow = ensureWorkflow(workflowId, registry);
+    state = createRun({
+      cwd: options.cwd,
+      taskId: options.taskId,
+      workflow,
+      taskDescription: options.description,
+    });
+  }
+
+  let stagesDriven = 0;
+  while (state.outcome === "in_progress" && state.current_stage) {
+    if (stagesDriven >= options.maxStages) {
+      throw new Error(
+        `Reached --max-stages ${options.maxStages} without completing run for task ${options.taskId} ` +
+          `(current_stage: ${state.current_stage})`,
+      );
+    }
+
+    const workflow = ensureWorkflow(state.workflow_id, registry);
+    const previousStage = state.current_stage;
+
+    const envelope = composeStageEnvelope({
+      cwd: options.cwd,
+      taskId: options.taskId,
+      workflow,
+    });
+
+    options.onStageStart?.(previousStage, envelope.prompt);
+
+    await spawnAgent({
+      cwd: options.cwd,
+      taskId: options.taskId,
+      envelopePrompt: envelope.prompt,
+      command: options.agentCommand,
+      args: options.agentArgs,
+    });
+
+    const nextState = getRunState(options.cwd, options.taskId);
+    if (!nextState) {
+      throw new Error(
+        `Run state for task ${options.taskId} disappeared during stage ${previousStage}`,
+      );
+    }
+
+    if (
+      nextState.current_stage === previousStage &&
+      nextState.outcome === "in_progress"
+    ) {
+      throw new Error(
+        `Agent for stage ${previousStage} exited without advancing the run. ` +
+          `Did the agent call cortex.workflow.advance? CORTEX_ACTIVE_TASK_ID was ${options.taskId}.`,
+      );
+    }
+
+    options.onStageEnd?.(previousStage, nextState);
+    state = nextState;
+    stagesDriven += 1;
+  }
+
+  return { state, stagesDriven };
+}

--- a/scaffold/mcp/src/cli/stage.ts
+++ b/scaffold/mcp/src/cli/stage.ts
@@ -9,6 +9,7 @@ import {
   type WorkflowDefinition,
 } from "../core/workflow/index.js";
 import { DEFAULT_WORKFLOWS } from "../core/workflow/default-workflows.js";
+import { runDrive } from "./stage-drive.js";
 
 /**
  * `cortex stage` CLI surface. Each subcommand is a thin shell wrapper
@@ -46,6 +47,8 @@ export async function runStageCommand(args: string[]): Promise<void> {
       return runAdvance(rest);
     case "run":
       return runRun(rest);
+    case "drive":
+      return runDriveSub(rest);
     case "help":
     case "--help":
     case "-h":
@@ -66,8 +69,11 @@ function printHelp(): void {
     "  cortex stage advance  --task-id <id> --stage <name> --body-file <path>",
     "                        [--frontmatter-file <path>] [--status <s>] [--outcome-file <path>]",
     "  cortex stage run      --task-id <id> -- <command> [args...]",
+    "  cortex stage drive    --task-id <id> [--description \"...\"] [--workflow <id>]",
+    "                        [--max-stages <N>] -- <agent-command> [args...]",
     "",
     "Status values: complete (default) | blocked | failed",
+    "drive auto-loops envelope → spawn agent (envelope on stdin) → poll state until run finishes.",
     "All commands operate on .agents/<task-id>/ in the current project root.",
   ];
   process.stdout.write(lines.join("\n") + "\n");
@@ -322,4 +328,47 @@ async function runRun(args: string[]): Promise<void> {
       resolve();
     });
   });
+}
+
+async function runDriveSub(args: string[]): Promise<void> {
+  const { flags, rest } = parseFlags(args);
+  const taskId = requireFlag(flags, "task-id");
+  const description =
+    typeof flags.description === "string" ? flags.description : undefined;
+  const workflowId =
+    typeof flags.workflow === "string" ? flags.workflow : undefined;
+  const maxStagesRaw = flags["max-stages"];
+  const maxStages =
+    typeof maxStagesRaw === "string" && Number.isFinite(Number(maxStagesRaw))
+      ? Math.max(1, Math.floor(Number(maxStagesRaw)))
+      : 50;
+
+  if (rest.length === 0) {
+    throw new Error(
+      "cortex stage drive requires an agent command after --, " +
+        "e.g. 'cortex stage drive --task-id task-1 --description \"...\" -- claude --print'",
+    );
+  }
+  const [agentCommand, ...agentArgs] = rest;
+
+  const result = await runDrive({
+    cwd: projectRoot(),
+    taskId,
+    description,
+    workflowId,
+    maxStages,
+    agentCommand,
+    agentArgs,
+    onStageStart: (stage) => {
+      process.stderr.write(`[harness] stage: ${stage}\n`);
+    },
+    onStageEnd: (stage, nextState) => {
+      const summary = nextState.current_stage
+        ? `→ ${nextState.current_stage}`
+        : `(${nextState.outcome})`;
+      process.stderr.write(`[harness] stage ${stage} done ${summary}\n`);
+    },
+  });
+
+  emitJson({ state: result.state, stages_driven: result.stagesDriven });
 }

--- a/scaffold/mcp/tests/workflow-drive.test.mjs
+++ b/scaffold/mcp/tests/workflow-drive.test.mjs
@@ -1,0 +1,292 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { runDrive } from "../dist/cli/stage-drive.js";
+import {
+  createRun,
+  advanceStage,
+  getRunState,
+} from "../dist/core/workflow/run-lifecycle.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-drive-"));
+}
+
+const TINY_WORKFLOW = {
+  id: "tiny",
+  description: "Two-stage tests workflow",
+  version: 1,
+  stages: [
+    {
+      name: "plan",
+      artifact: "plan.md",
+      reads: [],
+      required_fields: [],
+      capability: "planner",
+      description: "Produce a plan.",
+    },
+    {
+      name: "review",
+      artifact: "review.md",
+      reads: ["plan"],
+      required_fields: ["approved"],
+      capability: "reviewer",
+      description: "Review the plan.",
+    },
+  ],
+};
+
+const REGISTRY = { tiny: TINY_WORKFLOW };
+
+/**
+ * Fake agent that "completes" the current stage by directly calling
+ * advanceStage(). The real flow is: agent gets envelope on stdin →
+ * agent does work → agent calls cortex.workflow.advance via MCP. This
+ * mock collapses that into a synchronous call for unit-test purposes.
+ */
+function makeAdvancingAgent({
+  status = "complete",
+  body = "# Stage body",
+  frontmatter = {},
+} = {}) {
+  return async (args) => {
+    const state = getRunState(args.cwd, args.taskId);
+    if (!state || !state.current_stage) {
+      throw new Error("agent invoked but run is not in progress");
+    }
+    const stage = TINY_WORKFLOW.stages.find((s) => s.name === state.current_stage);
+    if (!stage) throw new Error(`unknown stage ${state.current_stage}`);
+    advanceStage({
+      cwd: args.cwd,
+      taskId: args.taskId,
+      workflow: TINY_WORKFLOW,
+      stageName: state.current_stage,
+      artifactName: stage.artifact,
+      frontmatter: {
+        stage: state.current_stage,
+        status,
+        references: [],
+        ...frontmatter,
+      },
+      body,
+      status,
+    });
+  };
+}
+
+test("runDrive: starts a new run when none exists", async () => {
+  const cwd = makeWorkspace();
+  let stagesSeen = 0;
+
+  const result = await runDrive({
+    cwd,
+    taskId: "task-1",
+    description: "Add a thing",
+    workflowId: "tiny",
+    maxStages: 10,
+    agentCommand: "<unused>",
+    agentArgs: [],
+    spawnAgent: makeAdvancingAgent(),
+    onStageStart: () => {
+      stagesSeen += 1;
+    },
+    workflows: REGISTRY,
+  });
+
+  assert.equal(result.state.outcome, "complete");
+  assert.equal(result.state.current_stage, null);
+  assert.equal(result.stagesDriven, 2);
+  assert.equal(stagesSeen, 2);
+});
+
+test("runDrive: resumes an existing run when no description given", async () => {
+  const cwd = makeWorkspace();
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: TINY_WORKFLOW,
+    taskDescription: "pre-existing",
+  });
+
+  const result = await runDrive({
+    cwd,
+    taskId: "task-1",
+    maxStages: 10,
+    agentCommand: "<unused>",
+    agentArgs: [],
+    spawnAgent: makeAdvancingAgent(),
+    workflows: REGISTRY,
+  });
+
+  assert.equal(result.state.outcome, "complete");
+  assert.equal(result.state.task_description, "pre-existing");
+});
+
+test("runDrive: rejects when no run exists and no --description given", async () => {
+  const cwd = makeWorkspace();
+  await assert.rejects(
+    runDrive({
+      cwd,
+      taskId: "ghost",
+      maxStages: 10,
+      agentCommand: "<unused>",
+      agentArgs: [],
+      spawnAgent: makeAdvancingAgent(),
+      workflows: REGISTRY,
+    }),
+    /No run exists.*--description was not provided/s,
+  );
+});
+
+test("runDrive: rejects when agent exits without advancing", async () => {
+  const cwd = makeWorkspace();
+  const noopAgent = async () => {
+    /* no-op: doesn't advance state */
+  };
+
+  await assert.rejects(
+    runDrive({
+      cwd,
+      taskId: "task-1",
+      description: "Test",
+      workflowId: "tiny",
+      maxStages: 10,
+      agentCommand: "<unused>",
+      agentArgs: [],
+      spawnAgent: noopAgent,
+      workflows: REGISTRY,
+    }),
+    /exited without advancing the run/,
+  );
+});
+
+test("runDrive: stops at max-stages limit", async () => {
+  const cwd = makeWorkspace();
+  await assert.rejects(
+    runDrive({
+      cwd,
+      taskId: "task-1",
+      description: "Test",
+      workflowId: "tiny",
+      maxStages: 1, // workflow has 2 stages
+      agentCommand: "<unused>",
+      agentArgs: [],
+      spawnAgent: makeAdvancingAgent(),
+      workflows: REGISTRY,
+    }),
+    /Reached --max-stages 1/,
+  );
+});
+
+test("runDrive: blocked status halts the loop and surfaces the run state", async () => {
+  const cwd = makeWorkspace();
+  const blockingAgent = makeAdvancingAgent({
+    status: "blocked",
+    body: "# Plan blocked\n\nMissing context.",
+  });
+
+  const result = await runDrive({
+    cwd,
+    taskId: "task-1",
+    description: "Test",
+    workflowId: "tiny",
+    maxStages: 10,
+    agentCommand: "<unused>",
+    agentArgs: [],
+    spawnAgent: blockingAgent,
+    workflows: REGISTRY,
+  });
+
+  assert.equal(result.state.outcome, "blocked");
+  assert.equal(result.stagesDriven, 1);
+});
+
+test("runDrive: rejects unknown workflow_id when starting fresh", async () => {
+  const cwd = makeWorkspace();
+  await assert.rejects(
+    runDrive({
+      cwd,
+      taskId: "task-1",
+      description: "Test",
+      workflowId: "no-such",
+      maxStages: 10,
+      agentCommand: "<unused>",
+      agentArgs: [],
+      spawnAgent: makeAdvancingAgent(),
+      workflows: REGISTRY,
+    }),
+    /Unknown workflow_id/,
+  );
+});
+
+test("runDrive: passes envelope text to the spawned agent for each stage", async () => {
+  const cwd = makeWorkspace();
+  const seenPrompts = [];
+  const spy = async (args) => {
+    seenPrompts.push({ stage: args.taskId, prompt: args.envelopePrompt });
+    const state = getRunState(args.cwd, args.taskId);
+    const stage = TINY_WORKFLOW.stages.find((s) => s.name === state.current_stage);
+    advanceStage({
+      cwd: args.cwd,
+      taskId: args.taskId,
+      workflow: TINY_WORKFLOW,
+      stageName: state.current_stage,
+      artifactName: stage.artifact,
+      frontmatter: {
+        stage: state.current_stage,
+        status: "complete",
+        references: [],
+      },
+      body: "# done",
+    });
+  };
+
+  await runDrive({
+    cwd,
+    taskId: "task-1",
+    description: "x",
+    workflowId: "tiny",
+    maxStages: 10,
+    agentCommand: "<unused>",
+    agentArgs: [],
+    spawnAgent: spy,
+    workflows: REGISTRY,
+  });
+
+  assert.equal(seenPrompts.length, 2);
+  assert.match(seenPrompts[0].prompt, /# STAGE: plan/);
+  assert.match(seenPrompts[1].prompt, /# STAGE: review/);
+});
+
+test("runDrive: surfaces stage transitions via callbacks in the right order", async () => {
+  const cwd = makeWorkspace();
+  const events = [];
+
+  await runDrive({
+    cwd,
+    taskId: "task-1",
+    description: "x",
+    workflowId: "tiny",
+    maxStages: 10,
+    agentCommand: "<unused>",
+    agentArgs: [],
+    spawnAgent: makeAdvancingAgent(),
+    onStageStart: (stage) => {
+      events.push(`start:${stage}`);
+    },
+    onStageEnd: (stage, nextState) => {
+      events.push(`end:${stage}:${nextState.current_stage ?? nextState.outcome}`);
+    },
+    workflows: REGISTRY,
+  });
+
+  assert.deepEqual(events, [
+    "start:plan",
+    "end:plan:review",
+    "start:review",
+    "end:review:complete",
+  ]);
+});


### PR DESCRIPTION
Turns the manual chain of \`cortex stage start / envelope / run / advance\` into a single end-to-end invocation:

\`\`\`sh
cortex stage drive --task-id add-login --description "Add password login flow" \\
  -- claude --print
\`\`\`

Loops: compose envelope → spawn agent (envelope on stdin, \`CORTEX_ACTIVE_TASK_ID\` in env) → poll state → next stage, until the run reaches a terminal state.

## What lands

\`scaffold/mcp/src/cli/stage-drive.ts\` (new):
- Pure \`runDrive({ cwd, taskId, description?, workflowId?, maxStages, agentCommand, agentArgs, spawnAgent? })\` function so the loop is unit-testable without spawning real subprocesses.
- \`spawnAgent\` defaults to a real \`child_process.spawn\` that pipes the envelope to stdin and inherits stdout/stderr. Tests pass a mock that mutates state directly.
- Resumes existing runs (no \`--description\` needed). Auto-starts a new run when description is provided and no state exists.
- **Capability gate trust model preserved**: the orchestrator never itself writes artifacts or advances stages — every state transition is owned by an agent's \`cortex.workflow.advance\` call. A missing advance is treated as a contract violation and surfaces as a fail-loud error (not a silent skip).
- \`onStageStart\` / \`onStageEnd\` hooks for progress reporting.

\`scaffold/mcp/src/cli/stage.ts\`:
- New \`drive\` subcommand parses flags + tail-args (after \`--\`), streams progress to stderr, and emits final state JSON to stdout on completion.
- Help text updated.

\`bin/cortex.mjs\`: HARNESS help section gains a \`stage drive\` row.

## Stream output (stderr)
\`\`\`
[harness] stage: plan
[harness] stage plan done → plan-review
[harness] stage: plan-review
[harness] stage plan-review done → build
…
[harness] stage approval done (complete)
\`\`\`

Stdout ends with \`{ state, stages_driven }\` JSON for scripting.

## Tests
9 new cases under \`tests/workflow-drive.test.mjs\`:
- fresh-start happy path (creates run + drives all stages)
- resume-existing (no description needed)
- rejects missing description on fresh run
- rejects agent that exited without advancing (contract violation)
- max-stages limit halts before completion
- blocked status surfaces as run outcome
- unknown workflow_id rejection
- envelope delivered to agent for each stage
- callback ordering: \`start:plan → end:plan:review → start:review → end:review:complete\`

214/214 daemon tests pass; \`tsc --noEmit\` clean.

## What this completes
With this PR merged, the harness goes from "pile of primitives that need scripting" to "single command end-to-end":

\`\`\`sh
# Run a complete secure-build workflow on a fresh task:
cortex stage drive --task-id add-login --description "Add password login flow" -- claude --print

# Or with an org-authored workflow synced from cortex-web:
cortex stage drive --task-id refactor-auth --description "..." --workflow our-strict-build -- claude --print
\`\`\`

The agent is responsible for calling \`cortex.workflow.advance\` after producing its artifact — the prompt envelope already instructs that, and the contract is enforced by the orchestrator's "did the stage advance?" check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)