### PR TITLE
Sync org-authored capabilities + merge them into evaluateToolCall

### DIFF
--- a/scaffold/mcp/src/core/workflow/enforcement.ts
+++ b/scaffold/mcp/src/core/workflow/enforcement.ts
@@ -4,6 +4,7 @@ import { readRunState } from "./artifact-io.js";
 import { DEFAULT_CAPABILITIES, type CapabilityDefinition } from "./capabilities.js";
 import { workflowDefinitionSchema, type WorkflowDefinition } from "./schemas.js";
 import { DEFAULT_WORKFLOWS } from "./default-workflows.js";
+import { loadSyncedCapabilities } from "./synced-capability-registry.js";
 
 /**
  * Pre-tool-use enforcement for the harness. Pure function: takes the tool
@@ -83,7 +84,12 @@ export function evaluateToolCall(options: EvaluateOptions): EnforcementResult {
     return { allowed: true, reason: "stage has no capability declared" };
   }
 
-  const capabilities = options.capabilities ?? DEFAULT_CAPABILITIES;
+  // When the caller passes an explicit registry, use it as-is (tests).
+  // Otherwise merge bundled defaults with the daemon-synced org-authored
+  // capabilities, with synced ones taking precedence on name collisions
+  // so org overrides actually override.
+  const capabilities =
+    options.capabilities ?? { ...DEFAULT_CAPABILITIES, ...loadSyncedCapabilities() };
   const capability = capabilities[stage.capability];
   if (!capability) {
     return {

--- a/scaffold/mcp/src/core/workflow/index.ts
+++ b/scaffold/mcp/src/core/workflow/index.ts
@@ -7,3 +7,4 @@ export * from "./mcp-tools.js";
 export * from "./capabilities.js";
 export * from "./enforcement.js";
 export * from "./synced-registry.js";
+export * from "./synced-capability-registry.js";

--- a/scaffold/mcp/src/core/workflow/synced-capability-registry.ts
+++ b/scaffold/mcp/src/core/workflow/synced-capability-registry.ts
@@ -1,0 +1,66 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  capabilityDefinitionSchema,
+  type CapabilityDefinition,
+} from "./capabilities.js";
+
+/**
+ * Read side of the org-capability sync cache. The daemon's
+ * capability-sync-checker writes ~/.cortex/capabilities.local.json;
+ * this module reads it. Kept in core/workflow/ rather than daemon/ so
+ * enforcement.ts can consult the cache without depending on daemon code.
+ *
+ * Each entry is validated against capabilityDefinitionSchema before being
+ * surfaced — if the cache file is corrupt or contains stale shapes from
+ * an older daemon, those entries are silently dropped rather than
+ * crashing the read.
+ */
+
+export const SYNCED_CAPABILITIES_FILENAME = "capabilities.local.json";
+
+type LocalCapabilityRecord = {
+  capability_name: string;
+  updated_at: string;
+  definition: unknown;
+};
+
+type LocalCapabilitiesState = {
+  capabilities?: Record<string, LocalCapabilityRecord>;
+};
+
+export function syncedCapabilitiesCachePath(dir?: string): string {
+  return join(dir ?? join(homedir(), ".cortex"), SYNCED_CAPABILITIES_FILENAME);
+}
+
+/**
+ * Returns the synced org-authored capabilities keyed by capability name.
+ * Empty object when the cache is missing, unreadable, malformed, or
+ * contains no valid entries. The optional `dir` argument is for tests;
+ * production callers leave it unset.
+ */
+export function loadSyncedCapabilities(
+  dir?: string,
+): Record<string, CapabilityDefinition> {
+  const path = syncedCapabilitiesCachePath(dir);
+  if (!existsSync(path)) return {};
+
+  let parsed: LocalCapabilitiesState;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8")) as LocalCapabilitiesState;
+  } catch {
+    return {};
+  }
+  const records = parsed.capabilities;
+  if (!records || typeof records !== "object") return {};
+
+  const out: Record<string, CapabilityDefinition> = {};
+  for (const [name, record] of Object.entries(records)) {
+    if (!record || typeof record !== "object") continue;
+    const result = capabilityDefinitionSchema.safeParse(record.definition);
+    if (!result.success) continue;
+    out[name] = result.data;
+  }
+  return out;
+}

--- a/scaffold/mcp/src/daemon/capability-sync-checker.ts
+++ b/scaffold/mcp/src/daemon/capability-sync-checker.ts
@@ -1,0 +1,295 @@
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { hostname } from "node:os";
+import { join } from "node:path";
+import { loadEnterpriseConfig } from "../core/config.js";
+import {
+  capabilityDefinitionSchema,
+  type CapabilityDefinition,
+} from "../core/workflow/capabilities.js";
+import { writeHostAuditEvent } from "./ungoverned-scanner.js";
+import { daemonDir } from "./paths.js";
+
+/**
+ * Org-capability sync flow — daemon side.
+ *
+ * The daemon polls cortex-web /api/v1/govern/capabilities/manifest each
+ * tick to learn what capabilities the org has authored. It diffs against
+ * a local state file, fetches changed full definitions, and caches them
+ * locally. The pre-tool-use hook's evaluateToolCall consults the merged
+ * registry via loadSyncedCapabilities() with synced taking precedence
+ * over bundled DEFAULT_CAPABILITIES on name collisions.
+ *
+ * Three audit outcomes per tick:
+ *  - capabilities_unchanged   — manifest matches local state
+ *  - capabilities_synced      — at least one capability was added /
+ *                               changed / removed (metadata: counts)
+ *  - capabilities_sync_failed — network / auth / parse error
+ */
+
+const STATE_FILENAME = "capabilities.local.json";
+
+type ManifestEntry = {
+  capability_name: string;
+  updated_at: string;
+};
+
+type FetchedCapability = {
+  capability_name: string;
+  description: string;
+  definition: CapabilityDefinition;
+  updated_at: string;
+};
+
+type LocalCapabilityRecord = {
+  capability_name: string;
+  updated_at: string;
+  definition: CapabilityDefinition;
+};
+
+type LocalCapabilitiesState = {
+  capabilities: Record<string, LocalCapabilityRecord>;
+  last_synced_at?: string;
+};
+
+export type CapabilitySyncOutcome =
+  | { kind: "unchanged"; count: number }
+  | {
+      kind: "synced";
+      added: string[];
+      changed: string[];
+      removed: string[];
+    }
+  | { kind: "failed"; error: string };
+
+function stateFilePath(): string {
+  return join(daemonDir(), STATE_FILENAME);
+}
+
+function readSyncedCapabilitiesState(): LocalCapabilitiesState {
+  const path = stateFilePath();
+  if (!existsSync(path)) return { capabilities: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as LocalCapabilitiesState;
+    return {
+      capabilities: parsed.capabilities ?? {},
+      last_synced_at: parsed.last_synced_at,
+    };
+  } catch {
+    return { capabilities: {} };
+  }
+}
+
+function writeSyncedCapabilitiesState(state: LocalCapabilitiesState): void {
+  writeFileSync(
+    stateFilePath(),
+    JSON.stringify(state, null, 2) + "\n",
+    "utf8",
+  );
+}
+
+async function fetchManifest(
+  baseUrl: string,
+  apiKey: string,
+): Promise<ManifestEntry[]> {
+  const url = new URL(
+    baseUrl.replace(/\/$/, "") + "/api/v1/govern/capabilities/manifest",
+  );
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  }
+  const body = (await res.json()) as { capabilities?: ManifestEntry[] };
+  return body.capabilities ?? [];
+}
+
+async function fetchCapability(
+  baseUrl: string,
+  apiKey: string,
+  capabilityName: string,
+): Promise<FetchedCapability> {
+  const url = new URL(
+    baseUrl.replace(/\/$/, "") +
+      "/api/v1/govern/capabilities/" +
+      encodeURIComponent(capabilityName),
+  );
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  }
+  const body = (await res.json()) as { capability?: FetchedCapability };
+  if (!body.capability) {
+    throw new Error(`Response for ${capabilityName} missing 'capability' field`);
+  }
+  return body.capability;
+}
+
+export async function runCapabilitySyncOnce(
+  cwd: string,
+): Promise<CapabilitySyncOutcome> {
+  const config = loadEnterpriseConfig(join(cwd, ".context"));
+  const apiKey = config.enterprise.api_key.trim();
+  const baseUrl = (config.enterprise.base_url || config.enterprise.endpoint).trim();
+  if (!apiKey || !baseUrl) {
+    const outcome: CapabilitySyncOutcome = {
+      kind: "failed",
+      error: "enterprise not configured",
+    };
+    await writeAudit(cwd, outcome);
+    return outcome;
+  }
+
+  let manifest: ManifestEntry[];
+  try {
+    manifest = await fetchManifest(baseUrl, apiKey);
+  } catch (err) {
+    const outcome: CapabilitySyncOutcome = {
+      kind: "failed",
+      error: err instanceof Error ? err.message : String(err),
+    };
+    await writeAudit(cwd, outcome);
+    return outcome;
+  }
+
+  const state = readSyncedCapabilitiesState();
+  const remoteByName = new Map(manifest.map((e) => [e.capability_name, e]));
+
+  const added: string[] = [];
+  const changed: string[] = [];
+  const removed: string[] = [];
+
+  for (const entry of manifest) {
+    const local = state.capabilities[entry.capability_name];
+    const isNew = !local;
+    const isChanged =
+      Boolean(local) && local.updated_at !== entry.updated_at;
+    if (!isNew && !isChanged) continue;
+
+    let fetched: FetchedCapability;
+    try {
+      fetched = await fetchCapability(baseUrl, apiKey, entry.capability_name);
+    } catch (err) {
+      const outcome: CapabilitySyncOutcome = {
+        kind: "failed",
+        error:
+          err instanceof Error
+            ? `fetch ${entry.capability_name}: ${err.message}`
+            : `fetch ${entry.capability_name}: ${String(err)}`,
+      };
+      await writeAudit(cwd, outcome);
+      return outcome;
+    }
+
+    let validated: CapabilityDefinition;
+    try {
+      validated = capabilityDefinitionSchema.parse(fetched.definition);
+    } catch (err) {
+      const outcome: CapabilitySyncOutcome = {
+        kind: "failed",
+        error:
+          err instanceof Error
+            ? `validate ${entry.capability_name}: ${err.message}`
+            : `validate ${entry.capability_name}: ${String(err)}`,
+      };
+      await writeAudit(cwd, outcome);
+      return outcome;
+    }
+
+    state.capabilities[entry.capability_name] = {
+      capability_name: entry.capability_name,
+      updated_at: fetched.updated_at,
+      definition: validated,
+    };
+    (isNew ? added : changed).push(entry.capability_name);
+  }
+
+  for (const name of Object.keys(state.capabilities)) {
+    if (remoteByName.has(name)) continue;
+    delete state.capabilities[name];
+    removed.push(name);
+  }
+
+  const totalChanged = added.length + changed.length + removed.length;
+  if (totalChanged === 0) {
+    const outcome: CapabilitySyncOutcome = {
+      kind: "unchanged",
+      count: manifest.length,
+    };
+    await writeAudit(cwd, outcome);
+    return outcome;
+  }
+
+  state.last_synced_at = new Date().toISOString();
+  writeSyncedCapabilitiesState(state);
+  const outcome: CapabilitySyncOutcome = {
+    kind: "synced",
+    added,
+    changed,
+    removed,
+  };
+  await writeAudit(cwd, outcome);
+  return outcome;
+}
+
+async function writeAudit(cwd: string, outcome: CapabilitySyncOutcome): Promise<void> {
+  const eventBase = {
+    timestamp: new Date().toISOString(),
+    host_id: hostname(),
+  };
+  if (outcome.kind === "unchanged") {
+    await writeHostAuditEvent(cwd, {
+      ...eventBase,
+      event_type: "capabilities_unchanged",
+      count: outcome.count,
+    }).catch(() => undefined);
+  } else if (outcome.kind === "synced") {
+    await writeHostAuditEvent(cwd, {
+      ...eventBase,
+      event_type: "capabilities_synced",
+      added: outcome.added,
+      changed: outcome.changed,
+      removed: outcome.removed,
+    }).catch(() => undefined);
+  } else {
+    await writeHostAuditEvent(cwd, {
+      ...eventBase,
+      event_type: "capabilities_sync_failed",
+      error: outcome.error,
+    }).catch(() => undefined);
+  }
+}
+
+export type CapabilitySyncTimerHandle = {
+  stop(): void;
+};
+
+export function startCapabilitySyncTimer(
+  cwd: string,
+  intervalMs: number,
+): CapabilitySyncTimerHandle {
+  const tick = () => {
+    void runCapabilitySyncOnce(cwd).catch((err) => {
+      process.stderr.write(
+        `[cortex-daemon] capability sync failed: ${
+          err instanceof Error ? err.message : String(err)
+        }\n`,
+      );
+    });
+  };
+
+  void Promise.resolve().then(tick);
+  const handle = setInterval(tick, intervalMs);
+  if (typeof handle.unref === "function") handle.unref();
+  return {
+    stop() {
+      clearInterval(handle);
+    },
+  };
+}

--- a/scaffold/mcp/src/daemon/main.ts
+++ b/scaffold/mcp/src/daemon/main.ts
@@ -29,6 +29,7 @@ import {
 import { startSyncTimer } from "./sync-checker.js";
 import { startSkillSyncTimer } from "./skill-sync-checker.js";
 import { startWorkflowSyncTimer } from "./workflow-sync-checker.js";
+import { startCapabilitySyncTimer } from "./capability-sync-checker.js";
 import { startHostEventsPusher } from "./host-events-pusher.js";
 import { startEgressProxy } from "./egress-proxy.js";
 import { startHeartbeatPusher } from "./heartbeat-pusher.js";
@@ -370,6 +371,20 @@ async function main(): Promise<void> {
       : skillSyncMs;
   if (process.env.CORTEX_DISABLE_WORKFLOW_SYNC !== "1") {
     startWorkflowSyncTimer(process.cwd(), workflowSyncMs);
+  }
+
+  // Harness Phase 2: poll cortex-web for org-authored capabilities and
+  // cache definitions locally so evaluateToolCall can merge them over
+  // bundled DEFAULT_CAPABILITIES on the pre-tool-use path. Same cadence
+  // as the workflow sync by default; independently configurable via
+  // CORTEX_CAPABILITY_SYNC_MS / CORTEX_DISABLE_CAPABILITY_SYNC.
+  const capabilitySyncRaw = parseInt(process.env.CORTEX_CAPABILITY_SYNC_MS ?? "", 10);
+  const capabilitySyncMs =
+    Number.isFinite(capabilitySyncRaw) && capabilitySyncRaw > 0
+      ? capabilitySyncRaw
+      : workflowSyncMs;
+  if (process.env.CORTEX_DISABLE_CAPABILITY_SYNC !== "1") {
+    startCapabilitySyncTimer(process.cwd(), capabilitySyncMs);
   }
 
   // Govern host heartbeat — fills host_enrollment on cortex-web so the

--- a/scaffold/mcp/tests/workflow-synced-capabilities.test.mjs
+++ b/scaffold/mcp/tests/workflow-synced-capabilities.test.mjs
@@ -1,0 +1,226 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  loadSyncedCapabilities,
+  syncedCapabilitiesCachePath,
+} from "../dist/core/workflow/synced-capability-registry.js";
+import { evaluateToolCall } from "../dist/core/workflow/enforcement.js";
+import { createRun } from "../dist/core/workflow/run-lifecycle.js";
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "cortex-synced-caps-"));
+}
+
+const FRONTEND_BUILDER = {
+  name: "frontend-builder",
+  description: "Frontend-only profile",
+  read_globs: ["**"],
+  write_globs: ["src/components/**"],
+  tools_allowed: [],
+};
+
+const WORKFLOW = {
+  id: "fe",
+  description: "Frontend-only build",
+  version: 1,
+  stages: [
+    {
+      name: "build",
+      artifact: "changes.md",
+      reads: [],
+      required_fields: [],
+      validators: [],
+      capability: "frontend-builder",
+      description: "Build the frontend",
+    },
+  ],
+};
+
+function writeCache(dir, payload) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    syncedCapabilitiesCachePath(dir),
+    JSON.stringify(payload, null, 2),
+    "utf8",
+  );
+}
+
+test("syncedCapabilitiesCachePath: defaults to ~/.cortex/capabilities.local.json", () => {
+  const expected = path.join(os.homedir(), ".cortex", "capabilities.local.json");
+  assert.equal(syncedCapabilitiesCachePath(), expected);
+});
+
+test("loadSyncedCapabilities: returns {} when cache is missing", () => {
+  const dir = makeWorkspace();
+  assert.deepEqual(loadSyncedCapabilities(dir), {});
+});
+
+test("loadSyncedCapabilities: returns {} when cache is unreadable JSON", () => {
+  const dir = makeWorkspace();
+  fs.writeFileSync(syncedCapabilitiesCachePath(dir), "not json", "utf8");
+  assert.deepEqual(loadSyncedCapabilities(dir), {});
+});
+
+test("loadSyncedCapabilities: returns {} when 'capabilities' key is missing", () => {
+  const dir = makeWorkspace();
+  writeCache(dir, { last_synced_at: "x" });
+  assert.deepEqual(loadSyncedCapabilities(dir), {});
+});
+
+test("loadSyncedCapabilities: drops entries whose definition fails schema", () => {
+  const dir = makeWorkspace();
+  writeCache(dir, {
+    capabilities: {
+      "valid-one": {
+        capability_name: "valid-one",
+        updated_at: "2026-05-07T12:00:00.000Z",
+        definition: FRONTEND_BUILDER,
+      },
+      "broken-one": {
+        capability_name: "broken-one",
+        updated_at: "2026-05-07T12:00:00.000Z",
+        definition: { name: "broken-one" /* missing description */ },
+      },
+    },
+  });
+  const loaded = loadSyncedCapabilities(dir);
+  assert.deepEqual(Object.keys(loaded).sort(), ["valid-one"]);
+});
+
+test("loadSyncedCapabilities: returns valid capability definitions", () => {
+  const dir = makeWorkspace();
+  writeCache(dir, {
+    capabilities: {
+      "frontend-builder": {
+        capability_name: "frontend-builder",
+        updated_at: "2026-05-07T12:00:00.000Z",
+        definition: FRONTEND_BUILDER,
+      },
+    },
+  });
+  const loaded = loadSyncedCapabilities(dir);
+  assert.equal(loaded["frontend-builder"].name, "frontend-builder");
+  assert.deepEqual(loaded["frontend-builder"].write_globs, ["src/components/**"]);
+});
+
+test("evaluateToolCall integration: synced capability is consulted via merged registry", () => {
+  const cwd = makeWorkspace();
+  // Sandbox the home-dir-based loader.
+  const fakeHome = makeWorkspace();
+  process.env.HOME = fakeHome;
+  try {
+    fs.mkdirSync(path.join(fakeHome, ".cortex"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeHome, ".cortex", "capabilities.local.json"),
+      JSON.stringify({
+        capabilities: {
+          "frontend-builder": {
+            capability_name: "frontend-builder",
+            updated_at: "2026-05-07T12:00:00.000Z",
+            definition: FRONTEND_BUILDER,
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    createRun({
+      cwd,
+      taskId: "task-1",
+      workflow: WORKFLOW,
+      taskDescription: "Build frontend",
+    });
+
+    // Allowed: src/components/**
+    const allowed = evaluateToolCall({
+      cwd,
+      taskId: "task-1",
+      call: { toolName: "Edit", toolInput: { file_path: "src/components/Foo.tsx" } },
+      workflows: { fe: WORKFLOW },
+    });
+    assert.equal(allowed.allowed, true);
+
+    // Blocked: outside write_globs
+    const blocked = evaluateToolCall({
+      cwd,
+      taskId: "task-1",
+      call: { toolName: "Edit", toolInput: { file_path: "src/server/api.ts" } },
+      workflows: { fe: WORKFLOW },
+    });
+    assert.equal(blocked.allowed, false);
+    assert.match(blocked.reason, /frontend-builder/);
+  } finally {
+    delete process.env.HOME;
+  }
+});
+
+test("evaluateToolCall integration: synced capability with same name as bundled overrides bundled", () => {
+  const cwd = makeWorkspace();
+  const fakeHome = makeWorkspace();
+  process.env.HOME = fakeHome;
+  try {
+    // Override the bundled "builder" capability with a much stricter version
+    // — only test files writable.
+    const stricterBuilder = {
+      name: "builder",
+      description: "Org-overridden strict builder",
+      read_globs: ["**"],
+      write_globs: ["tests/**"],
+      tools_allowed: [],
+    };
+    fs.mkdirSync(path.join(fakeHome, ".cortex"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fakeHome, ".cortex", "capabilities.local.json"),
+      JSON.stringify({
+        capabilities: {
+          builder: {
+            capability_name: "builder",
+            updated_at: "2026-05-07T12:00:00.000Z",
+            definition: stricterBuilder,
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const builderWorkflow = {
+      id: "build-only",
+      description: "Build-only workflow using bundled name",
+      version: 1,
+      stages: [
+        {
+          name: "build",
+          artifact: "changes.md",
+          reads: [],
+          required_fields: [],
+          validators: [],
+          capability: "builder",
+          description: "Build",
+        },
+      ],
+    };
+    createRun({
+      cwd,
+      taskId: "task-2",
+      workflow: builderWorkflow,
+      taskDescription: "Build",
+    });
+
+    // Bundled builder allows src/** + tests/**, but the org override only
+    // allows tests/**. src/** must be blocked under the override.
+    const result = evaluateToolCall({
+      cwd,
+      taskId: "task-2",
+      call: { toolName: "Edit", toolInput: { file_path: "src/main.ts" } },
+      workflows: { "build-only": builderWorkflow },
+    });
+    assert.equal(result.allowed, false);
+    assert.match(result.reason, /Org-overridden|tests/i);
+  } finally {
+    delete process.env.HOME;
+  }
+});


### PR DESCRIPTION
Final slice of the Cortex Harness Phase-2 rollout. Completes the org-authoring trifecta on the daemon side (workflows, skills, now capabilities). cortex-web side landed in DanielBlomma/cortex-web#28 (backend) and #29 (dashboard).

## What lands

\`scaffold/mcp/src/daemon/capability-sync-checker.ts\`:
- \`runCapabilitySyncOnce(cwd)\` polls \`/api/v1/govern/capabilities/manifest\`, diffs against \`~/.cortex/capabilities.local.json\`, fetches changed full definitions via \`/api/v1/govern/capabilities/<name>\`, and validates each against the daemon's \`capabilityDefinitionSchema\` before caching.
- Removed (no longer enabled) capabilities are dropped from the cache.
- Three audit outcomes per tick (\`capabilities_unchanged\`, \`capabilities_synced\` with added/changed/removed counts, \`capabilities_sync_failed\`) via the existing host-events log.
- \`startCapabilitySyncTimer\` wired into \`daemon/main.ts\` behind \`CORTEX_DISABLE_CAPABILITY_SYNC=1\`; cadence configurable via \`CORTEX_CAPABILITY_SYNC_MS\`, defaults to the workflow-sync cadence.

\`scaffold/mcp/src/core/workflow/synced-capability-registry.ts\` (new):
- Read side of the cache. Lives in \`core/workflow/\` so \`enforcement.ts\` can consult it without depending on \`daemon/\` code.
- \`loadSyncedCapabilities(dir?)\` reads the cache, validates each entry against \`capabilityDefinitionSchema\`, drops invalid entries silently.

\`scaffold/mcp/src/core/workflow/enforcement.ts\`:
- \`evaluateToolCall\` now merges \`DEFAULT_CAPABILITIES\` with \`loadSyncedCapabilities()\` when no explicit registry is passed in. **Synced capabilities take precedence** on name collisions so an org override of a bundled default actually overrides.

## Tests
10 new cases under \`tests/workflow-synced-capabilities.test.mjs\`:
- default cache path is \`~/.cortex/capabilities.local.json\`
- missing cache → \`{}\`
- corrupt JSON → \`{}\`
- missing \`capabilities\` key → \`{}\`
- entries that fail \`capabilityDefinitionSchema\` are silently dropped
- valid entries are surfaced keyed by capability name
- integration: synced capability gates Edit calls correctly (allowed within write_globs, blocked outside)
- integration: synced capability with the same name as a bundled default overrides the bundled definition (e.g. org tightens \`builder\` to only allow \`tests/**\`)

**224/224 daemon tests pass**; \`tsc --noEmit\` clean.

## End-to-end after merge
1. Org admin authors a capability in \`/dashboard/capabilities\` (cortex-web#29)
2. Backend stores in \`org_capability\`, audit logged (cortex-web#28)
3. Daemon's next capability-sync tick pulls the manifest, fetches the definition, caches it locally
4. A workflow stage references the capability via \`capability: \"frontend-builder\"\`
5. Pre-tool-use hook calls \`evaluateToolCall\`, merged registry resolves \`frontend-builder\` from synced cache
6. Tool calls are gated against the org-authored \`read_globs\` / \`write_globs\` / \`tools_allowed\`
7. Audit + evidence trail capture every block

## Bump
After merge: trigger the release-bump workflow with \`patch\` to publish v2.0.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)