### PR TITLE
perf: ONNX intra-op thread cap for co-located embedders

### DIFF
--- a/scaffold/mcp/src/embed.ts
+++ b/scaffold/mcp/src/embed.ts
@@ -432,7 +432,19 @@ async function main(): Promise<void> {
   const existing = parseExistingEmbeddings(readJsonl(EMBEDDINGS_PATH), modelId);
 
   env.cacheDir = MODEL_CACHE_DIR;
-  const extractor = await pipeline("feature-extraction", modelId);
+  // Optional intra-op thread cap so co-located embedders (e.g. parallel CI
+  // jobs or eval containers) do not oversubscribe shared cores. Unset =
+  // library default (all cores), which is correct for a single instance.
+  const threadsRaw = Number(process.env.CORTEX_EMBED_THREADS);
+  const sessionOptions =
+    Number.isFinite(threadsRaw) && threadsRaw >= 1
+      ? { session_options: { intraOpNumThreads: Math.floor(threadsRaw), interOpNumThreads: 1 } }
+      : undefined;
+  const extractor = await pipeline(
+    "feature-extraction",
+    modelId,
+    sessionOptions as Parameters<typeof pipeline>[2]
+  );
 
   let reused = 0;
   let embedded = 0;


### PR DESCRIPTION
## Summary

Adds one embedding-pipeline knob, default-off: **`CORTEX_EMBED_THREADS`** caps onnxruntime intra-op threads (`intraOpNumThreads`, with `interOpNumThreads: 1`) during embedding generation.

**Why:** without a cap, every embedder spawns threads as if it owns the whole machine, so co-located cortex instances (parallel CI jobs, eval containers, multi-repo servers) degrade each other badly. Measured on a 12-core host: three parallel bootstraps ran at 3 × 3.5 entities/s — *less than one instance alone* (12/s). With CPU quotas plus this cap, the same hardware reaches ~3 × 25/s. Unset keeps the library default (all cores), which remains correct for the common single-instance case.

The diff is intentionally minimal: 13 lines in `scaffold/mcp/src/embed.ts`, no behavior change when the variable is unset.

## What was evaluated and deliberately left out

Batched inference (`CORTEX_EMBED_BATCH_SIZE`) was prototyped, verified numerically equivalent (max cosine deviation ~5e-7 vs single-text), and benchmarked — then dropped, because it adds no value for cortex's workload:

| Workload (120 texts) | batch=16 vs single |
| --- | --- |
| real chunks, mixed lengths up to 7k chars | **0.20x** (5x slower) |
| same, ONNX capped to 1 thread | 0.31x — rules out thread saturation as the cause |
| short uniform texts (60 chars) | 2.12x faster |

Mixed-length batches pay quadratic attention cost on padding; cortex's entity texts (file contents, chunk bodies) are long and heterogeneous, which is exactly the losing regime. If batching ever becomes worthwhile here, it would be via token-length-bucketed batching inside the pipeline (or a GPU/WebGPU backend), not a global batch-size knob.

## Test plan

- [x] `npm test` in `scaffold/mcp`: 259/259 pass
- [x] `tsc` build clean
- [x] Default path unchanged: with `CORTEX_EMBED_THREADS` unset, `pipeline()` receives `undefined` options exactly as before
- [x] Cap verified effective in practice: used by the bootstrap eval harness (3 containers × 4-core quota) for a 69-repo run