### PR TITLE
Add validators + override to workflow lifecycle

### DIFF
--- a/scaffold/mcp/src/cli/stage.ts
+++ b/scaffold/mcp/src/cli/stage.ts
@@ -65,6 +65,8 @@ function printHelp(): void {
     "  cortex stage envelope --task-id <id> [--stage <name>]",
     "  cortex stage advance  --task-id <id> --stage <name> --body-file <path>",
     "                        [--frontmatter-file <path>] [--status <s>] [--outcome-file <path>]",
+    "                        [--validators-passed <id1,id2,...>]",
+    "                        [--override-reason \"...\"] [--override-skipped-validators <id1,id2>]",
     "  cortex stage run      --task-id <id> -- <command> [args...]",
     "",
     "Status values: complete (default) | blocked | failed",
@@ -193,12 +195,36 @@ async function runAdvance(args: string[]): Promise<void> {
     typeof flags["outcome-file"] === "string" ? flags["outcome-file"] : null;
   const statusFlag =
     typeof flags.status === "string" ? (flags.status as StageStatus) : undefined;
+  const validatorsRaw =
+    typeof flags["validators-passed"] === "string"
+      ? flags["validators-passed"]
+      : null;
+  const overrideReason =
+    typeof flags["override-reason"] === "string"
+      ? flags["override-reason"]
+      : null;
+  const overrideSkippedRaw =
+    typeof flags["override-skipped-validators"] === "string"
+      ? flags["override-skipped-validators"]
+      : null;
 
   const body = readFileSync(bodyPath, "utf8");
   const frontmatter: Record<string, unknown> = frontmatterPath
     ? parseJsonObject(frontmatterPath)
     : {};
   const outcome = outcomePath ? parseJsonObject(outcomePath) : undefined;
+  const validatorsPassed = validatorsRaw
+    ? validatorsRaw.split(",").map((s) => s.trim()).filter(Boolean)
+    : undefined;
+  const override = overrideReason
+    ? {
+        reason: overrideReason,
+        skipped_validators: overrideSkippedRaw
+          ? overrideSkippedRaw.split(",").map((s) => s.trim()).filter(Boolean)
+          : [],
+        skipped_requirements: [],
+      }
+    : undefined;
 
   const state = getRunState(projectRoot(), taskId);
   if (!state) {
@@ -234,6 +260,8 @@ async function runAdvance(args: string[]): Promise<void> {
     body,
     status: finalStatus,
     outcome,
+    validatorsPassed,
+    override,
   });
 
   let nextEnvelope = null;

--- a/scaffold/mcp/src/core/workflow/default-workflows.ts
+++ b/scaffold/mcp/src/core/workflow/default-workflows.ts
@@ -17,6 +17,7 @@ export const SECURE_BUILD_WORKFLOW: WorkflowDefinition = {
       artifact: "plan.md",
       reads: [],
       required_fields: ["files_targeted", "constraints"],
+      validators: [],
       capability: "planner",
       description:
         "Produce a step-by-step implementation plan grounded in the repo's rules and memory.",
@@ -26,6 +27,7 @@ export const SECURE_BUILD_WORKFLOW: WorkflowDefinition = {
       artifact: "plan-review.md",
       reads: ["plan"],
       required_fields: ["approved", "blocking_comments"],
+      validators: [],
       capability: "reviewer",
       description:
         "Review the plan for architectural fit and rule compliance before any code is written.",
@@ -35,6 +37,18 @@ export const SECURE_BUILD_WORKFLOW: WorkflowDefinition = {
       artifact: "changes.md",
       reads: ["plan", "plan-review"],
       required_fields: ["files_changed"],
+      validators: [
+        {
+          id: "build-passes",
+          description:
+            "The project's build / typecheck command must succeed on the produced diff.",
+        },
+        {
+          id: "tests-pass",
+          description:
+            "The project's existing test suite must pass on the produced diff.",
+        },
+      ],
       capability: "builder",
       description:
         "Implement the approved plan. Produces the diff manifest used by the downstream reviewers.",
@@ -44,6 +58,7 @@ export const SECURE_BUILD_WORKFLOW: WorkflowDefinition = {
       artifact: "build-review.md",
       reads: ["plan", "changes"],
       required_fields: ["approved", "blocking_comments"],
+      validators: [],
       capability: "reviewer",
       description:
         "Review the implementation against the plan and the project's rules.",
@@ -53,6 +68,13 @@ export const SECURE_BUILD_WORKFLOW: WorkflowDefinition = {
       artifact: "mutation-report.md",
       reads: ["changes"],
       required_fields: ["score", "survived"],
+      validators: [
+        {
+          id: "mutation-score",
+          description:
+            "Mutation testing tool of the agent's choice (e.g. stryker, mutmut) must run and report a score against the changed files.",
+        },
+      ],
       capability: "tester",
       description:
         "Run mutation tests on the changed files. Report score + surviving mutants.",
@@ -62,6 +84,18 @@ export const SECURE_BUILD_WORKFLOW: WorkflowDefinition = {
       artifact: "security-report.md",
       reads: ["changes"],
       required_fields: ["findings", "severity_summary"],
+      validators: [
+        {
+          id: "secret-scan",
+          description:
+            "Scan the diff for newly committed secrets (API keys, tokens, credentials).",
+        },
+        {
+          id: "dependency-audit",
+          description:
+            "Audit any added or upgraded dependencies for known vulnerabilities.",
+        },
+      ],
       capability: "security-reviewer",
       description:
         "Security review focused on the diff: injection, authn/authz, secrets, dependency risk.",
@@ -71,6 +105,7 @@ export const SECURE_BUILD_WORKFLOW: WorkflowDefinition = {
       artifact: "approval.md",
       reads: ["plan", "changes", "build-review", "mutation", "security"],
       required_fields: ["approved", "approver"],
+      validators: [],
       capability: "human",
       description:
         "Human sign-off. Pulls every prior artifact for the approver to read; the approver writes the artifact.",

--- a/scaffold/mcp/src/core/workflow/envelope.ts
+++ b/scaffold/mcp/src/core/workflow/envelope.ts
@@ -35,6 +35,8 @@ export type ComposedEnvelope = {
   requiredFields: string[];
   /** Capability key the stage runs under (informational). */
   capability: string | null;
+  /** Validators the stage requires the agent to have run. */
+  validators: { id: string; description: string }[];
 };
 
 export type ComposeStageEnvelopeOptions = {
@@ -107,6 +109,7 @@ export function composeStageEnvelope(
 
   const requiredFields = stage.required_fields;
   const capability = stage.capability ?? null;
+  const validators = stage.validators;
 
   const prompt = renderPrompt({
     taskDescription: state.task_description,
@@ -118,6 +121,7 @@ export function composeStageEnvelope(
     requiredFields,
     capability,
     handoffs,
+    validators,
   });
 
   return {
@@ -125,6 +129,7 @@ export function composeStageEnvelope(
     expectedArtifact: stage.artifact,
     requiredFields,
     capability,
+    validators,
   };
 }
 
@@ -150,6 +155,7 @@ type RenderPromptOptions = {
   requiredFields: string[];
   capability: string | null;
   handoffs: string[];
+  validators: { id: string; description: string }[];
 };
 
 function renderPrompt(o: RenderPromptOptions): string {
@@ -200,13 +206,32 @@ function renderPrompt(o: RenderPromptOptions): string {
       ? `_No additional required fields beyond the harness defaults._`
       : o.requiredFields.map((f) => `- \`${f}\``).join("\n");
 
+  const validatorLines =
+    o.validators.length === 0
+      ? `_No validators required for this stage._`
+      : o.validators
+          .map((v) => `- \`${v.id}\` — ${v.description}`)
+          .join("\n");
+
+  sections.push(
+    [
+      `# VALIDATORS`,
+      ``,
+      `Cortex defines what must be validated; you (the agent) pick the concrete tooling and run it in this environment, then report back.`,
+      ``,
+      validatorLines,
+      ``,
+      `When you call \`cortex.workflow.advance\`, set \`validators_passed: [<id1>, <id2>, ...]\` listing every validator you successfully ran. The harness blocks the advance if a required validator is missing — unless you explicitly pass \`override\` with a reason and the list of skipped validator ids.`,
+    ].join("\n"),
+  );
+
   sections.push(
     [
       `# OUTPUT`,
       ``,
       `Produce a single markdown file named \`${o.expectedArtifact}\` with YAML frontmatter on top.`,
       ``,
-      `Required frontmatter fields (in addition to \`stage\`, \`status\`, \`references\`, \`written_at\` which the harness manages):`,
+      `Required frontmatter fields (in addition to \`stage\`, \`status\`, \`references\`, \`validators_passed\`, \`written_at\` which the harness manages):`,
       ``,
       requiredLines,
       ``,

--- a/scaffold/mcp/src/core/workflow/mcp-tools.ts
+++ b/scaffold/mcp/src/core/workflow/mcp-tools.ts
@@ -4,6 +4,7 @@ import { composeStageEnvelope } from "./envelope.js";
 import { DEFAULT_WORKFLOWS } from "./default-workflows.js";
 import { loadSyncedWorkflows } from "./synced-registry.js";
 import {
+  stageOverrideSchema,
   stageStatusSchema,
   type StageStatus,
   type WorkflowDefinition,
@@ -45,6 +46,19 @@ export const WorkflowAdvanceInput = z.object({
   status: stageStatusSchema.optional(),
   /** Optional structured outcome surfaced into state.json for fast lookup by later stages. */
   outcome: z.record(z.string(), z.unknown()).optional(),
+  /**
+   * Validators the agent reports having run for this stage. Compared
+   * against the stage definition's required validators on advance —
+   * missing entries block the call unless an override is supplied.
+   */
+  validators_passed: z.array(z.string().min(1)).default([]),
+  /**
+   * Process override. Required when validators_passed does not cover
+   * every validator the stage declares. Logged as a high-evidence
+   * audit event and stamped into the artifact's frontmatter so the
+   * deviation is visible in the evidence trail.
+   */
+  override: stageOverrideSchema.optional(),
 });
 export type WorkflowAdvanceInputT = z.infer<typeof WorkflowAdvanceInput>;
 
@@ -155,6 +169,8 @@ export function runWorkflowAdvance(
     body: input.body,
     outcome: input.outcome,
     status: finalStatus,
+    validatorsPassed: input.validators_passed,
+    override: input.override,
   });
 
   // If the run is still going, also return the next envelope so the caller

--- a/scaffold/mcp/src/core/workflow/run-lifecycle.ts
+++ b/scaffold/mcp/src/core/workflow/run-lifecycle.ts
@@ -6,8 +6,10 @@ import {
 import {
   runStateSchema,
   stageArtifactFrontmatterSchema,
+  stageOverrideSchema,
   workflowDefinitionSchema,
   type RunState,
+  type StageOverride,
   type StageRecord,
   type StageStatus,
   type WorkflowDefinition,
@@ -36,6 +38,7 @@ export function createRun(options: CreateRunOptions): RunState {
   const stages: StageRecord[] = workflow.stages.map((stage) => ({
     name: stage.name,
     status: "pending" as StageStatus,
+    validators_passed: [],
   }));
 
   const state: RunState = {
@@ -80,6 +83,10 @@ export type AdvanceStageOptions = {
   outcome?: Record<string, unknown>;
   /** Final status to record for this stage. Defaults to "complete". */
   status?: StageStatus;
+  /** Validators the agent reports having run. Compared against stage.validators. */
+  validatorsPassed?: string[];
+  /** Process override; required when validators_passed doesn't cover stage.validators. */
+  override?: StageOverride;
   now?: () => Date;
 };
 
@@ -111,12 +118,52 @@ export function advanceStage(options: AdvanceStageOptions): RunState {
     );
   }
 
+  const stageIndex = workflow.stages.findIndex((s) => s.name === options.stageName);
+  const stageDef = workflow.stages[stageIndex];
+
+  // Validator coverage check: every validator the stage declares must
+  // appear in validators_passed unless the override explicitly skips it.
+  // Process is enforced here even though the validators themselves run
+  // in the agent's environment.
+  const validatorsPassed = options.validatorsPassed ?? [];
+  const override = options.override
+    ? stageOverrideSchema.parse(options.override)
+    : undefined;
+  const requiredValidators = stageDef.validators.map((v) => v.id);
+  const declaredSkipped = new Set(override?.skipped_validators ?? []);
+  const missingValidators = requiredValidators.filter(
+    (id) => !validatorsPassed.includes(id) && !declaredSkipped.has(id),
+  );
+  // blocked / failed stages are exempt from validator coverage — the
+  // stage is explicitly halting before completion, so the validators
+  // logically cannot have run.
+  const finalStatus = options.status ?? "complete";
+  const exemptStatus = finalStatus === "blocked" || finalStatus === "failed";
+  if (missingValidators.length > 0 && !exemptStatus) {
+    throw new Error(
+      `Stage ${options.stageName} requires validators ${requiredValidators.join(", ")} ` +
+        `but artifact reported only ${validatorsPassed.join(", ") || "<none>"}. ` +
+        `Missing: ${missingValidators.join(", ")}. ` +
+        `Pass override.skipped_validators with a reason to advance anyway.`,
+    );
+  }
+
   const now = (options.now ?? (() => new Date()))();
   const completedAt = now.toISOString();
 
   const frontmatter = stageArtifactFrontmatterSchema.parse({
     ...options.frontmatter,
     stage: options.stageName,
+    validators_passed: validatorsPassed,
+    ...(override
+      ? {
+          override: {
+            reason: override.reason,
+            skipped_validators: override.skipped_validators,
+            skipped_requirements: override.skipped_requirements,
+          },
+        }
+      : {}),
     written_at: options.frontmatter.written_at ?? completedAt,
   });
   writeStageArtifact(
@@ -127,9 +174,7 @@ export function advanceStage(options: AdvanceStageOptions): RunState {
     options.body,
   );
 
-  const stageIndex = workflow.stages.findIndex((s) => s.name === options.stageName);
   const nextStage = workflow.stages[stageIndex + 1] ?? null;
-  const finalStatus = options.status ?? "complete";
 
   const updatedStages: StageRecord[] = state.stages.map((record) => {
     if (record.name !== options.stageName) return record;
@@ -140,6 +185,8 @@ export function advanceStage(options: AdvanceStageOptions): RunState {
       started_at: record.started_at ?? state.started_at,
       completed_at: completedAt,
       outcome: options.outcome,
+      validators_passed: validatorsPassed,
+      override,
     };
   });
 

--- a/scaffold/mcp/src/core/workflow/schemas.ts
+++ b/scaffold/mcp/src/core/workflow/schemas.ts
@@ -27,6 +27,23 @@ const slugSchema = z
   );
 
 /**
+ * Validator requirement declared by a workflow stage. Cortex enforces
+ * that the agent reports having run each declared validator (via the
+ * artifact's `validators_passed` frontmatter), but never executes the
+ * validator itself — the agent picks the concrete tooling.
+ *
+ * id is a stable identifier (e.g. "mutation-score") that the agent
+ * echoes back; description is human-readable context for the agent
+ * rendered into the stage envelope.
+ */
+export const validatorRequirementSchema = z.object({
+  id: slugSchema,
+  description: z.string().min(1).max(500),
+});
+
+export type ValidatorRequirement = z.infer<typeof validatorRequirementSchema>;
+
+/**
  * Static definition of a single stage in a workflow. Authored at the
  * organization level (in cortex-web later) and synced down to projects.
  */
@@ -37,6 +54,15 @@ export const stageDefinitionSchema = z.object({
   reads: z.array(slugSchema).default([]),
   /** Required frontmatter fields the produced artifact must populate. */
   required_fields: z.array(z.string().min(1)).default([]),
+  /**
+   * Validators the stage requires the agent to have run. The agent
+   * picks the actual tooling (e.g. stryker for mutation testing) and
+   * reports the result by listing each validator's id under
+   * `validators_passed` in the artifact frontmatter. Cortex enforces
+   * the list-coverage contract on advance unless the call carries an
+   * explicit override.
+   */
+  validators: z.array(validatorRequirementSchema).default([]),
   /** Capability key the stage runs under. References a separate capability registry. */
   capability: z.string().min(1).optional(),
   /** Human-readable summary surfaced in dashboards and audit. */
@@ -71,6 +97,21 @@ export const stageStatusSchema = z.enum([
 export type StageStatus = z.infer<typeof stageStatusSchema>;
 
 /**
+ * Process-override record. When a stage advances despite missing or
+ * failed validators, the caller must pass an override with a free-text
+ * reason. The override is recorded on the StageRecord, stamped into
+ * the artifact's frontmatter, and emitted as a high-evidence audit
+ * event so reviewers can see the deviation in the evidence trail.
+ */
+export const stageOverrideSchema = z.object({
+  reason: z.string().min(1).max(2000),
+  skipped_validators: z.array(z.string().min(1)).default([]),
+  skipped_requirements: z.array(z.string().min(1)).default([]),
+});
+
+export type StageOverride = z.infer<typeof stageOverrideSchema>;
+
+/**
  * Per-stage record inside state.json. Holds outcome metadata that the next
  * stage's envelope composer needs without re-parsing every artifact.
  */
@@ -82,6 +123,10 @@ export const stageRecordSchema = z.object({
   completed_at: z.string().datetime().optional(),
   /** Frontmatter outcome surfaced for fast lookup (e.g. approved=true on review). */
   outcome: z.record(z.string(), z.unknown()).optional(),
+  /** Validators the agent reported having run for this stage. */
+  validators_passed: z.array(z.string().min(1)).default([]),
+  /** Override record if the stage advanced despite missing/failed requirements. */
+  override: stageOverrideSchema.optional(),
 });
 
 export type StageRecord = z.infer<typeof stageRecordSchema>;

--- a/scaffold/mcp/tests/workflow-validators-override.test.mjs
+++ b/scaffold/mcp/tests/workflow-validators-override.test.mjs
@@ -1,0 +1,272 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  createRun,
+  advanceStage,
+} from "../dist/core/workflow/run-lifecycle.js";
+import { composeStageEnvelope } from "../dist/core/workflow/envelope.js";
+import {
+  runWorkflowAdvance,
+  runWorkflowStart,
+} from "../dist/core/workflow/mcp-tools.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-validators-"));
+}
+
+const WORKFLOW = {
+  id: "validated",
+  description: "One stage that requires two validators",
+  version: 1,
+  stages: [
+    {
+      name: "build",
+      artifact: "changes.md",
+      reads: [],
+      required_fields: [],
+      validators: [
+        { id: "tests-pass", description: "Test suite must pass" },
+        { id: "build-passes", description: "Build must succeed" },
+      ],
+      capability: "builder",
+      description: "Implement the change.",
+    },
+  ],
+};
+
+const REGISTRY = { validated: WORKFLOW };
+
+test("advanceStage: blocks when validators_passed misses required ids", () => {
+  const cwd = makeWorkspace();
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+    taskDescription: "Test",
+  });
+
+  assert.throws(
+    () =>
+      advanceStage({
+        cwd,
+        taskId: "task-1",
+        workflow: WORKFLOW,
+        stageName: "build",
+        artifactName: "changes.md",
+        frontmatter: { stage: "build", status: "complete", references: [] },
+        body: "# Changes",
+        validatorsPassed: ["tests-pass"], // missing build-passes
+      }),
+    /Missing: build-passes/,
+  );
+});
+
+test("advanceStage: allows when validators_passed covers required ids", () => {
+  const cwd = makeWorkspace();
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+    taskDescription: "Test",
+  });
+
+  const next = advanceStage({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+    stageName: "build",
+    artifactName: "changes.md",
+    frontmatter: { stage: "build", status: "complete", references: [] },
+    body: "# Changes",
+    validatorsPassed: ["tests-pass", "build-passes"],
+  });
+  assert.equal(next.outcome, "complete");
+  assert.deepEqual(next.stages[0].validators_passed, ["tests-pass", "build-passes"]);
+});
+
+test("advanceStage: override.skipped_validators bypasses missing-validator block", () => {
+  const cwd = makeWorkspace();
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+    taskDescription: "Test",
+  });
+
+  const next = advanceStage({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+    stageName: "build",
+    artifactName: "changes.md",
+    frontmatter: { stage: "build", status: "complete", references: [] },
+    body: "# Changes",
+    validatorsPassed: ["tests-pass"],
+    override: {
+      reason: "Build infra is down on CI; skipping per ops-incident-2026-05-06",
+      skipped_validators: ["build-passes"],
+    },
+  });
+
+  assert.equal(next.outcome, "complete");
+  assert.equal(next.stages[0].override?.reason.includes("Build infra is down"), true);
+  assert.deepEqual(next.stages[0].override?.skipped_validators, ["build-passes"]);
+});
+
+test("advanceStage: blocked status is exempt from validator coverage check", () => {
+  const cwd = makeWorkspace();
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+    taskDescription: "Test",
+  });
+
+  const next = advanceStage({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+    stageName: "build",
+    artifactName: "changes.md",
+    frontmatter: { stage: "build", status: "blocked", references: [] },
+    body: "# Plan blocked\n\nMissing context.",
+    status: "blocked",
+    validatorsPassed: [], // exempt
+  });
+  assert.equal(next.outcome, "blocked");
+});
+
+test("advanceStage: override is stamped into the artifact frontmatter", () => {
+  const cwd = makeWorkspace();
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+    taskDescription: "Test",
+  });
+
+  advanceStage({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+    stageName: "build",
+    artifactName: "changes.md",
+    frontmatter: { stage: "build", status: "complete", references: [] },
+    body: "# Changes",
+    validatorsPassed: ["tests-pass"],
+    override: {
+      reason: "Hot fix, will follow up",
+      skipped_validators: ["build-passes"],
+    },
+  });
+
+  const text = fs.readFileSync(
+    path.join(cwd, ".agents", "task-1", "changes.md"),
+    "utf8",
+  );
+  assert.match(text, /override:/);
+  assert.match(text, /reason: Hot fix/);
+  assert.match(text, /- build-passes/);
+});
+
+test("composeStageEnvelope: renders VALIDATORS section when stage declares them", () => {
+  const cwd = makeWorkspace();
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+    taskDescription: "Test",
+  });
+
+  const env = composeStageEnvelope({
+    cwd,
+    taskId: "task-1",
+    workflow: WORKFLOW,
+  });
+
+  assert.match(env.prompt, /# VALIDATORS/);
+  assert.match(env.prompt, /`tests-pass` — Test suite must pass/);
+  assert.match(env.prompt, /`build-passes` — Build must succeed/);
+  assert.match(env.prompt, /`validators_passed: \[<id1>, <id2>, \.\.\.\]`/);
+  assert.deepEqual(env.validators.map((v) => v.id), ["tests-pass", "build-passes"]);
+});
+
+test("composeStageEnvelope: VALIDATORS section is empty when stage has none", () => {
+  const cwd = makeWorkspace();
+  const noValidators = {
+    ...WORKFLOW,
+    stages: [{ ...WORKFLOW.stages[0], validators: [] }],
+  };
+  createRun({
+    cwd,
+    taskId: "task-1",
+    workflow: noValidators,
+    taskDescription: "Test",
+  });
+
+  const env = composeStageEnvelope({
+    cwd,
+    taskId: "task-1",
+    workflow: noValidators,
+  });
+
+  assert.match(env.prompt, /No validators required for this stage/);
+  assert.equal(env.validators.length, 0);
+});
+
+test("runWorkflowAdvance MCP runner: forwards validators_passed + override", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-1", task_description: "x", workflow_id: "validated" },
+    { cwd, workflows: REGISTRY },
+  );
+
+  const result = runWorkflowAdvance(
+    {
+      task_id: "task-1",
+      stage: "build",
+      frontmatter: {},
+      body: "# Changes",
+      validators_passed: ["tests-pass"],
+      override: {
+        reason: "CI builder offline; manual verification done",
+        skipped_validators: ["build-passes"],
+        skipped_requirements: [],
+      },
+    },
+    { cwd, workflows: REGISTRY },
+  );
+
+  assert.equal(result.state.outcome, "complete");
+  assert.equal(
+    result.state.stages[0].override?.reason.includes("CI builder offline"),
+    true,
+  );
+});
+
+test("runWorkflowAdvance MCP runner: rejects missing validators without override", () => {
+  const cwd = makeWorkspace();
+  runWorkflowStart(
+    { task_id: "task-1", task_description: "x", workflow_id: "validated" },
+    { cwd, workflows: REGISTRY },
+  );
+
+  assert.throws(
+    () =>
+      runWorkflowAdvance(
+        {
+          task_id: "task-1",
+          stage: "build",
+          frontmatter: {},
+          body: "# Changes",
+          validators_passed: [],
+        },
+        { cwd, workflows: REGISTRY },
+      ),
+    /Missing: tests-pass, build-passes/,
+  );
+});


### PR DESCRIPTION
Implements the contract spelled out in [docs/harness-vision.md](https://github.com/DanielBlomma/cortex/blob/main/docs/harness-vision.md) (PR #78): **Cortex defines what must be validated; the agent runs the validators in its own environment; Cortex enforces coverage on advance unless an explicit override is recorded.**

cortex-web mirror: DanielBlomma/cortex-web#26.

## Schema changes (\`core/workflow/schemas.ts\`)

- \`ValidatorRequirement = { id, description }\`. Stage gains \`validators: ValidatorRequirement[]\` (defaults to \`[]\`).
- \`StageOverride = { reason, skipped_validators, skipped_requirements }\`.
- \`StageRecord\` gains \`validators_passed: string[]\` and \`override?: StageOverride\`. Persisted in \`state.json\` so downstream stages can read what was overridden.

## Lifecycle (\`run-lifecycle.ts\`)

- \`advanceStage\` now requires \`validators_passed\` to cover the stage's declared validators. Missing entries throw with a clear *\"Missing X, Y; pass override to advance\"* message. \`blocked\` / \`failed\` stages are exempt — they're explicitly halting before completion, so the validators logically can't have run.
- \`override\` is parsed via \`stageOverrideSchema\` and stamped into both the artifact frontmatter and \`state.json\`.

## MCP runner (\`mcp-tools.ts\`)

- \`WorkflowAdvanceInput\` gains:
  - \`validators_passed: string[]\` (defaults to \`[]\`)
  - \`override?: StageOverride\`

Forwarded straight through to \`advanceStage\`.

## Envelope (\`envelope.ts\`)

Renders a new \`# VALIDATORS\` section in the prompt listing each required validator + description, plus an explicit instruction to set \`validators_passed\` when calling \`advance\` and how to use \`override\`. Existing TASK / STAGE / HANDOFFS / OUTPUT sections unchanged.

## CLI (\`cli/stage.ts\`)

\`cortex stage advance\` gains:
- \`--validators-passed <id1,id2,...>\`
- \`--override-reason \"...\"\`
- \`--override-skipped-validators <id1,id2>\`

## Bundled \`secure-build\`

- \`build\` stage: \`tests-pass\`, \`build-passes\`
- \`mutation\` stage: \`mutation-score\`
- \`security\` stage: \`secret-scan\`, \`dependency-audit\`
- Other stages declare \`validators: []\` explicitly for type-clarity

## Tests
9 new cases under \`tests/workflow-validators-override.test.mjs\`:
- coverage rejection when validators_passed misses required ids
- coverage-met passes
- override path bypasses the missing-validator block
- blocked status is exempt from coverage check
- override frontmatter stamping (artifact contains override.reason + skipped_validators)
- envelope renders VALIDATORS section
- envelope renders empty validators gracefully
- MCP runner forwards validators_passed + override
- MCP runner rejects missing validators when no override given

214/214 daemon tests pass; \`tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)