### PR TITLE
feat: expand bootstrap metrics dashboard and animate the pipeline overview

### DIFF
--- a/frontend/src/components/bootstrap-pipeline.tsx
+++ b/frontend/src/components/bootstrap-pipeline.tsx
@@ -1,0 +1,509 @@
+import { useEffect, useState, type CSSProperties } from "react";
+import {
+  ArrowRight,
+  Binary,
+  ChevronsRight,
+  Cpu,
+  DownloadCloud,
+  FileCode2,
+  type LucideIcon,
+  Network,
+  Search
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type StageKey = "resolve" | "ingest" | "embed" | "graph" | "serve";
+
+type Stage = {
+  key: StageKey;
+  label: string;
+  icon: LucideIcon;
+  /** HSL triple (no `hsl(...)` wrapper) so we can compose alpha variants. */
+  accent: string;
+  tagline: string;
+  blurb: string;
+  facts: readonly string[];
+};
+
+const STAGES: readonly Stage[] = [
+  {
+    key: "resolve",
+    label: "Resolve",
+    icon: DownloadCloud,
+    accent: "222 47% 45%",
+    tagline: "Provision the local toolchain",
+    blurb:
+      "cortex bootstrap installs everything the pipeline needs — tree-sitter grammars, the ONNX embedding runtime and the RyuGraph engine — vendored under .context/ inside your repo. No services to start, nothing leaves the machine.",
+    facts: ["One command", "All deps vendored", "Zero cloud calls"]
+  },
+  {
+    key: "ingest",
+    label: "Ingest",
+    icon: FileCode2,
+    accent: "221 83% 53%",
+    tagline: "Parse source into entities",
+    blurb:
+      "Tree-sitter parses every file into structured entities — files, functions, classes, methods, plus rules and ADRs. Parsing fans out across a worker pool, one worker per core, so large repos index in parallel.",
+    facts: ["Worker pool · ≤ 8 cores", "AST-accurate chunks", "14+ languages"]
+  },
+  {
+    key: "embed",
+    label: "Embed",
+    icon: Binary,
+    accent: "199 89% 48%",
+    tagline: "Vectorize for semantic search",
+    blurb:
+      "A local sentence-transformer (all-MiniLM-L6-v2) turns each entity into a 384-dimension vector on the ONNX runtime — fully offline, no API keys. Unchanged code reuses cached vectors, so re-runs only embed what moved.",
+    facts: ["all-MiniLM-L6-v2", "384 dimensions", "Offline · cache-aware"]
+  },
+  {
+    key: "graph",
+    label: "Graph",
+    icon: Network,
+    accent: "173 80% 36%",
+    tagline: "Load the code graph",
+    blurb:
+      "Entities and their relations — DEFINES, CALLS, IMPORTS, CONSTRAINS, IMPLEMENTS, SUPERSEDES — bulk-load into RyuGraph, a local embedded property graph that powers fast traversal queries over the codebase.",
+    facts: ["RyuGraph · embedded", "6 relation types", "Bulk COPY load"]
+  },
+  {
+    key: "serve",
+    label: "Serve",
+    icon: Search,
+    accent: "262 70% 56%",
+    tagline: "Answer through MCP",
+    blurb:
+      "MCP tools answer assistant queries by fusing semantic search with graph traversal, ranked by semantic similarity, graph proximity, source-of-truth trust and recency — a compact, governed context instead of raw file dumps.",
+    facts: ["context.search + graph", "4-signal ranking", "Rules enforced"]
+  }
+] as const;
+
+const CYCLE_MS = 7200;
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+  return reduced;
+}
+
+export function BootstrapPipeline() {
+  const [active, setActive] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const reduced = usePrefersReducedMotion();
+
+  // Re-arm a one-shot timer on every stage change so a manual click also gets a
+  // full cycle before auto-advance resumes. Paused on hover/focus and disabled
+  // entirely under reduced-motion.
+  useEffect(() => {
+    if (reduced || paused) return;
+    const timer = setTimeout(() => {
+      setActive((current) => (current + 1) % STAGES.length);
+    }, CYCLE_MS);
+    return () => clearTimeout(timer);
+  }, [active, paused, reduced]);
+
+  const stage = STAGES[active];
+  const rootStyle = { "--accent-hsl": stage.accent } as CSSProperties;
+
+  return (
+    <div
+      className="rounded-xl border bg-card p-5 shadow-sm transition-colors sm:p-6"
+      style={rootStyle}
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      onFocusCapture={() => setPaused(true)}
+      onBlurCapture={() => setPaused(false)}
+    >
+      <StageRail active={active} onSelect={setActive} />
+
+      {!reduced && !paused ? (
+        <div className="mt-4 h-0.5 w-full overflow-hidden rounded-full bg-border/60">
+          <div
+            key={active}
+            className="cortex-progress h-full rounded-full"
+            style={{ background: `hsl(${stage.accent})`, animationDuration: `${CYCLE_MS}ms` }}
+          />
+        </div>
+      ) : (
+        <div className="mt-4 h-0.5 w-full rounded-full bg-border/60" />
+      )}
+
+      <div className="mt-6 grid items-stretch gap-6 md:grid-cols-[1.25fr_1fr]">
+        <div className="relative min-h-[220px] overflow-hidden rounded-lg border bg-muted/30 p-4">
+          <StageCanvas key={active} stageKey={stage.key} accent={stage.accent} />
+        </div>
+        {/* Every stage's detail is stacked in one grid cell so the panel sizes
+            to the tallest stage and stays a constant height — advancing the
+            timer (or clicking a stage) never reflows the page below it. */}
+        <div className="grid">
+          {STAGES.map((item, index) => (
+            <div
+              key={item.key}
+              className={cn("[grid-area:1/1]", index === active ? "" : "invisible pointer-events-none")}
+              aria-hidden={index !== active}
+            >
+              <StageDetail stage={item} index={index} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StageRail({ active, onSelect }: { active: number; onSelect: (index: number) => void }) {
+  return (
+    <div className="flex items-start">
+      {STAGES.map((stage, index) => {
+        const isActive = index === active;
+        const Icon = stage.icon;
+        return (
+          <button
+            key={stage.key}
+            type="button"
+            onClick={() => onSelect(index)}
+            aria-pressed={isActive}
+            aria-label={`Stage ${index + 1}: ${stage.label}`}
+            className="group relative flex flex-1 flex-col items-center gap-2 rounded-md px-1 py-1 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {/* Connector to the next node, drawn behind the circles. Anchored to
+                this column's center and one column wide, so it reaches exactly
+                the next node's center — node centers stay evenly spaced. */}
+            {index < STAGES.length - 1 ? (
+              <span aria-hidden className="absolute left-1/2 top-1 z-0 flex h-11 w-full items-center">
+                <span className="cortex-track h-0.5 w-full rounded-full bg-border">
+                  <span className="cortex-track-dot absolute inset-y-0 left-0 w-8 rounded-full bg-gradient-to-r from-transparent via-foreground/50 to-transparent" />
+                </span>
+              </span>
+            ) : null}
+            <span
+              className={cn(
+                "relative z-10 flex h-11 w-11 items-center justify-center rounded-full border-2 bg-card transition-all duration-300",
+                isActive ? "scale-110" : "border-border text-muted-foreground group-hover:text-foreground"
+              )}
+              style={
+                isActive
+                  ? {
+                      borderColor: `hsl(${stage.accent})`,
+                      color: `hsl(${stage.accent})`,
+                      background: `hsl(${stage.accent} / 0.08)`,
+                      boxShadow: `0 0 0 4px hsl(${stage.accent} / 0.12)`
+                    }
+                  : undefined
+              }
+            >
+              <Icon className="h-5 w-5" />
+              <span
+                className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-semibold text-primary-foreground"
+                style={{ background: isActive ? `hsl(${stage.accent})` : "hsl(var(--muted-foreground))" }}
+              >
+                {index + 1}
+              </span>
+            </span>
+            <span
+              className={cn(
+                "text-center text-xs font-medium transition-colors",
+                isActive ? "text-foreground" : "text-muted-foreground"
+              )}
+            >
+              {stage.label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function StageDetail({ stage, index }: { stage: Stage; index: number }) {
+  return (
+    <div className="flex flex-col justify-center gap-3">
+      <div className="flex items-center gap-2">
+        <span
+          className="rounded-full px-2 py-0.5 text-[11px] font-medium"
+          style={{ background: `hsl(${stage.accent} / 0.12)`, color: `hsl(${stage.accent})` }}
+        >
+          Step {index + 1} / {STAGES.length}
+        </span>
+        <span className="text-xs text-muted-foreground">{stage.tagline}</span>
+      </div>
+      <h3 className="text-lg font-semibold tracking-tight">{stage.label}</h3>
+      <p className="text-sm leading-relaxed text-muted-foreground">{stage.blurb}</p>
+      <div className="flex flex-wrap gap-1.5">
+        {stage.facts.map((fact) => (
+          <span
+            key={fact}
+            className="rounded-full border px-2 py-0.5 text-[11px] text-muted-foreground"
+            style={{ borderColor: `hsl(${stage.accent} / 0.35)` }}
+          >
+            {fact}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StageCanvas({ stageKey, accent }: { stageKey: StageKey; accent: string }) {
+  switch (stageKey) {
+    case "resolve":
+      return <ResolveCanvas accent={accent} />;
+    case "ingest":
+      return <IngestCanvas accent={accent} />;
+    case "embed":
+      return <EmbedCanvas accent={accent} />;
+    case "graph":
+      return <GraphCanvas accent={accent} />;
+    case "serve":
+      return <ServeCanvas accent={accent} />;
+  }
+}
+
+const RESOLVE_PACKAGES = [
+  { label: "tree-sitter grammars", delay: 0 },
+  { label: "onnx embedding runtime", delay: 0.18 },
+  { label: "ryugraph engine", delay: 0.36 }
+] as const;
+
+function ResolveCanvas({ accent }: { accent: string }) {
+  return (
+    <div className="flex h-full flex-col justify-center gap-4">
+      {RESOLVE_PACKAGES.map((pkg) => (
+        <div key={pkg.label} className="cortex-anim-rise" style={{ animationDelay: `${pkg.delay}s` }}>
+          <div className="mb-1.5 flex items-center justify-between text-[11px] text-muted-foreground">
+            <span className="font-mono">{pkg.label}</span>
+            <span className="font-mono" style={{ color: `hsl(${accent})` }}>
+              ready
+            </span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-border/60">
+            <div
+              className="cortex-fillbar h-full w-full rounded-full"
+              style={{ background: `hsl(${accent})`, animationDelay: `${pkg.delay + 0.12}s` }}
+            />
+          </div>
+        </div>
+      ))}
+      <p className="text-[11px] text-muted-foreground">
+        Installed under <code className="rounded bg-muted px-1 py-0.5">.context/</code> — no global state.
+      </p>
+    </div>
+  );
+}
+
+const INGEST_FILES = ["auth.ts", "User.java", "parse.go", "schema.sql"] as const;
+const INGEST_LANES = [0, 1, 2] as const;
+
+function IngestCanvas({ accent }: { accent: string }) {
+  return (
+    <div className="flex h-full items-center gap-3">
+      <div className="flex flex-col gap-1.5">
+        {INGEST_FILES.map((file, index) => (
+          <span
+            key={file}
+            className="cortex-anim-rise rounded border bg-background px-2 py-1 font-mono text-[10px]"
+            style={{ animationDelay: `${index * 0.08}s` }}
+          >
+            {file}
+          </span>
+        ))}
+      </div>
+      <ChevronsRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <div className="flex flex-1 flex-col gap-2.5">
+        {INGEST_LANES.map((lane) => (
+          <div key={lane} className="flex items-center gap-2">
+            <span className="flex shrink-0 items-center gap-1 rounded border bg-background px-1.5 py-0.5 text-[10px] text-muted-foreground">
+              <Cpu className="h-3 w-3" />w{lane + 1}
+            </span>
+            <div className="cortex-track h-px flex-1 bg-border">
+              <span
+                className="cortex-track-dot absolute top-1/2 left-0 h-1 w-6 -translate-y-1/2 rounded-full"
+                style={{ background: `hsl(${accent})`, animationDelay: `${lane * 0.3}s` }}
+              />
+            </div>
+            <div className="flex shrink-0 gap-1">
+              {[0, 1].map((chunk) => (
+                <span
+                  key={chunk}
+                  className="cortex-anim-pop h-4 w-4 rounded-sm"
+                  style={{
+                    background: `hsl(${accent} / ${0.4 + chunk * 0.35})`,
+                    animationDelay: `${0.5 + lane * 0.15 + chunk * 0.2}s`
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+        <p className="text-[10px] text-muted-foreground">files → chunks, in parallel</p>
+      </div>
+    </div>
+  );
+}
+
+const EMBED_CELLS = Array.from({ length: 48 }, (_, index) => index);
+
+function EmbedCanvas({ accent }: { accent: string }) {
+  return (
+    <div className="flex h-full flex-col justify-center gap-3">
+      <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+        <span className="rounded border bg-background px-2 py-0.5 font-mono">chunk</span>
+        <ArrowRight className="h-3 w-3" />
+        <span className="font-mono">[0.12, -0.04, 0.37, …]</span>
+      </div>
+      <div className="grid grid-cols-12 gap-1">
+        {EMBED_CELLS.map((cell) => {
+          // Deterministic pseudo-random intensity so the grid reads like a
+          // heat-mapped vector without per-render jitter.
+          const intensity = 0.18 + (((cell * 37) % 11) / 11) * 0.82;
+          const delay = (cell % 12) * 0.03 + Math.floor(cell / 12) * 0.07;
+          return (
+            <span
+              key={cell}
+              className="cortex-anim-pop aspect-square rounded-[2px]"
+              style={{ background: `hsl(${accent} / ${intensity.toFixed(2)})`, animationDelay: `${delay}s` }}
+            />
+          );
+        })}
+      </div>
+      <p className="text-[11px] text-muted-foreground">384 dims per entity · runs locally on the ONNX runtime.</p>
+    </div>
+  );
+}
+
+type GraphNode = { id: string; x: number; y: number; label: string };
+
+const GRAPH_NODES: readonly GraphNode[] = [
+  { id: "file", x: 42, y: 38, label: "File" },
+  { id: "fn1", x: 138, y: 24, label: "fn" },
+  { id: "fn2", x: 150, y: 92, label: "fn" },
+  { id: "cls", x: 248, y: 52, label: "class" },
+  { id: "rule", x: 240, y: 122, label: "Rule" },
+  { id: "adr", x: 58, y: 118, label: "ADR" }
+] as const;
+
+const GRAPH_EDGES: readonly [string, string][] = [
+  ["file", "fn1"],
+  ["file", "fn2"],
+  ["fn1", "cls"],
+  ["fn2", "cls"],
+  ["rule", "cls"],
+  ["adr", "file"]
+];
+
+function GraphCanvas({ accent }: { accent: string }) {
+  const byId = new Map(GRAPH_NODES.map((node) => [node.id, node]));
+  return (
+    <div className="flex h-full items-center justify-center">
+      <svg viewBox="0 0 300 150" className="h-full w-full" role="img" aria-label="Code graph of entities and relations">
+        {GRAPH_EDGES.map(([from, to], index) => {
+          const a = byId.get(from);
+          const b = byId.get(to);
+          if (!a || !b) return null;
+          return (
+            <line
+              key={`${from}-${to}`}
+              className="cortex-edge"
+              x1={a.x}
+              y1={a.y}
+              x2={b.x}
+              y2={b.y}
+              stroke={`hsl(${accent} / 0.55)`}
+              strokeWidth={1.5}
+              style={{ strokeDasharray: 300, animationDelay: `${index * 0.12}s` }}
+            />
+          );
+        })}
+        {GRAPH_NODES.map((node, index) => (
+          <g
+            key={node.id}
+            className="cortex-anim-pop"
+            style={{ animationDelay: `${0.3 + index * 0.1}s`, transformBox: "fill-box", transformOrigin: "center" }}
+          >
+            <circle cx={node.x} cy={node.y} r={11} fill={`hsl(${accent} / 0.15)`} stroke={`hsl(${accent})`} strokeWidth={1.5} />
+            <text
+              x={node.x}
+              y={node.y + 3}
+              textAnchor="middle"
+              fontSize={8}
+              fontFamily="ui-monospace, monospace"
+              fill={`hsl(${accent})`}
+            >
+              {node.label}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+const SERVE_RESULTS = [
+  { name: "auth/login.ts › verifyToken", score: 0.94 },
+  { name: "middleware/session.ts", score: 0.87 },
+  { name: "rule: no-plaintext-secrets", score: 0.79 }
+] as const;
+
+const SERVE_SIGNALS = ["semantic", "graph", "trust", "recency"] as const;
+
+function ServeCanvas({ accent }: { accent: string }) {
+  return (
+    <div className="flex h-full flex-col gap-2">
+      <div className="cortex-anim-rise flex items-center gap-2 rounded border bg-background px-2 py-1.5 font-mono text-[11px]">
+        <Search className="h-3 w-3 shrink-0 text-muted-foreground" />
+        <span className="truncate">context.search("how are sessions verified?")</span>
+      </div>
+      <div className="cortex-track my-1 h-px w-full bg-border">
+        <span
+          className="cortex-track-dot absolute top-1/2 left-0 h-1 w-10 -translate-y-1/2 rounded-full"
+          style={{ background: `hsl(${accent})` }}
+        />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {SERVE_RESULTS.map((result, index) => (
+          <div
+            key={result.name}
+            className="cortex-anim-rise flex items-center gap-2"
+            style={{ animationDelay: `${0.4 + index * 0.16}s` }}
+          >
+            <span className="w-8 shrink-0 text-right font-mono text-[10px]" style={{ color: `hsl(${accent})` }}>
+              {result.score.toFixed(2)}
+            </span>
+            <div className="relative h-5 flex-1 overflow-hidden rounded border bg-background">
+              <div
+                className="cortex-fillbar absolute inset-y-0 left-0 rounded"
+                style={{
+                  width: `${Math.round(result.score * 100)}%`,
+                  background: `hsl(${accent} / 0.15)`,
+                  animationDelay: `${0.5 + index * 0.16}s`
+                }}
+              />
+              <span className="absolute inset-0 flex items-center truncate px-2 font-mono text-[10px]">
+                {result.name}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-auto flex flex-wrap gap-1 pt-1">
+        {SERVE_SIGNALS.map((signal) => (
+          <span
+            key={signal}
+            className="rounded-full border px-1.5 py-0.5 text-[9px] text-muted-foreground"
+            style={{ borderColor: `hsl(${accent} / 0.35)` }}
+          >
+            {signal}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/bootstrap/repo-table.tsx
+++ b/frontend/src/components/bootstrap/repo-table.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { ArrowDown, ArrowUp } from "lucide-react";
 
-import { StatusBadge } from "@/components/bootstrap/stat-cards";
+import { MetricHelp, StatusBadge } from "@/components/bootstrap/stat-cards";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import type { RepoRow } from "@/data/bootstrap-types";
@@ -19,15 +19,50 @@ type SortKey =
   | "isolated_pct"
   | "total_ms";
 
-const COLUMNS: Array<{ key: SortKey; label: string; numeric: boolean }> = [
+const COLUMNS: Array<{ key: SortKey; label: string; numeric: boolean; explanation?: string }> = [
   { key: "name", label: "Repository", numeric: false },
-  { key: "tracked_files", label: "Tracked files", numeric: true },
-  { key: "chunks", label: "Chunks", numeric: true },
-  { key: "chunk_p50_lines", label: "P50 lines", numeric: true },
-  { key: "edges", label: "Edges", numeric: true },
-  { key: "avg_degree", label: "Avg degree", numeric: true },
-  { key: "isolated_pct", label: "Isolated", numeric: true },
-  { key: "total_ms", label: "Bootstrap", numeric: true }
+  {
+    key: "tracked_files",
+    label: "Tracked files",
+    numeric: true,
+    explanation: "Git-tracked files present at the pinned repository commit before Cortex filtering."
+  },
+  {
+    key: "chunks",
+    label: "Chunks",
+    numeric: true,
+    explanation: "Semantic units Cortex extracted from indexed files, such as symbols, sections, and windows."
+  },
+  {
+    key: "chunk_p50_lines",
+    label: "P50 lines",
+    numeric: true,
+    explanation: "Median chunk length in lines for this repository run."
+  },
+  {
+    key: "edges",
+    label: "Edges",
+    numeric: true,
+    explanation: "Total graph relation edges loaded for this repository."
+  },
+  {
+    key: "avg_degree",
+    label: "Avg degree",
+    numeric: true,
+    explanation: "Average chunk-to-chunk CALLS connectivity degree. Higher values indicate a denser call graph."
+  },
+  {
+    key: "isolated_pct",
+    label: "Isolated",
+    numeric: true,
+    explanation: "Percentage of chunks with no chunk-to-chunk CALLS edges."
+  },
+  {
+    key: "total_ms",
+    label: "Bootstrap",
+    numeric: true,
+    explanation: "Total wall-clock time for the repository bootstrap run."
+  }
 ];
 
 export function RepoTable({ rows, version }: { rows: RepoRow[]; version?: string }) {
@@ -63,23 +98,31 @@ export function RepoTable({ rows, version }: { rows: RepoRow[]; version?: string
           <TableRow className="hover:bg-transparent">
             {COLUMNS.map((column) => (
               <TableHead key={column.key} className={cn(column.numeric && "text-right")}>
-                <button
-                  type="button"
-                  onClick={() => toggleSort(column.key)}
+                <div
                   className={cn(
-                    "inline-flex items-center gap-1 font-medium transition-colors hover:text-foreground",
-                    column.numeric && "flex-row-reverse"
+                    "inline-flex items-center gap-1.5",
+                    column.numeric && "flex-row-reverse justify-end"
                   )}
                 >
-                  {column.label}
-                  {sortKey === column.key ? (
-                    descending ? (
-                      <ArrowDown className="h-3 w-3" />
-                    ) : (
-                      <ArrowUp className="h-3 w-3" />
-                    )
-                  ) : null}
-                </button>
+                  <button
+                    type="button"
+                    onClick={() => toggleSort(column.key)}
+                    className={cn(
+                      "inline-flex items-center gap-1 font-medium transition-colors hover:text-foreground",
+                      column.numeric && "flex-row-reverse"
+                    )}
+                  >
+                    {column.label}
+                    {sortKey === column.key ? (
+                      descending ? (
+                        <ArrowDown className="h-3 w-3" />
+                      ) : (
+                        <ArrowUp className="h-3 w-3" />
+                      )
+                    ) : null}
+                  </button>
+                  {column.explanation ? <MetricHelp label={column.label} explanation={column.explanation} /> : null}
+                </div>
               </TableHead>
             ))}
             <TableHead className="text-right">Status</TableHead>

--- a/frontend/src/components/bootstrap/stat-cards.tsx
+++ b/frontend/src/components/bootstrap/stat-cards.tsx
@@ -1,12 +1,14 @@
-import type { LucideIcon } from "lucide-react";
+import { CircleHelp, type LucideIcon } from "lucide-react";
 
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export type StatCardDatum = {
   label: string;
   value: string;
   hint?: string;
+  explanation?: string;
   icon?: LucideIcon;
 };
 
@@ -18,7 +20,8 @@ export function StatCards({ stats }: { stats: StatCardDatum[] }) {
           <CardContent className="flex flex-col gap-1 p-5">
             <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
               {stat.icon ? <stat.icon className="h-3.5 w-3.5" /> : null}
-              {stat.label}
+              <span>{stat.label}</span>
+              {stat.explanation ? <MetricHelp label={stat.label} explanation={stat.explanation} /> : null}
             </div>
             <div className="text-2xl font-semibold tabular-nums tracking-tight">{stat.value}</div>
             {stat.hint ? <div className="text-xs text-muted-foreground">{stat.hint}</div> : null}
@@ -26,6 +29,24 @@ export function StatCards({ stats }: { stats: StatCardDatum[] }) {
         </Card>
       ))}
     </div>
+  );
+}
+
+export function MetricHelp({ label, explanation }: { label: string; explanation: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          role="button"
+          tabIndex={0}
+          className="inline-flex h-4 w-4 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          aria-label={`What ${label} means`}
+        >
+          <CircleHelp className="h-3.5 w-3.5" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{explanation}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/frontend/src/components/charts.tsx
+++ b/frontend/src/components/charts.tsx
@@ -3,6 +3,11 @@ import {
   BarChart,
   CartesianGrid,
   Cell,
+  Label,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
   ResponsiveContainer,
   Scatter,
   ScatterChart,
@@ -35,7 +40,7 @@ const TOOLTIP_STYLE = {
   background: "hsl(var(--background))"
 } as const;
 
-type HistogramSeries = { name: string; histogram: HistogramBucket[]; color?: string };
+export type HistogramSeries = { name: string; histogram: HistogramBucket[]; color?: string };
 
 /**
  * Fixed-bucket histogram as a (optionally grouped) bar chart. All series must
@@ -127,7 +132,98 @@ export function HistogramChart({
   );
 }
 
+export function DistributionLineChart({
+  series,
+  height = 320,
+  unit,
+  valueLabel = "chunks"
+}: {
+  series: HistogramSeries[];
+  height?: number;
+  unit: string;
+  valueLabel?: string;
+}) {
+  const present = series.filter((entry) => entry.histogram.length > 0);
+  if (present.length === 0) {
+    return <EmptyChart height={height} />;
+  }
+
+  const labels = present[0].histogram.map((bucket) => bucket.label);
+  const data = labels.map((label, bucketIndex) => {
+    const row: Record<string, string | number> = { label };
+    for (const entry of present) {
+      row[entry.name] = entry.histogram[bucketIndex]?.count ?? 0;
+    }
+    return row;
+  });
+  const hasLegend = present.length > 1;
+
+  return (
+    <div className="flex flex-col" style={{ height }}>
+      <div className="min-h-0 flex-1">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 8, right: 16, bottom: 32, left: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
+            <XAxis
+              dataKey="label"
+              tick={AXIS_TICK}
+              tickLine={false}
+              axisLine={false}
+              label={{
+                value: `chunk size (${unit})`,
+                position: "insideBottom",
+                offset: -12,
+                fontSize: 11,
+                fill: "hsl(var(--muted-foreground))"
+              }}
+            />
+            <YAxis
+              tick={AXIS_TICK}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={formatCount}
+              label={{
+                value: valueLabel,
+                angle: -90,
+                position: "insideLeft",
+                fontSize: 11,
+                fill: "hsl(var(--muted-foreground))"
+              }}
+            />
+            <RechartsTooltip
+              contentStyle={TOOLTIP_STYLE}
+              formatter={(value: number, name: string) => [`${formatCount(value)} ${valueLabel}`, name]}
+              labelFormatter={(label: string) => `${label} ${unit}`}
+            />
+            {present.map((entry, index) => (
+              <Line
+                key={entry.name}
+                type="monotone"
+                dataKey={entry.name}
+                stroke={entry.color ?? chartColor(index)}
+                strokeWidth={2}
+                dot={{ r: 2 }}
+                activeDot={{ r: 4 }}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+      {hasLegend ? (
+        <ChartLegend
+          items={present.map((entry, index) => ({
+            label: entry.name,
+            color: entry.color ?? chartColor(index)
+          }))}
+          marker="circle"
+        />
+      ) : null}
+    </div>
+  );
+}
+
 export type CategoryDatum = { name: string; value: number };
+export type DistributionSlice = { id: string; label: string; count: number; fill?: string };
 
 /** Horizontal bar chart for categorical breakdowns (relation types, languages). */
 export function CategoryBarChart({
@@ -184,12 +280,16 @@ export function RepoScatterChart({
   points,
   xLabel,
   yLabel,
-  height = 300
+  height = 300,
+  xValueFormatter = formatCount,
+  yValueFormatter = formatCount
 }: {
   points: ScatterPoint[];
   xLabel: string;
   yLabel: string;
   height?: number;
+  xValueFormatter?: (value: number) => string;
+  yValueFormatter?: (value: number) => string;
 }) {
   if (points.length === 0) {
     return <EmptyChart height={height} />;
@@ -200,7 +300,7 @@ export function RepoScatterChart({
     <div className="flex flex-col" style={{ height }}>
       <div className="min-h-0 flex-1">
         <ResponsiveContainer width="100%" height="100%">
-          <ScatterChart margin={{ top: 8, right: 16, bottom: 32, left: 8 }}>
+          <ScatterChart margin={{ top: 12, right: 20, bottom: 48, left: 20 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
             <XAxis
               type="number"
@@ -208,11 +308,11 @@ export function RepoScatterChart({
               name={xLabel}
               tick={AXIS_TICK}
               tickLine={false}
-              tickFormatter={formatCount}
+              tickFormatter={xValueFormatter}
               label={{
                 value: xLabel,
                 position: "insideBottom",
-                offset: -12,
+                offset: -28,
                 fontSize: 11,
                 fill: "hsl(var(--muted-foreground))"
               }}
@@ -221,13 +321,15 @@ export function RepoScatterChart({
               type="number"
               dataKey="y"
               name={yLabel}
+              width={72}
               tick={AXIS_TICK}
               tickLine={false}
-              tickFormatter={formatCount}
+              tickFormatter={yValueFormatter}
               label={{
                 value: yLabel,
                 angle: -90,
                 position: "insideLeft",
+                offset: -2,
                 fontSize: 11,
                 fill: "hsl(var(--muted-foreground))"
               }}
@@ -236,7 +338,10 @@ export function RepoScatterChart({
             <RechartsTooltip
               contentStyle={TOOLTIP_STYLE}
               cursor={{ strokeDasharray: "3 3" }}
-              formatter={(value: number, name: string) => [formatCount(value), name]}
+              formatter={(value: number, name: string) => [
+                name === xLabel ? xValueFormatter(value) : yValueFormatter(value),
+                name
+              ]}
               labelFormatter={() => ""}
               content={({ payload }) => {
                 const point = payload?.[0]?.payload as ScatterPoint | undefined;
@@ -247,7 +352,7 @@ export function RepoScatterChart({
                   <div style={TOOLTIP_STYLE} className="px-3 py-2">
                     <div className="text-xs font-medium">{point.name}</div>
                     <div className="text-xs text-muted-foreground">
-                      {xLabel}: {formatCount(point.x)} · {yLabel}: {formatCount(point.y)}
+                      {xLabel}: {xValueFormatter(point.x)} · {yLabel}: {yValueFormatter(point.y)}
                     </div>
                   </div>
                 );
@@ -274,6 +379,134 @@ export function RepoScatterChart({
         />
       ) : null}
     </div>
+  );
+}
+
+export function DistributionDonutChart({
+  data,
+  height = 260,
+  variant = "donut",
+  centerValue,
+  centerLabel,
+  valueLabel = "repos"
+}: {
+  data: DistributionSlice[];
+  height?: number;
+  variant?: "donut" | "label";
+  centerValue?: number;
+  centerLabel?: string;
+  valueLabel?: string;
+}) {
+  if (data.length === 0) {
+    return <EmptyChart height={height} />;
+  }
+
+  const total = data.reduce((sum, entry) => sum + entry.count, 0);
+  const displayedCenterValue = centerValue ?? total;
+  const displayedCenterLabel = centerLabel ?? valueLabel;
+  const outerRadius = variant === "label" ? 74 : 76;
+  const innerRadius = variant === "donut" ? 48 : 0;
+
+  return (
+    <div className="flex flex-col" style={{ height }}>
+      <div className="min-h-0 flex-1">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart margin={{ top: 16, right: 16, bottom: 8, left: 16 }}>
+            <RechartsTooltip
+              contentStyle={TOOLTIP_STYLE}
+              formatter={(value: number, name: string, item) => {
+                const payload = item.payload as DistributionSlice | undefined;
+                const percent = total > 0 ? (value / total) * 100 : 0;
+                return [`${formatCount(value)} ${valueLabel} (${percent.toFixed(1)}%)`, payload?.label ?? name];
+              }}
+            />
+            <Pie
+              data={data}
+              dataKey="count"
+              nameKey="id"
+              cx="50%"
+              cy="50%"
+              innerRadius={innerRadius}
+              outerRadius={outerRadius}
+              stroke="none"
+              labelLine={false}
+              label={variant === "label" ? renderPieLabel : false}
+            >
+              {data.map((entry, index) => (
+                <Cell key={entry.id} fill={entry.fill ?? chartColor(index)} />
+              ))}
+              {variant === "donut" ? (
+                <Label
+                  content={({ viewBox }) => {
+                    if (!viewBox || !("cx" in viewBox) || !("cy" in viewBox)) {
+                      return null;
+                    }
+                    return (
+                      <text x={viewBox.cx} y={viewBox.cy} textAnchor="middle" dominantBaseline="middle">
+                        <tspan x={viewBox.cx} y={viewBox.cy} className="fill-foreground text-2xl font-semibold">
+                          {formatCount(displayedCenterValue)}
+                        </tspan>
+                        <tspan x={viewBox.cx} y={(viewBox.cy ?? 0) + 20} className="fill-muted-foreground text-xs">
+                          {displayedCenterLabel}
+                        </tspan>
+                      </text>
+                    );
+                  }}
+                />
+              ) : null}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+      <ChartLegend
+        items={data.map((entry, index) => ({
+          label: entry.label,
+          color: entry.fill ?? chartColor(index)
+        }))}
+        marker="circle"
+      />
+    </div>
+  );
+}
+
+function renderPieLabel({
+  cx,
+  cy,
+  midAngle,
+  outerRadius,
+  payload
+}: {
+  cx?: number;
+  cy?: number;
+  midAngle?: number;
+  outerRadius?: number;
+  payload?: DistributionSlice;
+}) {
+  if (
+    !payload ||
+    typeof cx !== "number" ||
+    typeof cy !== "number" ||
+    typeof midAngle !== "number" ||
+    typeof outerRadius !== "number"
+  ) {
+    return null;
+  }
+
+  const radius = outerRadius + 20;
+  const angle = -midAngle * (Math.PI / 180);
+  const x = cx + radius * Math.cos(angle);
+  const y = cy + radius * Math.sin(angle);
+
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor={x > cx ? "start" : "end"}
+      dominantBaseline="central"
+      className="fill-foreground text-xs"
+    >
+      {payload.label}
+    </text>
   );
 }
 

--- a/frontend/src/components/pages/bootstrap-page.tsx
+++ b/frontend/src/components/pages/bootstrap-page.tsx
@@ -1,14 +1,23 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Boxes, Clock, Database, FileCode2, Network, Share2 } from "lucide-react";
 
 import { RepoTable } from "@/components/bootstrap/repo-table";
 import { VersionSelect } from "@/components/bootstrap/version-select";
 import { StatCards } from "@/components/bootstrap/stat-cards";
-import { CategoryBarChart, HistogramChart, RepoScatterChart, chartColor } from "@/components/charts";
+import {
+  CategoryBarChart,
+  DistributionDonutChart,
+  DistributionLineChart,
+  RepoScatterChart,
+  chartColor,
+  type DistributionSlice,
+  type HistogramSeries
+} from "@/components/charts";
 import { SectionShell } from "@/components/section-shell";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import type { BootstrapSummaryDoc, VersionIndexEntry } from "@/data/bootstrap-types";
+import type { BootstrapSummaryDoc, HistogramBucket, RepoDetailDoc, RepoRow, VersionIndexEntry } from "@/data/bootstrap-types";
+import { loadRepoDetail } from "@/data/load-bootstrap";
 import { formatCount, formatDate, formatDuration, formatNumber, formatPercent, modelDisplayName } from "@/lib/format";
 import { bootstrapHash } from "@/routes";
 
@@ -34,6 +43,7 @@ function coveragePct(indexedLines: number | undefined, trackedLines: number | un
 
 const TABS = [
   { key: "overview", label: "Overview" },
+  { key: "dataset", label: "Dataset" },
   { key: "chunks", label: "Chunks & models" },
   { key: "graph", label: "Graph" },
   { key: "languages", label: "Languages" },
@@ -42,10 +52,22 @@ const TABS = [
 ] as const;
 
 type TabKey = (typeof TABS)[number]["key"];
+type ChunkDistributionMode = "all" | "language";
+type LanguageTokenHistograms = Record<string, HistogramBucket[]>;
+
+const REPO_SIZE_BUCKETS = [
+  { id: "size-tiny", label: "<50k LOC", min: 0, max: 50_000 },
+  { id: "size-small", label: "50k-100k", min: 50_000, max: 100_000 },
+  { id: "size-medium", label: "100k-250k", min: 100_000, max: 250_000 },
+  { id: "size-large", label: "250k-500k", min: 250_000, max: 500_000 },
+  { id: "size-xlarge", label: "500k+ LOC", min: 500_000, max: Infinity }
+] as const;
+
+const ESTIMATED_CHARS_PER_TOKEN = 4;
 
 function TabBar({ active, onSelect }: { active: TabKey; onSelect: (tab: TabKey) => void }) {
   return (
-    <nav className="flex gap-1 overflow-x-auto border-b" aria-label="Metric sections">
+    <nav className="scrollbar-hidden flex gap-1 overflow-x-auto border-b" aria-label="Metric sections">
       {TABS.map((tab) => (
         <button
           key={tab.key}
@@ -66,6 +88,108 @@ function TabBar({ active, onSelect }: { active: TabKey; onSelect: (tab: TabKey) 
   );
 }
 
+function uniqueRepoRows(rows: RepoRow[]): RepoRow[] {
+  const byKey = new Map<string, RepoRow>();
+  for (const row of rows) {
+    if (!byKey.has(row.key)) {
+      byKey.set(row.key, row);
+    }
+  }
+  return [...byKey.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function countMemberships(rows: RepoRow[], getValues: (row: RepoRow) => string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    for (const value of getValues(row)) {
+      counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+function slicesFromCounts(counts: Map<string, number>): DistributionSlice[] {
+  return [...counts.entries()]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .map(([label, count], index) => ({
+      id: label.toLowerCase().replace(/[^a-z0-9]+/g, "-") || `slice-${index}`,
+      label,
+      count,
+      fill: chartColor(index)
+    }));
+}
+
+function slicesFromBuckets<T extends { id: string; label: string; min: number; max: number }>(
+  rows: RepoRow[],
+  buckets: readonly T[],
+  getValue: (row: RepoRow) => number | null | undefined
+): DistributionSlice[] {
+  return buckets
+    .map((bucket, index) => ({
+      id: bucket.id,
+      label: bucket.label,
+      count: rows.filter((row) => {
+        const value = getValue(row);
+        return Number.isFinite(value ?? NaN) && (value as number) >= bucket.min && (value as number) < bucket.max;
+      }).length,
+      fill: chartColor(index)
+    }))
+    .filter((entry) => entry.count > 0);
+}
+
+function tokenBucketLabel(min: number, max: number | null): string {
+  const tokenMin = Math.floor(min / ESTIMATED_CHARS_PER_TOKEN);
+  if (max === null) {
+    return `${tokenMin}+`;
+  }
+  const tokenMax = Math.max(tokenMin, Math.ceil(max / ESTIMATED_CHARS_PER_TOKEN));
+  return `${tokenMin}-${tokenMax}`;
+}
+
+function charHistogramToEstimatedTokens(histogram: HistogramBucket[] | null | undefined): HistogramBucket[] {
+  return (histogram ?? []).map((bucket) => ({
+    ...bucket,
+    min: Math.floor(bucket.min / ESTIMATED_CHARS_PER_TOKEN),
+    max: bucket.max === null ? null : Math.ceil(bucket.max / ESTIMATED_CHARS_PER_TOKEN),
+    label: tokenBucketLabel(bucket.min, bucket.max)
+  }));
+}
+
+function mergeHistograms(left: HistogramBucket[] | null | undefined, right: HistogramBucket[] | null | undefined) {
+  if (!left || left.length === 0) {
+    return right ? right.map((bucket) => ({ ...bucket })) : [];
+  }
+  if (!right || right.length === 0) {
+    return left.map((bucket) => ({ ...bucket }));
+  }
+  return left.map((bucket, index) => ({
+    ...bucket,
+    count: bucket.count + (right[index]?.count ?? 0)
+  }));
+}
+
+function mean(values: Array<number | null | undefined>): number | null {
+  const finite = values.filter((value): value is number => Number.isFinite(value ?? NaN));
+  if (finite.length === 0) {
+    return null;
+  }
+  return finite.reduce((sum, value) => sum + value, 0) / finite.length;
+}
+
+function aggregateLanguageCharHistograms(details: RepoDetailDoc[]): LanguageTokenHistograms {
+  const histograms: LanguageTokenHistograms = {};
+  for (const detail of details) {
+    const run = detail.runs.find((item) => item.run.status === "ok" || item.run.status === "embed_failed") ?? detail.runs[0];
+    if (!run?.chunks?.by_language) {
+      continue;
+    }
+    for (const [language, stats] of Object.entries(run.chunks.by_language)) {
+      histograms[language] = mergeHistograms(histograms[language], stats.chars?.histogram);
+    }
+  }
+  return histograms;
+}
+
 export function BootstrapPage({
   summary,
   versions,
@@ -76,24 +200,98 @@ export function BootstrapPage({
   selectedVersion: string;
 }) {
   const { aggregate, run } = summary;
-  const [sizeUnit, setSizeUnit] = useState<"lines" | "chars">("lines");
   const [activeTab, setActiveTab] = useState<TabKey>("overview");
+  const [chunkDistributionMode, setChunkDistributionMode] = useState<ChunkDistributionMode>("all");
   const [sizeAxis, setSizeAxis] = useState<"files" | "lines">("files");
+  const [chunkDetails, setChunkDetails] = useState<RepoDetailDoc[] | null>(null);
+  const [languageTokenHistograms, setLanguageTokenHistograms] = useState<LanguageTokenHistograms | null>(null);
+  const [languageTokenError, setLanguageTokenError] = useState<string | null>(null);
 
   const models = Object.entries(aggregate.by_model);
   const okRows = useMemo(
     () => aggregate.repo_rows.filter((row) => row.status === "ok" || row.status === "embed_failed"),
     [aggregate.repo_rows]
   );
+  const datasetRows = useMemo(() => uniqueRepoRows(okRows), [okRows]);
 
-  const histogramSeries = models.map(([model, rollup], index) => ({
-    name: modelDisplayName(model),
-    histogram: (sizeUnit === "lines" ? rollup.chunk_lines_histogram : rollup.chunk_chars_histogram) ?? [],
-    color: chartColor(index)
-  }));
+  useEffect(() => {
+    setChunkDetails(null);
+    setLanguageTokenHistograms(null);
+    setLanguageTokenError(null);
+  }, [selectedVersion]);
 
-  const languageChunks = Object.entries(aggregate.by_language)
-    .map(([language, rollup]) => ({ name: language, value: rollup.chunks }))
+  useEffect(() => {
+    if (activeTab !== "chunks" || chunkDetails) {
+      return;
+    }
+    let active = true;
+    setLanguageTokenError(null);
+    void Promise.all(datasetRows.map((row) => loadRepoDetail(selectedVersion, row.key)))
+      .then((details) => {
+        if (active) {
+          const loadedDetails = details.filter(Boolean) as RepoDetailDoc[];
+          setChunkDetails(loadedDetails);
+          setLanguageTokenHistograms(aggregateLanguageCharHistograms(loadedDetails));
+        }
+      })
+      .catch((error: unknown) => {
+        if (active) {
+          setLanguageTokenError(error instanceof Error ? error.message : "Failed to load per-language chunk data.");
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [activeTab, chunkDetails, datasetRows, selectedVersion]);
+
+  const allLanguageTokenSeries: HistogramSeries[] = useMemo(() => {
+    const merged = languageTokenHistograms
+      ? Object.values(languageTokenHistograms).reduce<HistogramBucket[]>((acc, histogram) => mergeHistograms(acc, histogram), [])
+      : models[0]?.[1].chunk_chars_histogram ?? [];
+    return [
+      {
+        name: "All languages",
+        histogram: charHistogramToEstimatedTokens(merged),
+        color: chartColor(0)
+      }
+    ];
+  }, [languageTokenHistograms, models]);
+
+  const perLanguageTokenSeries: HistogramSeries[] = useMemo(
+    () =>
+      Object.entries(languageTokenHistograms ?? {})
+        .sort((left, right) => {
+          const leftTotal = left[1].reduce((sum, bucket) => sum + bucket.count, 0);
+          const rightTotal = right[1].reduce((sum, bucket) => sum + bucket.count, 0);
+          return rightTotal - leftTotal || left[0].localeCompare(right[0]);
+        })
+        .map(([language, histogram], index) => ({
+          name: language,
+          histogram: charHistogramToEstimatedTokens(histogram),
+          color: chartColor(index)
+        })),
+    [languageTokenHistograms]
+  );
+
+  const chunkTokenSeries = chunkDistributionMode === "language" ? perLanguageTokenSeries : allLanguageTokenSeries;
+
+  const languageChunkIntensity = Object.entries(
+    datasetRows.reduce<Record<string, { chunks: number; indexedLines: number }>>((acc, row) => {
+      const language = row.languages[0] ?? "unknown";
+      const chunks = Number.isFinite(row.chunks ?? NaN) ? (row.chunks as number) : 0;
+      const indexedLines = Number.isFinite(row.indexed_lines ?? NaN) ? (row.indexed_lines as number) : 0;
+      const current = acc[language] ?? { chunks: 0, indexedLines: 0 };
+      current.chunks += chunks;
+      current.indexedLines += indexedLines;
+      acc[language] = current;
+      return acc;
+    }, {})
+  )
+    .map(([language, rollup]) => ({
+      name: language,
+      value: perKiloLine(rollup.chunks, rollup.indexedLines) ?? 0
+    }))
+    .filter((entry) => entry.value > 0)
     .sort((left, right) => right.value - left.value);
 
   const languageMeanLines = Object.entries(aggregate.by_language)
@@ -126,6 +324,55 @@ export function BootstrapPage({
       group: row.languages[0] ?? "other"
     }));
 
+  const chunkConnectivitySummary = useMemo(() => {
+    const maxDegrees = (chunkDetails ?? []).map((detail) => {
+      const run = detail.runs.find((item) => item.run.status === "ok" || item.run.status === "embed_failed") ?? detail.runs[0];
+      return run?.graph?.chunk_connectivity.max_degree;
+    });
+    return {
+      avgCallsEdges: mean(datasetRows.map((row) => row.chunk_chunk_edges)),
+      avgDegree: mean(datasetRows.map((row) => row.avg_degree)),
+      avgMaxDegree: mean(maxDegrees),
+      avgIsolatedPct: mean(datasetRows.map((row) => row.isolated_pct))
+    };
+  }, [chunkDetails, datasetRows]);
+
+  const isolatedScatter = datasetRows
+    .filter(
+      (row): row is RepoRow & { indexed_lines: number; isolated_pct: number } =>
+        Number.isFinite(row.indexed_lines ?? NaN) && Number.isFinite(row.isolated_pct ?? NaN)
+    )
+    .map((row) => ({
+      x: row.indexed_lines,
+      y: row.isolated_pct,
+      name: row.name,
+      group: row.languages[0] ?? "other"
+    }));
+
+  const datasetBenchSlices = useMemo(
+    () => slicesFromCounts(countMemberships(datasetRows, (row) => row.benches)),
+    [datasetRows]
+  );
+  const datasetLanguageSlices = useMemo(
+    () => slicesFromCounts(countMemberships(datasetRows, (row) => row.languages)),
+    [datasetRows]
+  );
+  const datasetSizeSlices = useMemo(
+    () => slicesFromBuckets(datasetRows, REPO_SIZE_BUCKETS, (row) => row.tracked_lines),
+    [datasetRows]
+  );
+  const largestIndexedRepos = useMemo(
+    () =>
+      datasetRows
+        .filter((row): row is RepoRow & { indexed_lines: number } =>
+          Number.isFinite(row.indexed_lines ?? NaN)
+        )
+        .sort((left, right) => right.indexed_lines - left.indexed_lines)
+        .slice(0, 10)
+        .map((row) => ({ name: row.name, value: row.indexed_lines })),
+    [datasetRows]
+  );
+
   return (
     <main className="mx-auto flex max-w-[96rem] flex-col gap-10 px-4 pb-16 pt-8">
       <section className="space-y-2">
@@ -157,18 +404,23 @@ export function BootstrapPage({
                 label: "Repositories",
                 value: formatCount(aggregate.totals.repos),
                 hint: `${formatCount(aggregate.totals.succeeded)} bootstrapped ok`,
+                explanation: "Number of pinned repositories included in this bootstrap benchmark run.",
                 icon: Database
               },
               {
                 label: "Chunks / 1k LOC",
                 value: formatNumber(perKiloLine(aggregate.totals.chunks, aggregate.totals.indexed_lines)),
                 hint: "per 1,000 indexed lines",
+                explanation:
+                  "Chunks generated by Cortex per 1,000 indexed lines of code. LOC means lines of code; this uses indexed lines, not total repository lines.",
                 icon: Boxes
               },
               {
                 label: "Edges / 1k LOC",
                 value: formatNumber(perKiloLine(aggregate.totals.edges, aggregate.totals.indexed_lines)),
                 hint: "per 1,000 indexed lines",
+                explanation:
+                  "Graph relation edges loaded per 1,000 indexed lines of code. LOC means lines of code; this normalizes graph density by the code Cortex processed.",
                 icon: Network
               },
               {
@@ -177,12 +429,15 @@ export function BootstrapPage({
                   coveragePct(aggregate.totals.indexed_lines, aggregate.totals.tracked_lines)
                 ),
                 hint: "indexed lines / repo lines",
+                explanation:
+                  "Share of tracked repository lines that Cortex indexed. Lower values usually mean generated, vendored, binary, or unsupported files were skipped.",
                 icon: FileCode2
               },
               {
                 label: "Embedding models",
                 value: String(aggregate.totals.models.length),
                 hint: aggregate.totals.models.map(modelDisplayName).join(", "),
+                explanation: "Number of embedding models measured in this run.",
                 icon: Share2
               },
               {
@@ -191,6 +446,8 @@ export function BootstrapPage({
                   perKiloLine(aggregate.totals.duration_ms, aggregate.totals.indexed_lines)
                 ),
                 hint: "bootstrap wall-clock",
+                explanation:
+                  "Total bootstrap wall-clock time per 1,000 indexed lines of code. LOC means lines of code, and the denominator is Cortex indexed lines.",
                 icon: Clock
               }
             ]}
@@ -223,26 +480,155 @@ export function BootstrapPage({
         </>
       ) : null}
 
+      {activeTab === "dataset" ? (
+        <>
+          <StatCards
+            stats={[
+              {
+                label: "Dataset repos",
+                value: formatCount(datasetRows.length),
+                hint: "unique pinned repositories",
+                explanation: "Unique repositories included in this dataset view after de-duplicating embedding model runs.",
+                icon: Database
+              },
+              {
+                label: "Benchmark sources",
+                value: formatCount(datasetBenchSlices.length),
+                hint: "source benchmark tags",
+                explanation:
+                  "Distinct benchmark families that contributed repositories. A repository can carry more than one source tag.",
+                icon: Share2
+              },
+              {
+                label: "Language tags",
+                value: formatCount(datasetLanguageSlices.length),
+                hint: "detected primary tags",
+                explanation:
+                  "Distinct language tags attached to the pinned repositories. Multi-language repositories can contribute more than one tag.",
+                icon: FileCode2
+              },
+              {
+                label: "Tracked LOC",
+                value: formatCount(aggregate.totals.tracked_lines),
+                hint: "repo lines before filtering",
+                explanation:
+                  "Total tracked repository lines at the pinned commits. LOC means lines of code, although this raw count can include non-code tracked text.",
+                icon: Network
+              },
+              {
+                label: "Indexed LOC",
+                value: formatCount(aggregate.totals.indexed_lines),
+                hint: "lines Cortex processed",
+                explanation:
+                  "Total lines accepted by Cortex after source path, file kind, and ignore filtering. LOC means lines of code.",
+                icon: Boxes
+              },
+              {
+                label: "Coverage",
+                value: formatPercent(
+                  coveragePct(aggregate.totals.indexed_lines, aggregate.totals.tracked_lines)
+                ),
+                hint: "indexed / tracked LOC",
+                explanation:
+                  "Share of tracked lines included in Cortex indexing across this dataset.",
+                icon: Clock
+              }
+            ]}
+          />
+          <SectionShell
+            title="Dataset composition"
+            description="How the benchmark corpus is distributed by source dataset, language, repository size and indexed-line coverage."
+          >
+            <div className="grid gap-8 lg:grid-cols-3">
+              <DatasetChartCard title="Benchmark sources" description="Repository memberships by source benchmark">
+                <DistributionDonutChart
+                  data={datasetBenchSlices}
+                  centerLabel="sources"
+                  valueLabel="memberships"
+                />
+              </DatasetChartCard>
+              <DatasetChartCard title="Languages" description="Repository language tags">
+                <DistributionDonutChart
+                  data={datasetLanguageSlices}
+                  variant="label"
+                  centerLabel="tags"
+                  valueLabel="tags"
+                />
+              </DatasetChartCard>
+              <DatasetChartCard title="Repository size" description="Tracked LOC buckets">
+                <DistributionDonutChart
+                  data={datasetSizeSlices}
+                  variant="label"
+                  centerLabel="repos"
+                  valueLabel="repos"
+                />
+              </DatasetChartCard>
+            </div>
+          </SectionShell>
+          <SectionShell
+            title="Largest indexed repositories"
+            description="Top repositories by lines accepted into Cortex indexing. This highlights which projects dominate the processing volume."
+          >
+            <Card>
+              <CardContent className="pt-6">
+                <CategoryBarChart data={largestIndexedRepos} valueLabel="indexed lines" colorByIndex />
+              </CardContent>
+            </Card>
+          </SectionShell>
+        </>
+      ) : null}
+
       {activeTab === "chunks" ? (
       <SectionShell
-        title="Chunk sizes vs embedding models"
-        description="Distribution of chunk sizes produced by the ingest phase, grouped per embedding model run. Buckets are fixed so models and runs are directly comparable."
+        title="Chunk token distribution"
+        description="Number of chunks by estimated token size. Token buckets are estimated from exported character counts at roughly four characters per token."
         headerAside={
           <ToggleGroup
             type="single"
-            value={sizeUnit}
-            onValueChange={(value) => value && setSizeUnit(value as "lines" | "chars")}
+            value={chunkDistributionMode}
+            onValueChange={(value) => value && setChunkDistributionMode(value as ChunkDistributionMode)}
           >
-            <ToggleGroupItem value="lines">Lines</ToggleGroupItem>
-            <ToggleGroupItem value="chars">Characters</ToggleGroupItem>
+            <ToggleGroupItem value="all">All languages</ToggleGroupItem>
+            <ToggleGroupItem value="language">Per language</ToggleGroupItem>
           </ToggleGroup>
         }
       >
         <Card>
-          <CardContent className="pt-6">
-            <HistogramChart series={histogramSeries} unit={sizeUnit} height={300} />
+          <CardContent className="space-y-3 pt-6">
+            {languageTokenError ? (
+              <p className="text-sm text-rose-700">{languageTokenError}</p>
+            ) : chunkDistributionMode === "language" && !languageTokenHistograms ? (
+              <p className="text-sm text-muted-foreground">Loading per-language chunk distributions…</p>
+            ) : null}
+            <DistributionLineChart series={chunkTokenSeries} unit="estimated tokens" valueLabel="chunks" height={360} />
           </CardContent>
         </Card>
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">Average chunk connectivity</CardTitle>
+              <CardDescription>Average CALLS chunk-to-chunk edge metrics across repositories.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+              <ModelStat label="Avg CALLS edges" value={formatNumber(chunkConnectivitySummary.avgCallsEdges, 0)} />
+              <ModelStat label="Avg degree" value={formatNumber(chunkConnectivitySummary.avgDegree)} />
+              <ModelStat label="Avg max degree" value={formatNumber(chunkConnectivitySummary.avgMaxDegree, 0)} />
+              <ModelStat label="Avg isolated" value={formatPercent(chunkConnectivitySummary.avgIsolatedPct)} />
+            </CardContent>
+          </Card>
+          <ChartCard
+            title="Isolated chunks by repository"
+            description="Each point is a repository, colored by primary language."
+          >
+            <RepoScatterChart
+              points={isolatedScatter}
+              xLabel="indexed lines"
+              yLabel="isolated chunks (%)"
+              yValueFormatter={(value) => formatPercent(value)}
+              height={320}
+            />
+          </ChartCard>
+        </div>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {models.map(([model, rollup]) => (
             <Card key={model}>
@@ -289,11 +675,14 @@ export function BootstrapPage({
       {activeTab === "languages" ? (
       <SectionShell
         title="Languages"
-        description="Chunk volume and typical chunk size per language, aggregated over every repository in the run."
+        description="Normalized chunking intensity and typical chunk size per language, aggregated over every repository in the run."
       >
         <div className="grid gap-4 lg:grid-cols-2">
-          <ChartCard title="Chunks by language" description="Total chunks produced per language">
-            <CategoryBarChart data={languageChunks} valueLabel="chunks" colorByIndex />
+          <ChartCard
+            title="Chunks / 1k indexed LOC by language"
+            description="Chunks per 1,000 Cortex-indexed lines, grouped by each repository's primary language."
+          >
+            <CategoryBarChart data={languageChunkIntensity} valueLabel="chunks / 1k LOC" colorByIndex />
           </ChartCard>
           <ChartCard title="Mean chunk size by language" description="Average chunk length in lines">
             <CategoryBarChart data={languageMeanLines} valueLabel="lines (mean)" colorByIndex />
@@ -364,5 +753,25 @@ function ChartCard({
       </CardHeader>
       <CardContent>{children}</CardContent>
     </Card>
+  );
+}
+
+function DatasetChartCard({
+  title,
+  description,
+  children
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col">
+      <div className="pb-2 text-center">
+        <h3 className="text-base font-semibold leading-none tracking-tight">{title}</h3>
+        <p className="mt-1.5 text-sm text-muted-foreground">{description}</p>
+      </div>
+      <div>{children}</div>
+    </div>
   );
 }

--- a/frontend/src/components/pages/overview-page.tsx
+++ b/frontend/src/components/pages/overview-page.tsx
@@ -1,17 +1,6 @@
-import {
-  ArrowRight,
-  Boxes,
-  Braces,
-  FileSearch,
-  GitFork,
-  Network,
-  ScrollText,
-  Shield,
-  Sparkles,
-  Workflow,
-  Zap
-} from "lucide-react";
+import { ArrowRight, Braces, ScrollText, Shield, Sparkles, Workflow, Zap } from "lucide-react";
 
+import { BootstrapPipeline } from "@/components/bootstrap-pipeline";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -51,33 +40,6 @@ const FEATURES = [
     title: "One-command setup",
     description:
       "cortex init --bootstrap scaffolds the project, indexes the repo, generates embeddings and loads the graph."
-  }
-] as const;
-
-const PIPELINE = [
-  {
-    icon: FileSearch,
-    title: "Ingest",
-    description:
-      "Tree-sitter parses source files into entities — files, chunks (functions, classes, methods), rules, ADRs, modules."
-  },
-  {
-    icon: Boxes,
-    title: "Embed",
-    description:
-      "A local sentence-transformer model vectorizes every entity for semantic search. No API keys, fully offline."
-  },
-  {
-    icon: Network,
-    title: "Graph",
-    description:
-      "Entities and relations (CALLS, DEFINES, IMPORTS, CONSTRAINS, IMPLEMENTS, …) load into RyuGraph, a local property graph."
-  },
-  {
-    icon: GitFork,
-    title: "Retrieve & govern",
-    description:
-      "MCP tools combine semantic search with graph traversal, ranked by semantic, graph, trust and recency signals."
   }
 ] as const;
 
@@ -157,30 +119,16 @@ export function OverviewPage() {
       </section>
 
       <section className="space-y-5">
-        <h2 className="text-xl font-semibold tracking-tight">How bootstrap works</h2>
-        <p className="max-w-3xl text-sm text-muted-foreground">
-          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">cortex bootstrap</code> runs the full
-          indexing pipeline. The bootstrap metrics pages on this site measure exactly this phase across 69
-          large open-source repositories.
-        </p>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {PIPELINE.map((stage, index) => (
-            <Card key={stage.title} className="relative">
-              <CardHeader className="pb-2">
-                <div className="mb-1 flex items-center gap-2">
-                  <span className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
-                    {index + 1}
-                  </span>
-                  <stage.icon className="h-5 w-5 text-muted-foreground" />
-                </div>
-                <CardTitle className="text-base">{stage.title}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <CardDescription>{stage.description}</CardDescription>
-              </CardContent>
-            </Card>
-          ))}
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold tracking-tight">How bootstrap works</h2>
+          <p className="max-w-3xl text-sm text-muted-foreground">
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs">cortex bootstrap</code> runs the full
+            indexing pipeline end to end — resolving the toolchain, parsing source across a worker pool,
+            generating local embeddings, loading the code graph and serving it over MCP. The bootstrap
+            metrics pages on this site measure exactly this phase across 69 large open-source repositories.
+          </p>
         </div>
+        <BootstrapPipeline />
       </section>
 
       <section className="grid gap-8 lg:grid-cols-2">

--- a/frontend/src/components/pages/repo-detail-page.tsx
+++ b/frontend/src/components/pages/repo-detail-page.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import type { RepoDetailDoc, StatsItem, TimingsMs } from "@/data/bootstrap-types";
+import type { HistogramBucket, RepoDetailDoc, StatsItem, TimingsMs } from "@/data/bootstrap-types";
 import { bootstrapHash } from "@/routes";
 import {
   formatBytes,
@@ -28,6 +28,43 @@ const PHASES: Array<{ key: keyof TimingsMs; label: string }> = [
   { key: "status", label: "Status" }
 ];
 
+const ESTIMATED_CHARS_PER_TOKEN = 4;
+type ChunkSizeUnit = "lines" | "tokens";
+
+function tokenBucketLabel(min: number, max: number | null): string {
+  const tokenMin = Math.floor(min / ESTIMATED_CHARS_PER_TOKEN);
+  if (max === null) {
+    return `${tokenMin}+`;
+  }
+  const tokenMax = Math.max(tokenMin, Math.ceil(max / ESTIMATED_CHARS_PER_TOKEN));
+  return `${tokenMin}-${tokenMax}`;
+}
+
+function charHistogramToEstimatedTokens(histogram: HistogramBucket[] | null | undefined): HistogramBucket[] {
+  return (histogram ?? []).map((bucket) => ({
+    ...bucket,
+    min: Math.floor(bucket.min / ESTIMATED_CHARS_PER_TOKEN),
+    max: bucket.max === null ? null : Math.ceil(bucket.max / ESTIMATED_CHARS_PER_TOKEN),
+    label: tokenBucketLabel(bucket.min, bucket.max)
+  }));
+}
+
+function chunkSizeSummary(item: StatsItem, sizeUnit: ChunkSizeUnit): string {
+  if (sizeUnit === "tokens") {
+    const chars = item.chunks?.chars;
+    return `p50 ${formatNumber(chars?.p50 ? chars.p50 / ESTIMATED_CHARS_PER_TOKEN : null, 0)} · p90 ${formatNumber(
+      chars?.p90 ? chars.p90 / ESTIMATED_CHARS_PER_TOKEN : null,
+      0
+    )} · max ${formatNumber(chars?.max ? chars.max / ESTIMATED_CHARS_PER_TOKEN : null, 0)} estimated tokens`;
+  }
+
+  const distribution = item.chunks?.lines;
+  return `p50 ${formatNumber(distribution?.p50 ?? null, 0)} · p90 ${formatNumber(
+    distribution?.p90 ?? null,
+    0
+  )} · max ${formatNumber(distribution?.max ?? null, 0)} lines`;
+}
+
 export function RepoDetailPage({ detail, version }: { detail: RepoDetailDoc; version?: string }) {
   const models = detail.runs.map((run) => run.run.embed_model);
   const [selectedModel, setSelectedModel] = useState(models[0] ?? "");
@@ -35,7 +72,7 @@ export function RepoDetailPage({ detail, version }: { detail: RepoDetailDoc; ver
     () => detail.runs.find((run) => run.run.embed_model === selectedModel) ?? detail.runs[0],
     [detail.runs, selectedModel]
   );
-  const [sizeUnit, setSizeUnit] = useState<"lines" | "chars">("lines");
+  const [sizeUnit, setSizeUnit] = useState<ChunkSizeUnit>("lines");
 
   if (!item) {
     return (
@@ -46,7 +83,10 @@ export function RepoDetailPage({ detail, version }: { detail: RepoDetailDoc; ver
   }
 
   const repo = detail.repo;
-  const chunkHistogram = sizeUnit === "lines" ? item.chunks?.lines?.histogram : item.chunks?.chars?.histogram;
+  const chunkHistogram =
+    sizeUnit === "lines"
+      ? item.chunks?.lines?.histogram
+      : charHistogramToEstimatedTokens(item.chunks?.chars?.histogram);
   const kindRows = Object.entries(item.chunks?.by_kind ?? {}).sort((a, b) => b[1] - a[1]);
   const relationData = Object.entries(item.graph?.edges.by_type ?? {})
     .map(([name, value]) => ({ name, value }))
@@ -117,17 +157,35 @@ export function RepoDetailPage({ detail, version }: { detail: RepoDetailDoc; ver
           {
             label: "Tracked files",
             value: formatCount(item.workspace?.tracked_files ?? null),
-            hint: formatBytes(item.workspace?.tracked_bytes ?? null)
+            hint: formatBytes(item.workspace?.tracked_bytes ?? null),
+            explanation: "Git-tracked files present at the pinned repository commit before Cortex filtering."
           },
-          { label: "Files indexed", value: formatCount(item.files?.total ?? null) },
-          { label: "Chunks", value: formatCount(item.chunks?.total ?? null) },
-          { label: "Graph edges", value: formatCount(item.graph?.edges.total ?? null) },
+          {
+            label: "Files indexed",
+            value: formatCount(item.files?.total ?? null),
+            explanation: "Files Cortex accepted for indexing after source path, file kind, and ignore filtering."
+          },
+          {
+            label: "Chunks",
+            value: formatCount(item.chunks?.total ?? null),
+            explanation: "Semantic units Cortex extracted from indexed files, such as symbols, sections, and windows."
+          },
+          {
+            label: "Graph edges",
+            value: formatCount(item.graph?.edges.total ?? null),
+            explanation: "Relations loaded into the local graph, including definitions, calls, imports, and constraints."
+          },
           {
             label: "Vectors",
             value: formatCount(item.embeddings?.counts.embedded ?? null),
-            hint: item.embeddings?.dimensions ? `${item.embeddings.dimensions} dims` : undefined
+            hint: item.embeddings?.dimensions ? `${item.embeddings.dimensions} dims` : undefined,
+            explanation: "Embedded entities written to the vector index for semantic search."
           },
-          { label: "Bootstrap time", value: formatDuration(item.timings_ms?.total ?? null) }
+          {
+            label: "Bootstrap time",
+            value: formatDuration(item.timings_ms?.total ?? null),
+            explanation: "Total wall-clock time for dependency install, ingest, embeddings, graph load, and status checks."
+          }
         ]}
       />
 
@@ -145,31 +203,27 @@ export function RepoDetailPage({ detail, version }: { detail: RepoDetailDoc; ver
       <SectionShell
         title="Chunks"
         description={`Chunk size distribution for the ${modelDisplayName(item.run.embed_model)} run.`}
-        headerAside={
-          <ToggleGroup
-            type="single"
-            value={sizeUnit}
-            onValueChange={(value) => value && setSizeUnit(value as "lines" | "chars")}
-          >
-            <ToggleGroupItem value="lines">Lines</ToggleGroupItem>
-            <ToggleGroupItem value="chars">Characters</ToggleGroupItem>
-          </ToggleGroup>
-        }
       >
         <div className="grid gap-4 lg:grid-cols-2">
           <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-base">Size distribution</CardTitle>
-              <CardDescription>
-                p50 {formatNumber(item.chunks?.lines?.p50 ?? null, 0)} · p90{" "}
-                {formatNumber(item.chunks?.lines?.p90 ?? null, 0)} · max{" "}
-                {formatNumber(item.chunks?.lines?.max ?? null, 0)} lines
-              </CardDescription>
+            <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-3 pb-2">
+              <div className="space-y-1">
+                <CardTitle className="text-base">Size distribution</CardTitle>
+                <CardDescription>{chunkSizeSummary(item, sizeUnit)}</CardDescription>
+              </div>
+              <ToggleGroup
+                type="single"
+                value={sizeUnit}
+                onValueChange={(value) => value && setSizeUnit(value as ChunkSizeUnit)}
+              >
+                <ToggleGroupItem value="lines">Lines</ToggleGroupItem>
+                <ToggleGroupItem value="tokens">Tokens</ToggleGroupItem>
+              </ToggleGroup>
             </CardHeader>
             <CardContent>
               <HistogramChart
                 series={[{ name: modelDisplayName(item.run.embed_model), histogram: chunkHistogram ?? [] }]}
-                unit={sizeUnit}
+                unit={sizeUnit === "tokens" ? "estimated tokens" : sizeUnit}
               />
             </CardContent>
           </Card>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -38,3 +38,12 @@ body,
 body {
   @apply bg-background text-foreground;
 }
+
+.scrollbar-hidden {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.scrollbar-hidden::-webkit-scrollbar {
+  display: none;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -47,3 +47,113 @@ body {
 .scrollbar-hidden::-webkit-scrollbar {
   display: none;
 }
+
+/* ── Bootstrap pipeline visualization ──────────────────────────────────── */
+
+@keyframes cortex-rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes cortex-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.4);
+  }
+  70% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes cortex-fill-x {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes cortex-draw {
+  from {
+    stroke-dashoffset: var(--cortex-dash, 300);
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+@keyframes cortex-travel {
+  0% {
+    transform: translateX(-60%);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(380%);
+    opacity: 0;
+  }
+}
+
+.cortex-anim-rise {
+  animation: cortex-rise 0.5s ease-out both;
+}
+
+.cortex-anim-pop {
+  animation: cortex-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+.cortex-fillbar {
+  transform-origin: left center;
+  animation: cortex-fill-x 0.9s ease-out both;
+}
+
+.cortex-edge {
+  animation: cortex-draw 0.7s ease-out both;
+}
+
+.cortex-track {
+  position: relative;
+  overflow: hidden;
+}
+
+.cortex-track-dot {
+  opacity: 0;
+  animation: cortex-travel 1.8s ease-in-out infinite;
+}
+
+.cortex-progress {
+  transform-origin: left center;
+  animation: cortex-fill-x linear forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cortex-anim-rise,
+  .cortex-anim-pop,
+  .cortex-fillbar,
+  .cortex-edge,
+  .cortex-track-dot,
+  .cortex-progress {
+    animation: none !important;
+  }
+
+  .cortex-edge {
+    stroke-dashoffset: 0 !important;
+  }
+}


### PR DESCRIPTION
## Summary

Two front-end additions to the bootstrap-bench site, rebased fresh on `main` so the diff is exactly these two commits. **Frontend-only** — no core/runtime files touched.

1. **Expanded the bootstrap metrics dashboard** — dataset-composition and chunk-distribution views, new charts, and per-repo averages.
2. **Animated the "How bootstrap works" pipeline** on the overview page — a live, looping five-stage visualization that reflects the current pipeline.

## Changes

### Metrics dashboard — `c3c9c90`
- Tabbed metric sections on the bootstrap page (dataset composition, chunk distributions, connectivity)
- New distribution **line** and **donut** charts in `charts.tsx`; per-language chunk-distribution toggle
- "Largest indexed repositories" and "chunks / 1k indexed LOC by language" breakdowns
- Per-repo averages in the stat cards; repo-table and repo-detail refinements
- Adds the `.scrollbar-hidden` utility used by the section tab nav

### Animated pipeline — `c354a23`
- Replaces the static four-card pipeline with a live, looping five-stage visualization: **Resolve → Ingest → Embed → Graph → Serve**
- Reflects the current pipeline: worker-pool ingest, local ONNX embeddings (`all-MiniLM-L6-v2`, 384-dim), and the RyuGraph bulk load
- Auto-advances (7.2 s/stage), pauses on hover/focus, stages are clickable
- Respects `prefers-reduced-motion`; holds a constant height so advancing never reflows the page
- New self-contained `bootstrap-pipeline.tsx` component + CSS keyframes in `index.css`

## Test plan
- [x] `tsc --noEmit` and `vite build` pass
- [x] Browser-verified the pipeline (Playwright): stages cycle, equal node spacing (~240px), constant height at desktop/tablet/mobile (no layout shift), zero console errors
- [x] Reduced-motion: animations disabled, stages still navigable