### PR TITLE
Improve Angular coverage and bootstrap memory handling

### DIFF
--- a/benchmark/bootstrapbench/aggregate.mjs
+++ b/benchmark/bootstrapbench/aggregate.mjs
@@ -22,6 +22,18 @@ function addTo(target, key, amount) {
   }
 }
 
+function addExtensionCounts(target, source) {
+  for (const [ext, count] of Object.entries(source ?? {})) {
+    addTo(target, ext, count);
+  }
+}
+
+function sortedCounts(counts) {
+  return Object.fromEntries(
+    Object.entries(counts).sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+  );
+}
+
 function buildModelRollups(succeeded) {
   const byModel = {};
   for (const item of succeeded) {
@@ -114,7 +126,111 @@ function buildLanguageRollups(succeeded) {
   );
 }
 
+function buildCoverageRollup(succeeded) {
+  const skippedUnsupported = {};
+  const skippedTooLarge = {};
+  const skippedBinary = {};
+  const textSupportedNoParser = {};
+  const counts = {
+    candidate_files: 0,
+    indexed_files: 0,
+    chunks: 0,
+    text_supported_files: 0,
+    parser_supported_files: 0,
+    text_supported_no_parser_files: 0,
+    unsupported_files: 0,
+    too_large_files: 0,
+    binary_files: 0
+  };
+
+  for (const item of succeeded) {
+    const coverage = item.diagnostics?.coverage;
+    if (!coverage) {
+      continue;
+    }
+    for (const [key, value] of Object.entries(coverage.counts ?? {})) {
+      addTo(counts, key, value);
+    }
+    addExtensionCounts(skippedUnsupported, coverage.skipped?.by_extension?.unsupported);
+    addExtensionCounts(skippedTooLarge, coverage.skipped?.by_extension?.too_large);
+    addExtensionCounts(skippedBinary, coverage.skipped?.by_extension?.binary);
+    addExtensionCounts(textSupportedNoParser, coverage.parser_eligibility?.text_supported_no_parser_by_extension);
+  }
+
+  return {
+    counts,
+    skipped_by_extension: {
+      unsupported: sortedCounts(skippedUnsupported),
+      too_large: sortedCounts(skippedTooLarge),
+      binary: sortedCounts(skippedBinary)
+    },
+    parser_eligibility: {
+      text_supported_no_parser_by_extension: sortedCounts(textSupportedNoParser)
+    }
+  };
+}
+
+function buildMemoryRollup(succeeded) {
+  const byPhase = {};
+  let maxRssKb = null;
+  let maxItem = null;
+  let sampledItems = 0;
+
+  for (const item of succeeded) {
+    const memory = item.memory;
+    if (!memory || !Number.isFinite(memory.max_rss_kb)) {
+      continue;
+    }
+    sampledItems += 1;
+    if (maxRssKb === null || memory.max_rss_kb > maxRssKb) {
+      maxRssKb = memory.max_rss_kb;
+      maxItem = item;
+    }
+    for (const [phase, phaseMemory] of Object.entries(memory.by_phase ?? {})) {
+      if (!Number.isFinite(phaseMemory?.max_rss_kb)) {
+        continue;
+      }
+      const entry = byPhase[phase] ?? { max_rss_kb: null, repos: new Set() };
+      entry.max_rss_kb =
+        entry.max_rss_kb === null ? phaseMemory.max_rss_kb : Math.max(entry.max_rss_kb, phaseMemory.max_rss_kb);
+      entry.repos.add(item.repo?.key ?? "unknown");
+      byPhase[phase] = entry;
+    }
+  }
+
+  if (maxRssKb === null) {
+    return null;
+  }
+  return {
+    sampled_items: sampledItems,
+    max_rss_kb: maxRssKb,
+    max_rss_mb: round(maxRssKb / 1024),
+    max_repo: maxItem?.repo?.key ?? "unknown",
+    max_model: maxItem?.run?.embed_model ?? null,
+    by_phase: Object.fromEntries(
+      Object.entries(byPhase)
+        .sort((left, right) => left[0].localeCompare(right[0]))
+        .map(([phase, entry]) => [
+          phase,
+          {
+            max_rss_kb: entry.max_rss_kb,
+            max_rss_mb: round(entry.max_rss_kb / 1024),
+            repos: entry.repos.size
+          }
+        ])
+    )
+  };
+}
+
+function topExtensionCounts(counts, limit = 10) {
+  return Object.entries(counts ?? {})
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, limit)
+    .map(([extension, count]) => ({ extension, count }));
+}
+
 function buildRepoIndexRow(item) {
+  const coverage = item.diagnostics?.coverage;
   return {
     key: item.repo?.key ?? "unknown",
     name: item.repo?.name ?? "unknown",
@@ -140,7 +256,16 @@ function buildRepoIndexRow(item) {
     dimensions: item.embeddings?.dimensions ?? null,
     total_ms: item.timings_ms?.total ?? null,
     ingest_ms: item.timings_ms?.ingest ?? null,
-    embed_ms: item.timings_ms?.embed ?? null
+    embed_ms: item.timings_ms?.embed ?? null,
+    max_rss_kb: item.memory?.max_rss_kb ?? null,
+    max_rss_mb: item.memory?.max_rss_mb ?? null,
+    max_rss_phase: item.memory?.max_phase ?? null,
+    unsupported_files: coverage?.counts?.unsupported_files ?? null,
+    text_supported_no_parser_files: coverage?.counts?.text_supported_no_parser_files ?? null,
+    top_unsupported_extensions: topExtensionCounts(coverage?.skipped?.by_extension?.unsupported),
+    top_text_supported_no_parser_extensions: topExtensionCounts(
+      coverage?.parser_eligibility?.text_supported_no_parser_by_extension
+    )
   };
 }
 
@@ -172,6 +297,8 @@ export function aggregateResults(items) {
     totals,
     by_model: buildModelRollups(succeeded),
     by_language: buildLanguageRollups(succeeded),
+    coverage_diagnostics: buildCoverageRollup(succeeded),
+    memory: buildMemoryRollup(succeeded),
     relations_by_type: relationsByType,
     repo_rows: items.map(buildRepoIndexRow)
   };

--- a/benchmark/bootstrapbench/config.memory-rss.json
+++ b/benchmark/bootstrapbench/config.memory-rss.json
@@ -1,0 +1,18 @@
+{
+  "run_name": "memory-rss",
+  "repos": [
+    "DanielBlomma/cortex",
+    "angular/angular"
+  ],
+  "embed_models": [
+    "Xenova/all-MiniLM-L6-v2"
+  ],
+  "parallelism": 1,
+  "timeout_minutes": 180,
+  "docker": {
+    "image": "cortex-bootstrapbench:memory-rss",
+    "build": true,
+    "cpus": false
+  },
+  "results_dir": "benchmark/bootstrapbench/results"
+}

--- a/benchmark/bootstrapbench/docker/run-bootstrap.mjs
+++ b/benchmark/bootstrapbench/docker/run-bootstrap.mjs
@@ -14,7 +14,42 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { parseFlag, usageError, writeJson } from "../lib.mjs";
-import { parseBootstrapTimings } from "../stats.mjs";
+import { detectBootstrapPhase, parseBootstrapTimings, summarizeBootstrapMemory } from "../stats.mjs";
+
+function readProcessRssKb(pid) {
+  try {
+    const status = fs.readFileSync(`/proc/${pid}/status`, "utf8");
+    const match = status.match(/^VmRSS:\s+(\d+)\s+kB$/m);
+    return match ? Number(match[1]) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function readChildPids(pid) {
+  try {
+    const raw = fs.readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8").trim();
+    return raw ? raw.split(/\s+/).map((value) => Number(value)).filter(Number.isFinite) : [];
+  } catch {
+    return [];
+  }
+}
+
+function readProcessTreeRssKb(rootPid) {
+  const pending = [rootPid];
+  const seen = new Set();
+  let total = 0;
+  while (pending.length > 0) {
+    const pid = pending.pop();
+    if (!Number.isFinite(pid) || seen.has(pid)) {
+      continue;
+    }
+    seen.add(pid);
+    total += readProcessRssKb(pid);
+    pending.push(...readChildPids(pid));
+  }
+  return total;
+}
 
 function main() {
   const args = process.argv.slice(2);
@@ -28,12 +63,26 @@ function main() {
   fs.mkdirSync(path.dirname(logPath), { recursive: true });
   const logStream = fs.createWriteStream(logPath, { flags: "w" });
   const lines = [];
+  const memorySamples = [];
   let partial = { stdout: "", stderr: "" };
+  let currentPhase = null;
+  let memoryTimer = null;
 
   const recordLine = (text) => {
     const ts = Date.now();
+    const phase = detectBootstrapPhase(text);
+    if (phase) {
+      currentPhase = phase;
+    }
     lines.push({ ts, text });
     logStream.write(`${ts} ${text}\n`);
+  };
+
+  const writeTimings = () => {
+    writeJson(timingsPath, {
+      ...parseBootstrapTimings(lines),
+      memory: summarizeBootstrapMemory(memorySamples)
+    });
   };
 
   const handleChunk = (channel) => (chunk) => {
@@ -51,23 +100,41 @@ function main() {
     stdio: ["ignore", "pipe", "pipe"]
   });
 
+  const sampleIntervalMs = Math.max(250, Number(process.env.BB_RSS_SAMPLE_MS) || 1000);
+  const sampleMemory = () => {
+    const rssKb = readProcessTreeRssKb(child.pid);
+    if (rssKb > 0) {
+      memorySamples.push({ ts: Date.now(), phase: currentPhase, rss_kb: rssKb });
+    }
+  };
+  sampleMemory();
+  memoryTimer = setInterval(sampleMemory, sampleIntervalMs);
+  memoryTimer.unref?.();
+
   child.stdout.on("data", handleChunk("stdout"));
   child.stderr.on("data", handleChunk("stderr"));
 
   child.on("error", (error) => {
+    if (memoryTimer) {
+      clearInterval(memoryTimer);
+    }
     recordLine(`[run-bootstrap] spawn error: ${error.message}`);
-    writeJson(timingsPath, parseBootstrapTimings(lines));
+    writeTimings();
     logStream.end(() => process.exit(1));
   });
 
   child.on("close", (code) => {
+    if (memoryTimer) {
+      clearInterval(memoryTimer);
+    }
+    sampleMemory();
     for (const channel of ["stdout", "stderr"]) {
       if (partial[channel]) {
         recordLine(partial[channel]);
       }
     }
     recordLine(`[run-bootstrap] cortex bootstrap exited with code ${code}`);
-    writeJson(timingsPath, parseBootstrapTimings(lines));
+    writeTimings();
     logStream.end(() => process.exit(code ?? 1));
   });
 }

--- a/benchmark/bootstrapbench/extract-stats.mjs
+++ b/benchmark/bootstrapbench/extract-stats.mjs
@@ -14,6 +14,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   loadJsonIfExists,
   nowIso,
@@ -23,9 +24,24 @@ import {
   usageError,
   writeJson
 } from "./lib.mjs";
-import { computeChunkStats, computeGraphStats } from "./stats.mjs";
+import { computeChunkStats, computeCoverageDiagnostics, computeGraphStats, isTextSupportedPath } from "./stats.mjs";
 
 const SCHEMA_VERSION = 1;
+const MAX_FILE_BYTES = 1024 * 1024;
+const SKIP_DIRECTORIES = new Set([
+  ".git",
+  ".idea",
+  ".vscode",
+  "node_modules",
+  "bin",
+  "obj",
+  "dist",
+  "build",
+  "coverage",
+  ".next",
+  ".cache",
+  ".context"
+]);
 
 function relationTypeFromFilename(fileName) {
   const match = fileName.match(/^relations\.([a-z0-9_]+)\.jsonl$/);
@@ -36,6 +52,7 @@ function mapChunkLine(line) {
   const record = JSON.parse(line);
   return {
     id: record.id,
+    file_id: record.file_id,
     kind: record.kind,
     language: record.language,
     start_line: record.start_line,
@@ -43,6 +60,94 @@ function mapChunkLine(line) {
     exported: record.exported,
     body_chars: typeof record.body === "string" ? record.body.length : null
   };
+}
+
+function toPosixPath(value) {
+  return value.split(path.sep).join("/");
+}
+
+function isBinaryBuffer(buffer) {
+  const scanLength = Math.min(buffer.length, 4000);
+  for (let index = 0; index < scanLength; index += 1) {
+    if (buffer[index] === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isInsideProject(projectRoot, absolutePath) {
+  return absolutePath === projectRoot || absolutePath.startsWith(projectRoot + path.sep);
+}
+
+export function collectWorkspaceCandidates(projectRoot, sourcePaths) {
+  const candidates = [];
+  const visitedAbsolutePaths = new Set();
+  const visitFile = (absolutePath) => {
+    if (!isInsideProject(projectRoot, absolutePath)) {
+      return;
+    }
+    if (visitedAbsolutePaths.has(absolutePath)) {
+      return;
+    }
+    visitedAbsolutePaths.add(absolutePath);
+    const relPath = toPosixPath(path.relative(projectRoot, absolutePath));
+    const stats = fs.statSync(absolutePath);
+    const candidate = {
+      path: relPath,
+      size_bytes: stats.size,
+      too_large: false,
+      binary: false
+    };
+    if (isTextSupportedPath(relPath)) {
+      candidate.too_large = stats.size > MAX_FILE_BYTES;
+      if (!candidate.too_large) {
+        try {
+          const handle = fs.openSync(absolutePath, "r");
+          try {
+            const buffer = Buffer.alloc(Math.min(stats.size, 4000));
+            const bytesRead = fs.readSync(handle, buffer, 0, buffer.length, 0);
+            candidate.binary = isBinaryBuffer(buffer.subarray(0, bytesRead));
+          } finally {
+            fs.closeSync(handle);
+          }
+        } catch {
+          // Keep diagnostics best-effort; unreadable files remain non-binary.
+        }
+      }
+    }
+    candidates.push(candidate);
+  };
+
+  const walk = (directoryPath) => {
+    const entries = fs.readdirSync(directoryPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory() && SKIP_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+      const absolutePath = path.join(directoryPath, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolutePath);
+      } else if (entry.isFile()) {
+        visitFile(absolutePath);
+      }
+    }
+  };
+
+  for (const sourcePath of sourcePaths ?? []) {
+    const absolutePath = path.resolve(projectRoot, sourcePath);
+    if (!isInsideProject(projectRoot, absolutePath) || !fs.existsSync(absolutePath)) {
+      continue;
+    }
+    const stats = fs.statSync(absolutePath);
+    if (stats.isFile()) {
+      visitFile(absolutePath);
+    } else if (stats.isDirectory()) {
+      walk(absolutePath);
+    }
+  }
+
+  return candidates.sort((left, right) => left.path.localeCompare(right.path));
 }
 
 const ENTITY_TYPE_PATTERN = /"entity_type"\s*:\s*"([A-Za-z]+)"/;
@@ -167,7 +272,8 @@ async function main() {
     path.join(cacheDir, "documents.jsonl"),
     (line) => {
       const record = JSON.parse(line);
-      return { kind: String(record.kind ?? "unknown"), path: String(record.path ?? "") };
+      const pathValue = String(record.path ?? "");
+      return { id: String(record.id ?? `file:${pathValue}`), kind: String(record.kind ?? "unknown"), path: pathValue };
     },
     { onError: (failure) => parseErrors.push(failure) }
   );
@@ -183,12 +289,13 @@ async function main() {
   // workspace.tracked_lines, the cortex-coverage ratio.
   let indexedLines = 0;
   const projectRoot = path.resolve(projectDir);
+  const workspaceCandidates = collectWorkspaceCandidates(projectRoot, detectedSourcePaths);
   for (const doc of documents) {
     if (!doc.path) {
       continue;
     }
     const absolute = path.resolve(projectRoot, doc.path);
-    if (!absolute.startsWith(projectRoot + path.sep)) {
+    if (!isInsideProject(projectRoot, absolute)) {
       continue; // defensive: never follow paths escaping the workspace
     }
     try {
@@ -232,6 +339,12 @@ async function main() {
   });
 
   const embeddings = computeEmbeddingSection(embeddingsManifest, byEntityType, timings.embed ?? null);
+  const coverageDiagnostics = computeCoverageDiagnostics({
+    candidateFiles: workspaceCandidates,
+    indexedDocuments: documents,
+    chunkRecords,
+    ingestSkipped: ingestManifest?.skipped ?? null
+  });
 
   const stats = {
     schema_version: SCHEMA_VERSION,
@@ -254,6 +367,7 @@ async function main() {
       status: timings.status ?? null,
       total: timings.total ?? null
     },
+    memory: timings.memory ?? null,
     ingest: ingestManifest
       ? {
           mode: ingestManifest.mode ?? null,
@@ -266,6 +380,9 @@ async function main() {
     chunks: chunkStats,
     embeddings,
     graph: graphStats,
+    diagnostics: {
+      coverage: coverageDiagnostics
+    },
     parse_errors: parseErrors.length
   };
 
@@ -275,7 +392,9 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  console.error(`[extract-stats] ${error instanceof Error ? error.message : String(error)}`);
-  process.exit(error?.isUsageError ? 2 : 1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`[extract-stats] ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(error?.isUsageError ? 2 : 1);
+  });
+}

--- a/benchmark/bootstrapbench/stats.mjs
+++ b/benchmark/bootstrapbench/stats.mjs
@@ -12,12 +12,139 @@ export const CHUNK_LINE_BUCKETS = [1, 11, 21, 41, 81, 161, 321];
 export const CHUNK_CHAR_BUCKETS = [0, 201, 501, 1001, 2001, 4001, 8001, 12001];
 export const DEGREE_BUCKETS = [0, 1, 2, 3, 5, 9, 17, 33];
 
+export const TEXT_SUPPORTED_EXTENSIONS = new Set([
+  ".md",
+  ".mdx",
+  ".txt",
+  ".adoc",
+  ".rst",
+  ".yaml",
+  ".yml",
+  ".json",
+  ".toml",
+  ".csv",
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".py",
+  ".go",
+  ".java",
+  ".cs",
+  ".vb",
+  ".sln",
+  ".vbproj",
+  ".csproj",
+  ".fsproj",
+  ".props",
+  ".targets",
+  ".config",
+  ".resx",
+  ".settings",
+  ".rb",
+  ".rs",
+  ".php",
+  ".swift",
+  ".kt",
+  ".sql",
+  ".sh",
+  ".bash",
+  ".zsh",
+  ".ps1",
+  ".c",
+  ".h",
+  ".cpp",
+  ".hpp",
+  ".cc",
+  ".hh",
+  ".bas",
+  ".cls",
+  ".frm",
+  ".ctl"
+]);
+
+export const PARSER_SUPPORTED_EXTENSIONS = new Set([
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".vb",
+  ".cs",
+  ".sql",
+  ".md",
+  ".mdx",
+  ".config",
+  ".resx",
+  ".settings",
+  ".c",
+  ".h",
+  ".cpp",
+  ".cc",
+  ".hpp",
+  ".hh",
+  ".rs",
+  ".py",
+  ".go",
+  ".java",
+  ".rb",
+  ".sh",
+  ".bash",
+  ".zsh",
+  ".bas",
+  ".cls",
+  ".frm",
+  ".ctl"
+]);
+
 const PERCENTILES = [25, 50, 75, 90, 99];
 const TOP_CONNECTED_LIMIT = 10;
 
 function round(value, decimals = 2) {
   const factor = 10 ** decimals;
   return Math.round(value * factor) / factor;
+}
+
+export function extensionKey(filePath) {
+  const fileName = String(filePath ?? "").split(/[\\/]/).pop() ?? "";
+  const dotIndex = fileName.lastIndexOf(".");
+  if (dotIndex <= 0 || dotIndex === fileName.length - 1) {
+    return "[none]";
+  }
+  return fileName.slice(dotIndex).toLowerCase();
+}
+
+function isReadmePath(filePath) {
+  const base = String(filePath ?? "").split(/[\\/]/).pop()?.toLowerCase() ?? "";
+  return base === "readme" || base.startsWith("readme.");
+}
+
+export function isTextSupportedPath(filePath) {
+  return TEXT_SUPPORTED_EXTENSIONS.has(extensionKey(filePath)) || isReadmePath(filePath);
+}
+
+export function isParserSupportedPath(filePath) {
+  return PARSER_SUPPORTED_EXTENSIONS.has(extensionKey(filePath));
+}
+
+function incrementExtensionCount(target, ext, amount = 1) {
+  if (!Number.isFinite(amount) || amount === 0) {
+    return;
+  }
+  target[ext] = (target[ext] ?? 0) + amount;
+}
+
+function sortedCountObject(counts) {
+  return Object.fromEntries(
+    Object.entries(counts).sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+  );
 }
 
 /**
@@ -247,6 +374,131 @@ export function computeGraphStats({ nodeCounts, relationCounts, callEdges, chunk
   };
 }
 
+/**
+ * File coverage diagnostics for benchmark output. Inputs are plain records so
+ * extract-stats can build them from a workspace scan without touching ingest.
+ */
+export function computeCoverageDiagnostics({ candidateFiles, indexedDocuments, chunkRecords, ingestSkipped }) {
+  const candidateList = Array.isArray(candidateFiles) ? candidateFiles : [];
+  const indexedList = Array.isArray(indexedDocuments) ? indexedDocuments : [];
+  const chunkList = Array.isArray(chunkRecords) ? chunkRecords : [];
+
+  const byExtension = new Map();
+  const skippedByExtension = {
+    unsupported: {},
+    too_large: {},
+    binary: {}
+  };
+  const textSupportedNoParserByExtension = {};
+
+  const entryFor = (ext) => {
+    const existing = byExtension.get(ext);
+    if (existing) {
+      return existing;
+    }
+    const entry = {
+      candidate_files: 0,
+      indexed_files: 0,
+      chunks: 0,
+      unsupported_files: 0,
+      too_large_files: 0,
+      binary_files: 0,
+      text_supported: ext === "[none]" ? null : TEXT_SUPPORTED_EXTENSIONS.has(ext),
+      parser_supported: ext === "[none]" ? null : PARSER_SUPPORTED_EXTENSIONS.has(ext),
+      text_supported_no_parser: false
+    };
+    byExtension.set(ext, entry);
+    return entry;
+  };
+
+  for (const file of candidateList) {
+    const ext = extensionKey(file.path);
+    const entry = entryFor(ext);
+    entry.candidate_files += 1;
+    const textSupported = isTextSupportedPath(file.path);
+    const parserSupported = isParserSupportedPath(file.path);
+    entry.text_supported = entry.text_supported === true || textSupported;
+    entry.parser_supported = entry.parser_supported === true || parserSupported;
+
+    if (!textSupported) {
+      entry.unsupported_files += 1;
+      incrementExtensionCount(skippedByExtension.unsupported, ext);
+      continue;
+    }
+    if (file.too_large === true) {
+      entry.too_large_files += 1;
+      incrementExtensionCount(skippedByExtension.too_large, ext);
+      continue;
+    }
+    if (file.binary === true) {
+      entry.binary_files += 1;
+      incrementExtensionCount(skippedByExtension.binary, ext);
+    }
+  }
+
+  for (const doc of indexedList) {
+    entryFor(extensionKey(doc.path)).indexed_files += 1;
+  }
+
+  const indexedPathById = new Map(indexedList.map((doc) => [doc.id ?? `file:${doc.path}`, doc.path]));
+  for (const chunk of chunkList) {
+    const filePath = indexedPathById.get(chunk.file_id);
+    if (filePath) {
+      entryFor(extensionKey(filePath)).chunks += 1;
+    }
+  }
+
+  let textSupportedFiles = 0;
+  let parserSupportedFiles = 0;
+  let textSupportedNoParserFiles = 0;
+  for (const [ext, entry] of byExtension) {
+    if (entry.text_supported === true) {
+      textSupportedFiles += entry.candidate_files;
+    }
+    if (entry.parser_supported === true) {
+      parserSupportedFiles += entry.candidate_files;
+    }
+    entry.text_supported_no_parser = entry.text_supported === true && entry.parser_supported !== true;
+    if (entry.text_supported_no_parser) {
+      textSupportedNoParserFiles += entry.candidate_files;
+      incrementExtensionCount(textSupportedNoParserByExtension, ext, entry.candidate_files);
+    }
+  }
+
+  const byExtensionObject = Object.fromEntries(
+    [...byExtension.entries()]
+      .sort((left, right) => right[1].candidate_files - left[1].candidate_files || left[0].localeCompare(right[0]))
+      .map(([ext, entry]) => [ext, entry])
+  );
+
+  return {
+    source: "workspace_scan",
+    counts: {
+      candidate_files: candidateList.length,
+      indexed_files: indexedList.length,
+      chunks: chunkList.length,
+      text_supported_files: textSupportedFiles,
+      parser_supported_files: parserSupportedFiles,
+      text_supported_no_parser_files: textSupportedNoParserFiles,
+      unsupported_files: Object.values(skippedByExtension.unsupported).reduce((acc, value) => acc + value, 0),
+      too_large_files: Object.values(skippedByExtension.too_large).reduce((acc, value) => acc + value, 0),
+      binary_files: Object.values(skippedByExtension.binary).reduce((acc, value) => acc + value, 0)
+    },
+    skipped: {
+      ingest_totals: ingestSkipped ?? null,
+      by_extension: {
+        unsupported: sortedCountObject(skippedByExtension.unsupported),
+        too_large: sortedCountObject(skippedByExtension.too_large),
+        binary: sortedCountObject(skippedByExtension.binary)
+      }
+    },
+    parser_eligibility: {
+      text_supported_no_parser_by_extension: sortedCountObject(textSupportedNoParserByExtension),
+      by_extension: byExtensionObject
+    }
+  };
+}
+
 // Bootstrap step markers printed by scaffold/scripts/bootstrap.sh, mapped to
 // stable phase keys. The numbered prefix looks like "[cortex][2/6] <title>".
 const PHASE_MARKERS = [
@@ -256,8 +508,21 @@ const PHASE_MARKERS = [
   { key: "graph_load", pattern: /\[cortex\]\[\d+\/\d+\] Loading RyuGraph/ },
   { key: "status", pattern: /\[cortex\]\[\d+\/\d+\] Reading context status/ }
 ];
+export const BOOTSTRAP_PHASE_KEYS = PHASE_MARKERS.map((marker) => marker.key);
 const BOOTSTRAP_START = /\[cortex\] bootstrap start/;
 const BOOTSTRAP_COMPLETE = /\[cortex\] bootstrap complete/;
+
+export function detectBootstrapPhase(text) {
+  if (typeof text !== "string") {
+    return null;
+  }
+  for (const marker of PHASE_MARKERS) {
+    if (marker.pattern.test(text)) {
+      return marker.key;
+    }
+  }
+  return null;
+}
 
 /**
  * Derives per-phase durations (ms) from a timestamped bootstrap log.
@@ -314,4 +579,64 @@ export function parseBootstrapTimings(lines) {
   timings.total =
     Number.isFinite(totalStart) && Number.isFinite(endTs) && endTs >= totalStart ? endTs - totalStart : null;
   return timings;
+}
+
+export function summarizeBootstrapMemory(samples) {
+  const sampleList = Array.isArray(samples) ? samples : [];
+  const byPhase = {};
+  let maxRssKb = null;
+  let maxSample = null;
+  let firstTs = null;
+  let lastTs = null;
+
+  for (const sample of sampleList) {
+    const rssKb = Number(sample?.rss_kb);
+    if (!Number.isFinite(rssKb) || rssKb < 0) {
+      continue;
+    }
+    const ts = Number(sample?.ts);
+    if (Number.isFinite(ts)) {
+      firstTs = firstTs === null ? ts : Math.min(firstTs, ts);
+      lastTs = lastTs === null ? ts : Math.max(lastTs, ts);
+    }
+    const phase = BOOTSTRAP_PHASE_KEYS.includes(sample?.phase) ? sample.phase : "unknown";
+    const phaseEntry = byPhase[phase] ?? { max_rss_kb: null, samples: 0 };
+    phaseEntry.samples += 1;
+    phaseEntry.max_rss_kb = phaseEntry.max_rss_kb === null ? rssKb : Math.max(phaseEntry.max_rss_kb, rssKb);
+    byPhase[phase] = phaseEntry;
+
+    if (maxRssKb === null || rssKb > maxRssKb) {
+      maxRssKb = rssKb;
+      maxSample = {
+        ts: Number.isFinite(ts) ? ts : null,
+        phase
+      };
+    }
+  }
+
+  if (maxRssKb === null) {
+    return null;
+  }
+  return {
+    max_rss_kb: maxRssKb,
+    max_rss_mb: round(maxRssKb / 1024),
+    max_phase: maxSample?.phase ?? null,
+    sample_count: Object.values(byPhase).reduce((acc, entry) => acc + entry.samples, 0),
+    duration_ms: firstTs !== null && lastTs !== null && lastTs >= firstTs ? lastTs - firstTs : null,
+    by_phase: Object.fromEntries(
+      Object.entries(byPhase)
+        .sort((left, right) => {
+          const leftIndex = BOOTSTRAP_PHASE_KEYS.indexOf(left[0]);
+          const rightIndex = BOOTSTRAP_PHASE_KEYS.indexOf(right[0]);
+          return (leftIndex === -1 ? 999 : leftIndex) - (rightIndex === -1 ? 999 : rightIndex);
+        })
+        .map(([phase, entry]) => [
+          phase,
+          {
+            ...entry,
+            max_rss_mb: round(entry.max_rss_kb / 1024)
+          }
+        ])
+    )
+  };
 }

--- a/bin/cortex.mjs
+++ b/bin/cortex.mjs
@@ -229,6 +229,8 @@ const INIT_SOURCE_EXTENSIONS = new Set([
   ".csv",
   ".ts",
   ".tsx",
+  ".mts",
+  ".cts",
   ".js",
   ".jsx",
   ".mjs",

--- a/scaffold/mcp/src/embed.ts
+++ b/scaffold/mcp/src/embed.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { env, pipeline } from "@huggingface/transformers";
-import { readJsonl, asString, asNumber, asBoolean } from "./jsonl.js";
+import { readJsonl, readJsonlRecords, writeJsonlRecords, asString, asNumber, asBoolean } from "./jsonl.js";
 import { CACHE_DIR, PATHS } from "./paths.js";
 import {
   createTokenCounter,
@@ -150,11 +150,6 @@ function hashText(value: string): string {
 
 function normalizeText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
-}
-
-function writeJsonl(filePath: string, records: EmbeddingRecord[]): void {
-  const body = records.map((record) => JSON.stringify(record)).join("\n");
-  fs.writeFileSync(filePath, body ? `${body}\n` : "", "utf8");
 }
 
 function ensureRequiredFiles(): void {
@@ -365,7 +360,7 @@ function parseProjectEntities(raw: JsonObject[]): ProjectEntity[] {
     .filter((value): value is ProjectEntity => value !== null);
 }
 
-function parseExistingEmbeddings(raw: JsonObject[], modelId: string): Map<string, EmbeddingRecord> {
+function parseExistingEmbeddings(raw: Iterable<JsonObject>, modelId: string): Map<string, EmbeddingRecord> {
   const index = new Map<string, EmbeddingRecord>();
 
   for (const item of raw) {
@@ -375,9 +370,12 @@ function parseExistingEmbeddings(raw: JsonObject[], modelId: string): Map<string
     const vectorRaw = item.vector;
     if (!Array.isArray(vectorRaw)) continue;
 
-    const vector = vectorRaw
-      .map((value) => (typeof value === "number" && Number.isFinite(value) ? value : null))
-      .filter((value): value is number => value !== null);
+    const vector: number[] = [];
+    for (const value of vectorRaw) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        vector.push(value);
+      }
+    }
 
     if (vector.length === 0) continue;
     const model = asString(item.model);
@@ -407,6 +405,16 @@ function roundVector(values: number[]): number[] {
   return values.map((value) => Number(value.toFixed(6)));
 }
 
+function* presentEmbeddingRecords(
+  slots: Array<EmbeddingRecord | null>
+): Generator<EmbeddingRecord> {
+  for (const record of slots) {
+    if (record) {
+      yield record;
+    }
+  }
+}
+
 async function main(): Promise<void> {
   const { mode } = parseArgs(process.argv);
   ensureRequiredFiles();
@@ -431,7 +439,7 @@ async function main(): Promise<void> {
 
   const entities: SearchEntity[] = [...documents, ...rules, ...adrs, ...modules, ...projects, ...chunks].sort((a, b) => a.id.localeCompare(b.id));
 
-  const existing = parseExistingEmbeddings(readJsonl(EMBEDDINGS_PATH), modelId);
+  const existing = parseExistingEmbeddings(readJsonlRecords(EMBEDDINGS_PATH), modelId);
 
   env.cacheDir = MODEL_CACHE_DIR;
   // Total thread budget for embedding. CORTEX_EMBED_THREADS caps it so
@@ -513,6 +521,7 @@ async function main(): Promise<void> {
 
   // Fully warm cache: nothing to embed, so skip model loading entirely —
   // this is the common repeat-bootstrap / small-update path.
+  let embedded = 0;
   let result: { vectors: Map<number, number[]>; failures: Array<{ index: number; message: string }> } = {
     vectors: new Map(),
     failures: []
@@ -572,30 +581,30 @@ async function main(): Promise<void> {
       Number.isFinite(inFlightRaw) && inFlightRaw >= 1024
         ? Math.floor(inFlightRaw)
         : resolveInFlightTokens({ memoryBytes: readHeadroom(), modelMaxTokens });
-    result = await runWorkUnits(units, extractors, { maxInFlightTokens });
-  }
-
-  let embedded = 0;
-  for (const [index, rawVector] of result.vectors) {
-    const entity = entities[index];
-    const vector = roundVector(rawVector);
-    embedded += 1;
-    dimensions = dimensions || vector.length;
-    slots[index] = {
-      id: entity.id,
-      entity_type: entity.type,
-      kind: entity.kind,
-      label: entity.label,
-      path: entity.path,
-      status: entity.status,
-      source_of_truth: entity.source_of_truth,
-      trust_level: entity.trust_level,
-      updated_at: entity.updated_at,
-      signature: entity.signature,
-      model: modelId,
-      dimensions: vector.length,
-      vector
-    };
+    result = await runWorkUnits(units, extractors, {
+      maxInFlightTokens,
+      onVector(index, rawVector) {
+        const entity = entities[index];
+        const vector = roundVector(rawVector);
+        embedded += 1;
+        dimensions = dimensions || vector.length;
+        slots[index] = {
+          id: entity.id,
+          entity_type: entity.type,
+          kind: entity.kind,
+          label: entity.label,
+          path: entity.path,
+          status: entity.status,
+          source_of_truth: entity.source_of_truth,
+          trust_level: entity.trust_level,
+          updated_at: entity.updated_at,
+          signature: entity.signature,
+          model: modelId,
+          dimensions: vector.length,
+          vector
+        };
+      }
+    });
   }
 
   const failures = result.failures.map(
@@ -603,8 +612,7 @@ async function main(): Promise<void> {
   );
   const failed = result.failures.length;
 
-  const output = slots.filter((record): record is EmbeddingRecord => record !== null);
-  writeJsonl(EMBEDDINGS_PATH, output);
+  const outputCount = writeJsonlRecords(EMBEDDINGS_PATH, presentEmbeddingRecords(slots));
 
   const manifest = {
     generated_at: new Date().toISOString(),
@@ -613,7 +621,7 @@ async function main(): Promise<void> {
     dimensions,
     counts: {
       entities: entities.length,
-      output: output.length,
+      output: outputCount,
       embedded,
       reused,
       failed

--- a/scaffold/mcp/src/embedScheduler.ts
+++ b/scaffold/mcp/src/embedScheduler.ts
@@ -345,6 +345,7 @@ export type RunOptions = {
    * lane busy. Default keeps roughly one 8k giant plus a stream of shorts.
    */
   maxInFlightTokens?: number;
+  onVector?: (index: number, vector: number[]) => void;
 };
 
 export const DEFAULT_MAX_IN_FLIGHT_TOKENS = 12288;
@@ -375,7 +376,11 @@ export async function runWorkUnits(
 
   const assign = (members: number[], vector: number[]) => {
     for (const index of members) {
-      vectors.set(index, vector);
+      if (options.onVector) {
+        options.onVector(index, vector);
+      } else {
+        vectors.set(index, vector);
+      }
     }
   };
   const recordFailure = (members: number[], error: unknown) => {

--- a/scaffold/mcp/src/embeddings.ts
+++ b/scaffold/mcp/src/embeddings.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { env, pipeline } from "@huggingface/transformers";
+import { readJsonlRecords } from "./jsonl.js";
 import { LruCache } from "./lruCache.js";
 import { PATHS } from "./paths.js";
 import type { EmbeddingIndex, JsonObject } from "./types.js";
@@ -15,26 +16,6 @@ let embeddingRuntimeWarning: string | null = null;
 
 function asString(value: unknown, fallback = ""): string {
   return typeof value === "string" ? value : fallback;
-}
-
-function readJsonl(filePath: string): JsonObject[] {
-  if (!fs.existsSync(filePath)) {
-    return [];
-  }
-
-  const raw = fs.readFileSync(filePath, "utf8");
-  return raw
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      try {
-        return JSON.parse(line) as JsonObject;
-      } catch {
-        return null;
-      }
-    })
-    .filter((value): value is JsonObject => value !== null);
 }
 
 function toVector(output: unknown): Float32Array | null {
@@ -65,7 +46,7 @@ function readFileVersion(filePath: string): string {
   }
 }
 
-function parseEmbeddingIndex(raw: JsonObject[]): EmbeddingIndex {
+function parseEmbeddingIndex(raw: Iterable<JsonObject>): EmbeddingIndex {
   const vectors = new Map<string, Float32Array>();
   let model: string | null = null;
 
@@ -76,9 +57,12 @@ function parseEmbeddingIndex(raw: JsonObject[]): EmbeddingIndex {
     const vectorRaw = item.vector;
     if (!Array.isArray(vectorRaw)) continue;
 
-    const vector = vectorRaw
-      .map((value) => (typeof value === "number" && Number.isFinite(value) ? value : null))
-      .filter((value): value is number => value !== null);
+    const vector: number[] = [];
+    for (const value of vectorRaw) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        vector.push(value);
+      }
+    }
 
     if (vector.length === 0) continue;
     // The boxed number[] is transient — only the Float32Array is retained,
@@ -110,7 +94,7 @@ export function loadEmbeddingIndex(): EmbeddingIndex {
     return embeddingsCache;
   }
 
-  const parsed = parseEmbeddingIndex(readJsonl(PATHS.embeddingsEntities));
+  const parsed = parseEmbeddingIndex(readJsonlRecords(PATHS.embeddingsEntities));
   embeddingsCacheKey = key;
   embeddingsCache =
     parsed.vectors.size === 0

--- a/scaffold/mcp/src/graphCsv.ts
+++ b/scaffold/mcp/src/graphCsv.ts
@@ -37,12 +37,21 @@ export function toCsvRow(values: CsvValue[]): string {
   return values.map(toCsvCell).join(",");
 }
 
-export function writeCsv(filePath: string, header: string[], rows: CsvValue[][]): void {
-  const lines = [toCsvRow(header)];
-  for (const row of rows) {
-    lines.push(toCsvRow(row));
+export function writeCsv(filePath: string, header: string[], rows: Iterable<CsvValue[]>): number {
+  const fd = fs.openSync(filePath, "w");
+  let rowCount = 0;
+
+  try {
+    fs.writeSync(fd, `${toCsvRow(header)}\n`, undefined, "utf8");
+    for (const row of rows) {
+      fs.writeSync(fd, `${toCsvRow(row)}\n`, undefined, "utf8");
+      rowCount += 1;
+    }
+  } finally {
+    fs.closeSync(fd);
   }
-  fs.writeFileSync(filePath, `${lines.join("\n")}\n`, "utf8");
+
+  return rowCount;
 }
 
 // Escape a filesystem path for use inside a double-quoted ryugraph COPY path

--- a/scaffold/mcp/src/jsonl.ts
+++ b/scaffold/mcp/src/jsonl.ts
@@ -1,24 +1,79 @@
 import fs from "node:fs";
+import { StringDecoder } from "node:string_decoder";
 import type { JsonObject, JsonValue } from "./types.js";
 
-export function readJsonl(filePath: string): JsonObject[] {
-  if (!fs.existsSync(filePath)) {
-    return [];
+function parseJsonlLine(line: string): JsonObject | null {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
   }
 
-  return fs
-    .readFileSync(filePath, "utf8")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      try {
-        return JSON.parse(line) as JsonObject;
-      } catch {
-        return null;
+  try {
+    return JSON.parse(trimmed) as JsonObject;
+  } catch {
+    return null;
+  }
+}
+
+export function* readJsonlRecords(filePath: string): Generator<JsonObject> {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  const fd = fs.openSync(filePath, "r");
+  const decoder = new StringDecoder("utf8");
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  let carry = "";
+
+  try {
+    while (true) {
+      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) {
+        break;
       }
-    })
-    .filter((value): value is JsonObject => value !== null);
+
+      carry += decoder.write(buffer.subarray(0, bytesRead));
+      let lineStart = 0;
+      let newlineIndex = carry.indexOf("\n", lineStart);
+      while (newlineIndex !== -1) {
+        const parsed = parseJsonlLine(carry.slice(lineStart, newlineIndex));
+        if (parsed) {
+          yield parsed;
+        }
+        lineStart = newlineIndex + 1;
+        newlineIndex = carry.indexOf("\n", lineStart);
+      }
+      carry = carry.slice(lineStart);
+    }
+
+    carry += decoder.end();
+    const parsed = parseJsonlLine(carry);
+    if (parsed) {
+      yield parsed;
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+export function readJsonl(filePath: string): JsonObject[] {
+  return Array.from(readJsonlRecords(filePath));
+}
+
+export function writeJsonlRecords(filePath: string, records: Iterable<unknown>): number {
+  const fd = fs.openSync(filePath, "w");
+  let count = 0;
+
+  try {
+    for (const record of records) {
+      fs.writeSync(fd, `${JSON.stringify(record)}\n`, undefined, "utf8");
+      count += 1;
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  return count;
 }
 
 export function asString(value: JsonValue | undefined, fallback = ""): string {

--- a/scaffold/mcp/src/loadGraph.ts
+++ b/scaffold/mcp/src/loadGraph.ts
@@ -493,24 +493,43 @@ function parseGraphData(): GraphData {
 // COPY into a rel table instead errors on an unknown primary key, so edges
 // must be pre-filtered against the node-id sets to stay byte-identical.
 function filterEdges<T extends { from: string; to: string }>(
-  edges: T[],
+  edges: Iterable<T>,
   fromSet: Set<string>,
   toSet: Set<string>
-): T[] {
-  return edges.filter((edge) => fromSet.has(edge.from) && toSet.has(edge.to));
+): Iterable<T> {
+  return (function* filteredEdges() {
+    for (const edge of edges) {
+      if (fromSet.has(edge.from) && toSet.has(edge.to)) {
+        yield edge;
+      }
+    }
+  })();
+}
+
+function* ids<T extends { id: string }>(items: Iterable<T>): Iterable<string> {
+  for (const item of items) {
+    yield item.id;
+  }
+}
+
+function* csvRows<T>(items: Iterable<T>, toRow: (item: T) => CsvValue[]): Iterable<CsvValue[]> {
+  for (const item of items) {
+    yield toRow(item);
+  }
 }
 
 async function copyTable(
   conn: Connection,
   table: string,
   header: string[],
-  rows: CsvValue[][]
+  rows: Iterable<CsvValue[]>
 ): Promise<void> {
-  if (rows.length === 0) {
+  const csvPath = path.join(GRAPH_IMPORT_DIR, `${table}.csv`);
+  const rowCount = writeCsv(csvPath, header, rows);
+  if (rowCount === 0) {
+    fs.rmSync(csvPath, { force: true });
     return;
   }
-  const csvPath = path.join(GRAPH_IMPORT_DIR, `${table}.csv`);
-  writeCsv(csvPath, header, rows);
   // ryugraph parses COPY's path as a double-quoted literal; toCopyPathLiteral
   // normalizes separators and escapes any embedded quote so a repo/cache path
   // containing a double quote still bulk-loads instead of falling back.
@@ -526,19 +545,20 @@ async function bulkLoad(conn: Connection, data: GraphData): Promise<void> {
   fs.rmSync(GRAPH_IMPORT_DIR, { recursive: true, force: true });
   fs.mkdirSync(GRAPH_IMPORT_DIR, { recursive: true });
 
-  const fileIds = new Set(data.fileEntities.map((e) => e.id));
-  const ruleIds = new Set(data.ruleEntities.map((e) => e.id));
-  const adrIds = new Set(data.adrEntities.map((e) => e.id));
-  const chunkIds = new Set(data.chunkEntities.map((e) => e.id));
-  const moduleIds = new Set(data.moduleEntities.map((e) => e.id));
-  const projectIds = new Set(data.projectEntities.map((e) => e.id));
+  try {
+    const fileIds = new Set(ids(data.fileEntities));
+    const ruleIds = new Set(ids(data.ruleEntities));
+    const adrIds = new Set(ids(data.adrEntities));
+    const chunkIds = new Set(ids(data.chunkEntities));
+    const moduleIds = new Set(ids(data.moduleEntities));
+    const projectIds = new Set(ids(data.projectEntities));
 
   // Nodes first — edges reference them by primary key.
   await copyTable(
     conn,
     "File",
     ["id", "path", "kind", "excerpt", "checksum", "updated_at", "source_of_truth", "trust_level", "status"],
-    data.fileEntities.map((e) => [
+    csvRows(data.fileEntities, (e) => [
       e.id, e.path, e.kind, e.excerpt, e.checksum, e.updated_at, e.source_of_truth, e.trust_level, e.status
     ])
   );
@@ -546,7 +566,7 @@ async function bulkLoad(conn: Connection, data: GraphData): Promise<void> {
     conn,
     "Rule",
     ["id", "title", "body", "scope", "priority", "updated_at", "source_of_truth", "trust_level", "status"],
-    data.ruleEntities.map((e) => [
+    csvRows(data.ruleEntities, (e) => [
       e.id, e.title, e.body, e.scope, e.priority, e.updated_at, e.source_of_truth, e.trust_level, e.status
     ])
   );
@@ -554,7 +574,7 @@ async function bulkLoad(conn: Connection, data: GraphData): Promise<void> {
     conn,
     "ADR",
     ["id", "path", "title", "body", "decision_date", "supersedes_id", "source_of_truth", "trust_level", "status"],
-    data.adrEntities.map((e) => [
+    csvRows(data.adrEntities, (e) => [
       e.id, e.path, e.title, e.body, e.decision_date, e.supersedes_id, e.source_of_truth, e.trust_level, e.status
     ])
   );
@@ -565,7 +585,7 @@ async function bulkLoad(conn: Connection, data: GraphData): Promise<void> {
       "id", "file_id", "name", "kind", "signature", "body", "description", "start_line", "end_line",
       "language", "exported", "checksum", "updated_at", "source_of_truth", "trust_level", "status"
     ],
-    data.chunkEntities.map((e) => [
+    csvRows(data.chunkEntities, (e) => [
       e.id, e.file_id, e.name, e.kind, e.signature, e.body, e.description, e.start_line, e.end_line,
       e.language, e.exported, e.checksum, e.updated_at, e.source_of_truth, e.trust_level, e.status
     ])
@@ -574,7 +594,7 @@ async function bulkLoad(conn: Connection, data: GraphData): Promise<void> {
     conn,
     "Module",
     ["id", "path", "name", "summary", "file_count", "exported_symbols", "updated_at", "source_of_truth", "trust_level", "status"],
-    data.moduleEntities.map((e) => [
+    csvRows(data.moduleEntities, (e) => [
       e.id, e.path, e.name, e.summary, e.file_count, e.exported_symbols, e.updated_at, e.source_of_truth, e.trust_level, e.status
     ])
   );
@@ -585,7 +605,7 @@ async function bulkLoad(conn: Connection, data: GraphData): Promise<void> {
       "id", "path", "name", "kind", "language", "target_framework", "summary", "file_count",
       "updated_at", "source_of_truth", "trust_level", "status"
     ],
-    data.projectEntities.map((e) => [
+    csvRows(data.projectEntities, (e) => [
       e.id, e.path, e.name, e.kind, e.language, e.target_framework, e.summary, e.file_count,
       e.updated_at, e.source_of_truth, e.trust_level, e.status
     ])
@@ -595,45 +615,46 @@ async function bulkLoad(conn: Connection, data: GraphData): Promise<void> {
   // (COPY into a rel table reads src key, dst key, then properties in schema
   // order), but emitting real names keeps the CSVs self-describing.
   await copyTable(conn, "CONSTRAINS", ["from", "to", "note"],
-    filterEdges(data.constrains, ruleIds, fileIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.constrains, ruleIds, fileIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "IMPLEMENTS", ["from", "to", "note"],
-    filterEdges(data.implementsEdges, fileIds, ruleIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.implementsEdges, fileIds, ruleIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "SUPERSEDES", ["from", "to", "reason"],
-    filterEdges(data.supersedes, adrIds, adrIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.supersedes, adrIds, adrIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "DEFINES", ["from", "to"],
-    filterEdges(data.defines, fileIds, chunkIds).map((e) => [e.from, e.to]));
+    csvRows(filterEdges(data.defines, fileIds, chunkIds), (e) => [e.from, e.to]));
   await copyTable(conn, "CALLS", ["from", "to", "call_type"],
-    filterEdges(data.calls, chunkIds, chunkIds).map((e) => [e.from, e.to, e.call_type]));
+    csvRows(filterEdges(data.calls, chunkIds, chunkIds), (e) => [e.from, e.to, e.call_type]));
   await copyTable(conn, "IMPORTS", ["from", "to", "import_name"],
-    filterEdges(data.imports, chunkIds, fileIds).map((e) => [e.from, e.to, e.import_name]));
+    csvRows(filterEdges(data.imports, chunkIds, fileIds), (e) => [e.from, e.to, e.import_name]));
   await copyTable(conn, "CALLS_SQL", ["from", "to", "note"],
-    filterEdges(data.callsSql, fileIds, chunkIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.callsSql, fileIds, chunkIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "USES_CONFIG_KEY", ["from", "to", "note"],
-    filterEdges(data.usesConfigKey, fileIds, chunkIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.usesConfigKey, fileIds, chunkIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "USES_RESOURCE_KEY", ["from", "to", "note"],
-    filterEdges(data.usesResourceKey, fileIds, chunkIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.usesResourceKey, fileIds, chunkIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "USES_SETTING_KEY", ["from", "to", "note"],
-    filterEdges(data.usesSettingKey, fileIds, chunkIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.usesSettingKey, fileIds, chunkIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "CONTAINS", ["from", "to"],
-    filterEdges(data.contains, moduleIds, fileIds).map((e) => [e.from, e.to]));
+    csvRows(filterEdges(data.contains, moduleIds, fileIds), (e) => [e.from, e.to]));
   await copyTable(conn, "CONTAINS_MODULE", ["from", "to"],
-    filterEdges(data.containsModule, moduleIds, moduleIds).map((e) => [e.from, e.to]));
+    csvRows(filterEdges(data.containsModule, moduleIds, moduleIds), (e) => [e.from, e.to]));
   await copyTable(conn, "EXPORTS", ["from", "to"],
-    filterEdges(data.exports, moduleIds, chunkIds).map((e) => [e.from, e.to]));
+    csvRows(filterEdges(data.exports, moduleIds, chunkIds), (e) => [e.from, e.to]));
   await copyTable(conn, "INCLUDES_FILE", ["from", "to"],
-    filterEdges(data.includesFile, projectIds, fileIds).map((e) => [e.from, e.to]));
+    csvRows(filterEdges(data.includesFile, projectIds, fileIds), (e) => [e.from, e.to]));
   await copyTable(conn, "REFERENCES_PROJECT", ["from", "to", "note"],
-    filterEdges(data.referencesProject, projectIds, projectIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.referencesProject, projectIds, projectIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "USES_RESOURCE", ["from", "to", "note"],
-    filterEdges(data.usesResource, fileIds, fileIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.usesResource, fileIds, fileIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "USES_SETTING", ["from", "to", "note"],
-    filterEdges(data.usesSetting, fileIds, fileIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.usesSetting, fileIds, fileIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "USES_CONFIG", ["from", "to", "note"],
-    filterEdges(data.usesConfig, fileIds, fileIds).map((e) => [e.from, e.to, e.note]));
+    csvRows(filterEdges(data.usesConfig, fileIds, fileIds), (e) => [e.from, e.to, e.note]));
   await copyTable(conn, "TRANSFORMS_CONFIG", ["from", "to", "note"],
-    filterEdges(data.transformsConfig, fileIds, fileIds).map((e) => [e.from, e.to, e.note]));
-
-  fs.rmSync(GRAPH_IMPORT_DIR, { recursive: true, force: true });
+    csvRows(filterEdges(data.transformsConfig, fileIds, fileIds), (e) => [e.from, e.to, e.note]));
+  } finally {
+    fs.rmSync(GRAPH_IMPORT_DIR, { recursive: true, force: true });
+  }
 }
 
 // Original loader: clears every table, then inserts each node/edge through a

--- a/scaffold/mcp/tests/embed-scheduler.test.mjs
+++ b/scaffold/mcp/tests/embed-scheduler.test.mjs
@@ -147,6 +147,28 @@ test("runWorkUnits: assigns vectors to every duplicate index", async () => {
   assert.deepEqual(result.vectors.get(1), [2, 1]);
 });
 
+test("runWorkUnits: onVector consumes vectors without retaining them", async () => {
+  const extractor = async (texts) => {
+    const list = Array.isArray(texts) ? texts : [texts];
+    return fakeTensor(list.map((t) => [t.length, 1]));
+  };
+  const units = packWorkUnits(
+    [measured("aaa", 3, [0, 5]), measured("bb", 2, [1])],
+    { ...DEFAULT_SCHEDULER_OPTIONS, batchMaxItems: 32 }
+  );
+  const consumed = new Map();
+  const result = await runWorkUnits(units, [extractor], {
+    onVector(index, vector) {
+      consumed.set(index, vector);
+    }
+  });
+  assert.equal(result.failures.length, 0);
+  assert.equal(result.vectors.size, 0);
+  assert.deepEqual(consumed.get(0), [3, 1]);
+  assert.deepEqual(consumed.get(5), [3, 1]);
+  assert.deepEqual(consumed.get(1), [2, 1]);
+});
+
 test("runWorkUnits: batch failure retries per item and isolates the poison text", async () => {
   const extractor = async (texts) => {
     if (Array.isArray(texts)) {

--- a/scaffold/mcp/tests/embedding-jsonl.test.mjs
+++ b/scaffold/mcp/tests/embedding-jsonl.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { readJsonlRecords, writeJsonlRecords } from "../dist/jsonl.js";
+
+test("writeJsonlRecords writes canonical JSONL without building a joined body", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-jsonl-"));
+  const filePath = path.join(dir, "embeddings.jsonl");
+  const records = [
+    { id: "a", vector: [1, 2.5], model: "m" },
+    { id: "b", vector: [0], model: "m", label: "two" }
+  ];
+
+  const count = writeJsonlRecords(filePath, records);
+
+  assert.equal(count, 2);
+  assert.equal(fs.readFileSync(filePath, "utf8"), records.map(JSON.stringify).join("\n") + "\n");
+});
+
+test("readJsonlRecords streams valid records and skips blank or invalid lines", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-jsonl-"));
+  const filePath = path.join(dir, "embeddings.jsonl");
+  fs.writeFileSync(filePath, '{"id":"a"}\r\n\nnot json\n{"id":"b"}\n', "utf8");
+
+  assert.deepEqual(Array.from(readJsonlRecords(filePath)), [{ id: "a" }, { id: "b" }]);
+});
+
+test("writeJsonlRecords creates an empty file for empty output", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-jsonl-"));
+  const filePath = path.join(dir, "empty.jsonl");
+
+  const count = writeJsonlRecords(filePath, []);
+
+  assert.equal(count, 0);
+  assert.equal(fs.readFileSync(filePath, "utf8"), "");
+});

--- a/scaffold/mcp/tests/graph-csv.test.mjs
+++ b/scaffold/mcp/tests/graph-csv.test.mjs
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { toCsvCell, toCsvRow, toCopyPathLiteral, CSV_NULL_SENTINEL, CSV_COPY_OPTIONS } from "../dist/graphCsv.js";
+import { toCsvCell, toCsvRow, writeCsv, toCopyPathLiteral, CSV_NULL_SENTINEL, CSV_COPY_OPTIONS } from "../dist/graphCsv.js";
 
 test("toCsvCell: quotes plain strings", () => {
   assert.equal(toCsvCell("hello"), '"hello"');
@@ -43,6 +46,45 @@ test("toCsvCell: preserves unicode and backslashes", () => {
 test("toCsvRow: joins cells with commas", () => {
   assert.equal(toCsvRow(["a", 1, true]), '"a","1","true"');
   assert.equal(toCsvRow(['a"b', "c,d"]), '"a""b","c,d"');
+});
+
+test("writeCsv: streams iterable rows with byte-equivalent CSV output", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-csv-"));
+  const filePath = path.join(dir, "rows.csv");
+  try {
+    function* rows() {
+      yield ["a", 1, true];
+      yield ['she said "hi"', "a\nb", ""];
+      yield [null, undefined, false];
+    }
+
+    const rowCount = writeCsv(filePath, ["c1", "c2", "c3"], rows());
+    const expected = [
+      toCsvRow(["c1", "c2", "c3"]),
+      toCsvRow(["a", 1, true]),
+      toCsvRow(['she said "hi"', "a\nb", ""]),
+      toCsvRow([null, undefined, false]),
+      ""
+    ].join("\n");
+
+    assert.equal(rowCount, 3);
+    assert.equal(fs.readFileSync(filePath, "utf8"), expected);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeCsv: empty iterables write only the header and return zero rows", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-csv-empty-"));
+  const filePath = path.join(dir, "rows.csv");
+  try {
+    const rowCount = writeCsv(filePath, ["only"], []);
+
+    assert.equal(rowCount, 0);
+    assert.equal(fs.readFileSync(filePath, "utf8"), `${toCsvRow(["only"])}\n`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("CSV_NULL_SENTINEL is a single NUL byte (impossible in any text-file-derived cell)", () => {

--- a/scaffold/scripts/dashboard.mjs
+++ b/scaffold/scripts/dashboard.mjs
@@ -17,7 +17,7 @@ const CONFIG_PATH = path.join(CONTEXT_DIR, "config.yaml");
 const SUPPORTED_TEXT_EXTENSIONS = new Set([
   ".md", ".mdx", ".txt", ".adoc", ".rst",
   ".yaml", ".yml", ".json", ".toml", ".csv",
-  ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
+  ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
   ".py", ".go", ".java", ".cs", ".rb", ".rs", ".php", ".swift", ".kt",
   ".sql", ".sh", ".bash", ".zsh", ".ps1",
   ".c", ".h", ".cpp", ".hpp", ".cc", ".hh"

--- a/scaffold/scripts/ingest-parsers.mjs
+++ b/scaffold/scripts/ingest-parsers.mjs
@@ -41,7 +41,9 @@ let loadPromise = null;
 // subprocess) stay on the main thread.
 export const PARALLEL_SAFE_LANGUAGES = new Set([
   "javascript",
+  "jsx",
   "typescript",
+  "tsx",
   "python",
   "go",
   "java",
@@ -128,9 +130,13 @@ export async function loadParsers() {
 
 const CHUNK_PARSERS = new Map([
   [".js", { language: "javascript", parse: parseJavaScriptCode }],
+  [".jsx", { language: "jsx", parse: parseJavaScriptCode }],
   [".mjs", { language: "javascript", parse: parseJavaScriptCode }],
   [".cjs", { language: "javascript", parse: parseJavaScriptCode }],
   [".ts", { language: "typescript", parse: parseJavaScriptCode }],
+  [".tsx", { language: "tsx", parse: parseJavaScriptCode }],
+  [".mts", { language: "typescript", parse: parseJavaScriptCode }],
+  [".cts", { language: "typescript", parse: parseJavaScriptCode }],
   [
     ".vb",
     {

--- a/scaffold/scripts/ingest-worker.mjs
+++ b/scaffold/scripts/ingest-worker.mjs
@@ -5,11 +5,12 @@
  * parsers) for one file at a time off the main thread. It does nothing
  * stateful: no id allocation, windowing, checksums, or relation building —
  * all of that stays on the main thread in deterministic order. The worker
- * only turns (ext, content, path) into a parse result.
+ * only turns (ext, file path) into a parse result.
  *
  * Parsers initialize lazily on first use and cache per module instance, so a
  * long-lived worker pays each grammar's WASM init once.
  */
+import fs from "node:fs";
 import { parentPort } from "node:worker_threads";
 import { loadParsers, parseFileContent } from "./ingest-parsers.mjs";
 
@@ -24,9 +25,17 @@ parentPort.on("message", async (message) => {
     process.exit(0);
   }
 
-  const { taskId, ext, content, filePath } = message;
+  const { taskId, ext, filePath } = message;
   try {
     await ready;
+    let content = typeof message.content === "string" ? message.content : null;
+    if (content === null) {
+      const limit = Number.isFinite(message.contentLimit) ? Math.max(0, Math.floor(message.contentLimit)) : null;
+      content = fs.readFileSync(message.absolutePath, "utf8");
+      if (limit !== null) {
+        content = content.slice(0, limit);
+      }
+    }
     const parsed = await parseFileContent(ext, content, filePath);
     if (!parsed) {
       parentPort.postMessage({ taskId, ok: false, reason: "no parser available" });

--- a/scaffold/scripts/ingest.mjs
+++ b/scaffold/scripts/ingest.mjs
@@ -38,6 +38,8 @@ const SUPPORTED_TEXT_EXTENSIONS = new Set([
   ".csv",
   ".ts",
   ".tsx",
+  ".mts",
+  ".cts",
   ".js",
   ".jsx",
   ".mjs",
@@ -96,6 +98,8 @@ const STRUCTURED_NON_CODE_CHUNK_EXTENSIONS = new Set([".config", ".resx", ".sett
 const CODE_FILE_EXTENSIONS = new Set([
   ".ts",
   ".tsx",
+  ".mts",
+  ".cts",
   ".js",
   ".jsx",
   ".mjs",
@@ -193,9 +197,9 @@ const DEFAULT_CHUNK_WINDOW_LINES = 80;
 const DEFAULT_CHUNK_OVERLAP_LINES = 16;
 const DEFAULT_CHUNK_SPLIT_MIN_LINES = 120;
 const DEFAULT_CHUNK_MAX_WINDOWS = 8;
-const IMPORT_RESOLUTION_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json"];
+const IMPORT_RESOLUTION_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".json"];
 const IMPORT_RUNTIME_JS_EXTENSIONS = new Set([".js", ".jsx", ".mjs", ".cjs"]);
-const IMPORT_RUNTIME_JS_RESOLUTION_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+const IMPORT_RUNTIME_JS_RESOLUTION_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"];
 const CPP_IMPORT_RESOLUTION_EXTENSIONS = [".h", ".hh", ".hpp", ".c", ".cc", ".cpp"];
 
 const STOP_WORDS = new Set([
@@ -333,6 +337,40 @@ function parseNonNegativeIntegerEnv(name, fallback) {
     return fallback;
   }
   return Math.floor(parsed);
+}
+
+function isTruthyEnv(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized !== "" && normalized !== "0" && normalized !== "false" && normalized !== "no" && normalized !== "off";
+}
+
+function createIngestMemoryTrace() {
+  const enabled = isTruthyEnv(process.env.CORTEX_INGEST_TRACE_MEMORY);
+
+  return {
+    enabled,
+    checkpoint(label, counts = {}) {
+      if (!enabled) {
+        return;
+      }
+
+      const memory = process.memoryUsage();
+      process.stderr.write(
+        `${JSON.stringify({
+          type: "cortex.ingest.memory",
+          label,
+          rss_bytes: memory.rss,
+          rss_mb: Number((memory.rss / 1024 / 1024).toFixed(2)),
+          heap_used_bytes: memory.heapUsed,
+          external_bytes: memory.external,
+          counts
+        })}\n`
+      );
+    }
+  };
 }
 
 function parseSourcePaths(configText) {
@@ -710,8 +748,14 @@ function findSupersedesReferences(content) {
 }
 
 function writeJsonl(filePath, records) {
-  const body = records.map((record) => JSON.stringify(record)).join("\n");
-  fs.writeFileSync(filePath, body ? `${body}\n` : "", "utf8");
+  const fd = fs.openSync(filePath, "w");
+  try {
+    for (const record of records) {
+      fs.writeSync(fd, `${JSON.stringify(record)}\n`, undefined, "utf8");
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 function sanitizeTsvCell(value) {
@@ -720,11 +764,21 @@ function sanitizeTsvCell(value) {
 }
 
 function writeTsv(filePath, headers, rows) {
-  const lines = [headers.join("\t")];
-  for (const row of rows) {
-    lines.push(row.map((value) => sanitizeTsvCell(value)).join("\t"));
+  const fd = fs.openSync(filePath, "w");
+  try {
+    fs.writeSync(fd, `${headers.join("\t")}\n`, undefined, "utf8");
+    for (const row of rows) {
+      fs.writeSync(fd, `${row.map((value) => sanitizeTsvCell(value)).join("\t")}\n`, undefined, "utf8");
+    }
+  } finally {
+    fs.closeSync(fd);
   }
-  fs.writeFileSync(filePath, `${lines.join("\n")}\n`, "utf8");
+}
+
+function* mapRows(records, project) {
+  for (const record of records) {
+    yield project(record);
+  }
 }
 
 function readJsonlSafe(filePath) {
@@ -2061,7 +2115,16 @@ function generateModuleSummary(dir, files, exportNames, repoRoot = REPO_ROOT) {
   const exts = new Set(codeFiles.map(f => path.extname(f.path).toLowerCase()));
   if (exts.size === 1) {
     const ext = [...exts][0];
-    const extNames = { ".ts": "TypeScript", ".js": "JavaScript", ".mjs": "JavaScript (ESM)", ".tsx": "TypeScript React" };
+    const extNames = {
+      ".ts": "TypeScript",
+      ".tsx": "TypeScript React",
+      ".mts": "TypeScript ESM",
+      ".cts": "TypeScript CommonJS",
+      ".js": "JavaScript",
+      ".jsx": "JavaScript React",
+      ".mjs": "JavaScript ESM",
+      ".cjs": "JavaScript CommonJS"
+    };
     if (extNames[ext]) parts.push(`${extNames[ext]} source files`);
   }
 
@@ -2212,16 +2275,32 @@ function resolveIngestWorkerCount(taskCount) {
   return Math.min(desired, taskCount);
 }
 
-// Parse files in a worker pool, returning Map<fileId, parseResult> for the
-// tasks that completed. Any task not present (worker miss, skip, or a fatal
-// worker error) is left to the caller's inline parse — the same parse
-// function on the same content, so output is identical either way. Never
-// rejects: a fatal worker error resolves with the partial results collected
-// so far.
-async function parseFilesInWorkers(tasks, { workerCount, verbose, workerUrl } = {}) {
-  const results = new Map();
+function createEmptyWorkerParseStream(tasks, workerCount) {
+  const stats = () => ({
+    worker_tasks: tasks.length,
+    worker_count: Number.isFinite(workerCount) ? workerCount : 0,
+    worker_tasks_assigned: 0,
+    worker_tasks_settled: 0,
+    worker_tasks_unsettled_fallback: tasks.length,
+    worker_results: 0,
+    worker_results_consumed: 0,
+    worker_results_retained: 0,
+    worker_results_retained_peak: 0,
+    worker_results_pending: 0,
+    worker_results_missing: tasks.length,
+    worker_waiters: 0
+  });
+  return {
+    hasTask: () => false,
+    stats,
+    take: async () => undefined,
+    drain: async () => stats()
+  };
+}
+
+function startWorkerParseStream(tasks, { workerCount, verbose, workerUrl } = {}) {
   if (tasks.length === 0) {
-    return results;
+    return createEmptyWorkerParseStream(tasks, workerCount);
   }
 
   const resolvedWorkerUrl = workerUrl ?? new URL("./ingest-worker.mjs", import.meta.url);
@@ -2231,102 +2310,219 @@ async function parseFilesInWorkers(tasks, { workerCount, verbose, workerUrl } = 
   // Return empty so the caller parses everything inline. (Math.min(undefined, n)
   // is NaN, which is why this is `!(>= 1)` rather than `< 1`.)
   if (!(poolSize >= 1)) {
-    return results;
+    return createEmptyWorkerParseStream(tasks, workerCount);
   }
+
+  const taskIds = new Set(tasks.map((task) => task.id));
+  const results = new Map();
+  const missingResults = new Set();
+  const waiters = new Map();
   const workers = [];
   const inflight = new Map(); // worker -> taskId being parsed, or null when idle
   let nextTask = 0;
-  let settled = 0;
   let alive = poolSize;
+  let finished = false;
+  let resolveDone;
+  const done = new Promise((resolve) => {
+    resolveDone = resolve;
+  });
+  const state = {
+    assigned: 0,
+    settled: 0,
+    successful: 0,
+    consumed: 0,
+    retainedPeak: 0
+  };
 
-  await new Promise((resolve) => {
-    let finished = false;
-    const finish = () => {
-      if (finished) return;
-      finished = true;
-      resolve();
-    };
-    // A task is "settled" once it has a result, was skipped, or its worker
-    // died holding it. Finish when every task is settled, or when no worker is
-    // left alive to make progress (any still-queued tasks then parse inline).
-    const maybeFinish = () => {
-      if (settled >= tasks.length || alive <= 0) {
-        finish();
-      }
-    };
-
-    const assign = (worker) => {
-      if (nextTask >= tasks.length) {
-        inflight.set(worker, null);
-        worker.postMessage({ type: "shutdown" });
-        return;
-      }
-      const task = tasks[nextTask++];
-      inflight.set(worker, task.id);
-      worker.postMessage({ taskId: task.id, ext: task.ext, content: task.content, filePath: task.path });
-    };
-
-    const onMessage = (worker, message) => {
-      if (finished) return;
-      if (message.ok) {
-        results.set(message.taskId, message.result);
-      } else if (verbose) {
-        console.log(`[ingest] worker skipped ${message.taskId}: ${message.reason}`);
-      }
-      inflight.set(worker, null);
-      settled += 1;
-      if (settled >= tasks.length) {
-        finish();
-        return;
-      }
-      assign(worker);
-    };
-
-    const onExit = (worker) => {
-      if (finished) return;
-      alive -= 1;
-      const taskId = inflight.get(worker);
-      if (taskId != null) {
-        // Worker exited mid-parse without posting a result (OOM, native abort,
-        // process.exit) and without an 'error' event. Count its in-flight task
-        // as settled so it falls back to inline parsing rather than leaving the
-        // pool waiting on a dead worker forever.
-        if (verbose) {
-          console.log(`[ingest] worker exited mid-task ${taskId}; will parse inline`);
-        }
-        inflight.set(worker, null);
-        settled += 1;
-      }
-      maybeFinish();
-    };
-
-    for (let i = 0; i < poolSize; i += 1) {
-      const worker = new Worker(resolvedWorkerUrl);
-      workers.push(worker);
-      worker.on("message", (message) => onMessage(worker, message));
-      worker.on("error", (error) => {
-        // Uncaught exception in the worker. The 'exit' event that always
-        // follows does the task accounting (idempotent via inflight), so we
-        // only log here to avoid double-counting.
-        if (verbose) {
-          console.log(`[ingest] worker error: ${error.message}`);
-        }
-      });
-      worker.on("exit", () => onExit(worker));
-    }
-
-    for (const worker of workers) {
-      assign(worker);
-    }
+  const stats = () => ({
+    worker_tasks: tasks.length,
+    worker_count: poolSize,
+    worker_tasks_assigned: state.assigned,
+    worker_tasks_settled: state.settled,
+    worker_tasks_unsettled_fallback: finished ? Math.max(0, tasks.length - state.settled) : 0,
+    worker_results: state.successful,
+    worker_results_consumed: state.consumed,
+    worker_results_retained: results.size,
+    worker_results_retained_peak: state.retainedPeak,
+    worker_results_pending: finished ? 0 : Math.max(0, tasks.length - state.settled),
+    worker_results_missing: tasks.length - state.successful,
+    worker_waiters: waiters.size
   });
 
-  await Promise.all(workers.map((worker) => worker.terminate().catch(() => {})));
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    for (const resolve of waiters.values()) {
+      resolve(undefined);
+    }
+    waiters.clear();
+    resolveDone();
+  };
+
+  // A task is "settled" once it has a result, was skipped, or its worker
+  // died holding it. Finish when every task is settled, or when no worker is
+  // left alive to make progress (any still-queued tasks then parse inline).
+  const maybeFinish = () => {
+    if (state.settled >= tasks.length || alive <= 0) {
+      finish();
+    }
+  };
+
+  const resolveWaiter = (taskId, result) => {
+    const resolve = waiters.get(taskId);
+    if (!resolve) {
+      return false;
+    }
+    waiters.delete(taskId);
+    if (result !== undefined) {
+      state.consumed += 1;
+    }
+    resolve(result);
+    return true;
+  };
+
+  const settleTask = (taskId, result) => {
+    state.settled += 1;
+    if (result !== undefined) {
+      state.successful += 1;
+      if (!resolveWaiter(taskId, result)) {
+        results.set(taskId, result);
+        state.retainedPeak = Math.max(state.retainedPeak, results.size);
+      }
+    } else {
+      missingResults.add(taskId);
+      resolveWaiter(taskId, undefined);
+    }
+    maybeFinish();
+  };
+
+  const assign = (worker) => {
+    if (nextTask >= tasks.length) {
+      inflight.set(worker, null);
+      worker.postMessage({ type: "shutdown" });
+      return;
+    }
+    const task = tasks[nextTask++];
+    state.assigned += 1;
+    inflight.set(worker, task.id);
+    worker.postMessage({
+      taskId: task.id,
+      ext: task.ext,
+      content: task.content,
+      absolutePath: task.absolutePath,
+      contentLimit: task.contentLimit,
+      filePath: task.path
+    });
+  };
+
+  const onMessage = (worker, message) => {
+    if (finished) return;
+    inflight.set(worker, null);
+    if (message.ok) {
+      settleTask(message.taskId, message.result);
+    } else {
+      if (verbose) {
+        console.log(`[ingest] worker skipped ${message.taskId}: ${message.reason}`);
+      }
+      settleTask(message.taskId, undefined);
+    }
+    if (!finished) {
+      assign(worker);
+    }
+  };
+
+  const onExit = (worker) => {
+    if (finished) return;
+    alive -= 1;
+    const taskId = inflight.get(worker);
+    if (taskId != null) {
+      // Worker exited mid-parse without posting a result (OOM, native abort,
+      // process.exit) and without an 'error' event. Count its in-flight task
+      // as settled so it falls back to inline parsing rather than leaving the
+      // pool waiting on a dead worker forever.
+      if (verbose) {
+        console.log(`[ingest] worker exited mid-task ${taskId}; will parse inline`);
+      }
+      inflight.set(worker, null);
+      settleTask(taskId, undefined);
+      return;
+    }
+    maybeFinish();
+  };
+
+  for (let i = 0; i < poolSize; i += 1) {
+    const worker = new Worker(resolvedWorkerUrl);
+    workers.push(worker);
+    worker.on("message", (message) => onMessage(worker, message));
+    worker.on("error", (error) => {
+      // Uncaught exception in the worker. The 'exit' event that always
+      // follows does the task accounting (idempotent via inflight), so we
+      // only log here to avoid double-counting.
+      if (verbose) {
+        console.log(`[ingest] worker error: ${error.message}`);
+      }
+    });
+    worker.on("exit", () => onExit(worker));
+  }
+
+  for (const worker of workers) {
+    assign(worker);
+  }
+
+  return {
+    hasTask(taskId) {
+      return taskIds.has(taskId);
+    },
+    stats,
+    async take(taskId) {
+      if (!taskIds.has(taskId)) {
+        return undefined;
+      }
+      if (results.has(taskId)) {
+        const result = results.get(taskId);
+        results.delete(taskId);
+        state.consumed += 1;
+        return result;
+      }
+      if (missingResults.has(taskId) || finished) {
+        return undefined;
+      }
+      return new Promise((resolve) => {
+        waiters.set(taskId, resolve);
+      });
+    },
+    async drain() {
+      await done;
+      await Promise.all(workers.map((worker) => worker.terminate().catch(() => {})));
+      return stats();
+    }
+  };
+}
+
+// Parse files in a worker pool, returning Map<fileId, parseResult> for the
+// tasks that completed. Any task not present (worker miss, skip, or a fatal
+// worker error) is left to the caller's inline parse — the same parse
+// function on the same content, so output is identical either way. Never
+// rejects: a fatal worker error resolves with the partial results collected
+// so far.
+async function parseFilesInWorkers(tasks, options = {}) {
+  const stream = startWorkerParseStream(tasks, options);
+  const results = new Map();
+  for (const task of tasks) {
+    const result = await stream.take(task.id);
+    if (result) {
+      results.set(task.id, result);
+    }
+  }
+
+  await stream.drain();
   return results;
 }
 
 async function main() {
   await loadParsers();
   const { mode, verbose } = parseArgs(process.argv);
+  const memoryTrace = createIngestMemoryTrace();
   const configPath = path.join(CONTEXT_DIR, "config.yaml");
   const rulesPath = path.join(CONTEXT_DIR, "rules.yaml");
 
@@ -2347,6 +2543,11 @@ async function main() {
   }
 
   const rules = parseRules(fs.readFileSync(rulesPath, "utf8"));
+  memoryTrace.checkpoint("scan:start", {
+    mode,
+    source_paths: sourcePaths.length,
+    rules: rules.length
+  });
   const { candidates, incrementalMode, deletedRelPaths } = collectCandidateFiles(sourcePaths, mode);
   const chunkWindowLines = parsePositiveIntegerEnv(
     "CORTEX_CHUNK_WINDOW_LINES",
@@ -2500,6 +2701,16 @@ async function main() {
 
   const fileRecords = [...fileRecordMap.values()].sort((a, b) => a.path.localeCompare(b.path));
   const adrRecords = [...adrRecordMap.values()].sort((a, b) => a.path.localeCompare(b.path));
+  memoryTrace.checkpoint("scan:file_records", {
+    candidates: candidates.size,
+    incremental_mode: incrementalMode,
+    deleted_paths: deletedRelPaths.length,
+    files: fileRecords.length,
+    adrs: adrRecords.length,
+    skipped_unsupported: skipped.unsupported,
+    skipped_too_large: skipped.tooLarge,
+    skipped_binary: skipped.binary
+  });
   const csharpFileCount = fileRecords.filter((record) => path.extname(record.path).toLowerCase() === ".cs").length;
   const csharpRuntime = csharpFileCount > 0 ? getCSharpParserRuntime() : null;
   const indexedFileIds = new Set(fileRecords.map((record) => record.id));
@@ -2522,6 +2733,14 @@ async function main() {
         importsRelationMap: new Map(),
         callsSqlRelationMap: new Map()
       };
+  memoryTrace.checkpoint("hydration:complete", {
+    incremental_mode: incrementalMode,
+    cached_chunks: chunkRecordMap.size,
+    cached_defines_relations: definesRelationMap.size,
+    cached_calls_relations: callsRelationMap.size,
+    cached_imports_relations: importsRelationMap.size,
+    cached_calls_sql_relations: callsSqlRelationMap.size
+  });
 
   const cachedChunkFileIds = new Set(
     [...chunkRecordMap.values()].map((record) => String(record.file_id ?? "")).filter(Boolean)
@@ -2594,6 +2813,11 @@ async function main() {
     }
     parseEligible.set(fileRecord.id, { parser, ext });
   }
+  memoryTrace.checkpoint("parse:eligible", {
+    files: fileRecords.length,
+    parse_eligible: parseEligible.size,
+    csharp_batch_cached: csharpBatchCache.size
+  });
 
   // Parse parallel-safe files (tree-sitter/JS, no subprocess, no cross-file
   // state) in a worker pool. C# batch-cached files and any worker miss fall
@@ -2610,14 +2834,28 @@ async function main() {
     .map((fileRecord) => ({
       id: fileRecord.id,
       ext: parseEligible.get(fileRecord.id).ext,
-      content: fileRecord.content,
+      absolutePath: path.resolve(REPO_ROOT, fileRecord.path),
+      contentLimit: MAX_CONTENT_CHARS,
       path: fileRecord.path
     }));
   const workerCount = resolveIngestWorkerCount(workerTasks.length);
-  const workerResults =
-    workerCount > 1 ? await parseFilesInWorkers(workerTasks, { workerCount, verbose }) : new Map();
-  if (verbose && workerCount > 1) {
-    console.log(`[ingest] parsed ${workerResults.size}/${workerTasks.length} files across ${workerCount} workers`);
+  memoryTrace.checkpoint("parse:workers_start", {
+    worker_tasks: workerTasks.length,
+    worker_count: workerCount
+  });
+  const workerStream =
+    workerCount > 1 ? startWorkerParseStream(workerTasks, { workerCount, verbose }) : null;
+  if (!workerStream) {
+    memoryTrace.checkpoint("parse:workers_complete", {
+      worker_tasks: workerTasks.length,
+      worker_count: workerCount,
+      worker_results: 0,
+      worker_results_consumed: 0,
+      worker_results_retained: 0,
+      worker_results_retained_peak: 0,
+      worker_results_pending: 0,
+      worker_results_missing: workerTasks.length
+    });
   }
 
   for (const fileRecord of fileRecords) {
@@ -2638,8 +2876,11 @@ async function main() {
       let parseResult;
       if (parser.language === "csharp" && csharpBatchCache.has(fileRecord.path)) {
         parseResult = csharpBatchCache.get(fileRecord.path);
-      } else if (workerResults.has(fileRecord.id)) {
-        parseResult = workerResults.get(fileRecord.id);
+      } else if (workerStream?.hasTask(fileRecord.id)) {
+        parseResult = await workerStream.take(fileRecord.id);
+        if (!parseResult) {
+          parseResult = await parser.parse(fileRecord.content, fileRecord.path, parser.language);
+        }
       } else {
         parseResult = await parser.parse(fileRecord.content, fileRecord.path, parser.language);
       }
@@ -2791,6 +3032,27 @@ async function main() {
       }
     }
   }
+  const finalWorkerStats = workerStream ? await workerStream.drain() : null;
+  if (finalWorkerStats) {
+    memoryTrace.checkpoint("parse:workers_complete", finalWorkerStats);
+    if (verbose) {
+      console.log(
+        `[ingest] parsed ${finalWorkerStats.worker_results}/${workerTasks.length} files across ${workerCount} workers`
+      );
+    }
+  }
+  memoryTrace.checkpoint("parse:merge_complete", {
+    chunk_map: chunkRecordMap.size,
+    defines_relations: definesRelationMap.size,
+    calls_relations: callsRelationMap.size,
+    imports_relations: importsRelationMap.size,
+    calls_sql_relations: callsSqlRelationMap.size,
+    deferred_sql_edges: deferredSqlCallEdges.length,
+    windowed_chunks: windowedChunkCount,
+    worker_results_retained: finalWorkerStats?.worker_results_retained ?? 0,
+    worker_results_retained_peak: finalWorkerStats?.worker_results_retained_peak ?? 0,
+    worker_results_pending: finalWorkerStats?.worker_results_pending ?? 0
+  });
 
   const chunkRecords = [...chunkRecordMap.values()].sort((a, b) => String(a.id).localeCompare(String(b.id)));
   ({
@@ -2920,6 +3182,17 @@ async function main() {
   const validUsesSettingKeyRelations = [...usesSettingKeyRelationMap.values()].filter(
     (rel) => indexedFileIds.has(rel.from) && chunkIdSet.has(rel.to)
   );
+  memoryTrace.checkpoint("materialize:chunks_relations", {
+    chunks: chunkRecords.length,
+    chunk_ids: chunkIdSet.size,
+    relations_defines: validDefinesRelations.length,
+    relations_calls: validCallsRelations.length,
+    relations_imports: validImportsRelations.length,
+    relations_calls_sql: validCallsSqlRelations.length,
+    relations_uses_config_key: validUsesConfigKeyRelations.length,
+    relations_uses_resource_key: validUsesResourceKeyRelations.length,
+    relations_uses_setting_key: validUsesSettingKeyRelations.length
+  });
 
   if (verbose && chunkRecords.length > 0) {
     console.log(`[ingest] extracted ${chunkRecords.length} chunks from ${fileRecords.filter(f => f.kind === "CODE").length} code files`);
@@ -2982,6 +3255,19 @@ async function main() {
     ...sectionHandlerRelations
   ]);
   const configTransformRelations = generateConfigTransformRelations(fileRecords);
+  memoryTrace.checkpoint("materialize:modules_projects_relations", {
+    modules: moduleRecords.length,
+    projects: projectRecords.length,
+    relations_contains: moduleContainsRelations.length,
+    relations_contains_module: moduleContainsModuleRelations.length,
+    relations_exports: moduleExportsRelations.length,
+    relations_includes_file: projectIncludesFileRelations.length,
+    relations_references_project: projectReferencesProjectRelations.length,
+    relations_uses_resource: usesResourceRelations.length,
+    relations_uses_setting: usesSettingRelations.length,
+    relations_uses_config: usesConfigRelations.length,
+    relations_transforms_config: configTransformRelations.length
+  });
 
   if (verbose && moduleRecords.length > 0) {
     console.log(`[ingest] modules=${moduleRecords.length} contains=${moduleContainsRelations.length} contains_module=${moduleContainsModuleRelations.length} exports=${moduleExportsRelations.length}`);
@@ -3047,9 +3333,10 @@ async function main() {
   const implementsRelations = [];
   const constrainsSeen = new Set();
   const implementsSeen = new Set();
-  const lowerContentByFileId = new Map(
-    fileRecords.map((fileRecord) => [fileRecord.id, fileRecord.content.toLowerCase()])
-  );
+  memoryTrace.checkpoint("tokens:rule_matching_start", {
+    files: fileRecords.length,
+    rules: ruleRecords.length
+  });
   const tokenByFileId = new Map(fileRecords.map((fileRecord) => [fileRecord.id, fileTokenSet(fileRecord)]));
 
   for (const ruleRecord of ruleRecords) {
@@ -3057,7 +3344,7 @@ async function main() {
     const ruleKeywords = normalizeRuleTokens(ruleRecord);
 
     for (const fileRecord of fileRecords) {
-      const lower = lowerContentByFileId.get(fileRecord.id) ?? "";
+      const lower = fileRecord.content.toLowerCase();
       const explicitMention = lower.includes(needle);
       const tokens = tokenByFileId.get(fileRecord.id) ?? new Set();
       const matchedKeywords = ruleKeywords.filter((keyword) => tokens.has(keyword));
@@ -3095,7 +3382,20 @@ async function main() {
       }
     }
   }
+  memoryTrace.checkpoint("tokens:rule_matching_complete", {
+    file_token_sets: tokenByFileId.size,
+    rules: ruleRecords.length,
+    relations_constrains: constrainsRelations.length,
+    relations_implements: implementsRelations.length,
+    relations_supersedes: supersedesRelations.length
+  });
 
+  memoryTrace.checkpoint("writes:cache_start", {
+    files: fileRecords.length,
+    adrs: adrRecords.length,
+    rules: ruleRecords.length,
+    chunks: chunkRecords.length
+  });
   writeJsonl(path.join(CACHE_DIR, "documents.jsonl"), fileRecords);
   writeJsonl(path.join(CACHE_DIR, "entities.file.jsonl"), fileRecords);
   writeJsonl(path.join(CACHE_DIR, "entities.adr.jsonl"), adrRecords);
@@ -3125,7 +3425,15 @@ async function main() {
     path.join(CACHE_DIR, "relations.references_project.jsonl"),
     projectReferencesProjectRelations
   );
+  memoryTrace.checkpoint("writes:cache_complete", {
+    jsonl_files: 26,
+    files: fileRecords.length,
+    chunks: chunkRecords.length
+  });
 
+  memoryTrace.checkpoint("writes:db_start", {
+    tsv_files: 21
+  });
   writeTsv(
     path.join(DB_IMPORT_DIR, "file_nodes.tsv"),
     [
@@ -3139,7 +3447,7 @@ async function main() {
       "trust_level",
       "status"
     ],
-    fileRecords.map((record) => [
+    mapRows(fileRecords, (record) => [
       record.id,
       record.path,
       record.kind,
@@ -3165,7 +3473,7 @@ async function main() {
       "trust_level",
       "status"
     ],
-    ruleRecords.map((record) => [
+    mapRows(ruleRecords, (record) => [
       record.id,
       record.title,
       record.body,
@@ -3191,7 +3499,7 @@ async function main() {
       "trust_level",
       "status"
     ],
-    adrRecords.map((record) => [
+    mapRows(adrRecords, (record) => [
       record.id,
       record.path,
       record.title,
@@ -3207,19 +3515,19 @@ async function main() {
   writeTsv(
     path.join(DB_IMPORT_DIR, "constrains_rel.tsv"),
     ["from", "to", "note"],
-    constrainsRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(constrainsRelations, (record) => [record.from, record.to, record.note])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "implements_rel.tsv"),
     ["from", "to", "note"],
-    implementsRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(implementsRelations, (record) => [record.from, record.to, record.note])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "supersedes_rel.tsv"),
     ["from", "to", "reason"],
-    supersedesRelations.map((record) => [record.from, record.to, record.reason])
+    mapRows(supersedesRelations, (record) => [record.from, record.to, record.reason])
   );
 
   writeTsv(
@@ -3238,7 +3546,7 @@ async function main() {
       "updated_at",
       "trust_level"
     ],
-    chunkRecords.map((record) => [
+    mapRows(chunkRecords, (record) => [
       record.id,
       record.file_id,
       record.name,
@@ -3257,43 +3565,43 @@ async function main() {
   writeTsv(
     path.join(DB_IMPORT_DIR, "defines_rel.tsv"),
     ["from", "to"],
-    validDefinesRelations.map((record) => [record.from, record.to])
+    mapRows(validDefinesRelations, (record) => [record.from, record.to])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "calls_rel.tsv"),
     ["from", "to", "call_type"],
-    validCallsRelations.map((record) => [record.from, record.to, record.call_type])
+    mapRows(validCallsRelations, (record) => [record.from, record.to, record.call_type])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "imports_rel.tsv"),
     ["from", "to", "import_name"],
-    validImportsRelations.map((record) => [record.from, record.to, record.import_name])
+    mapRows(validImportsRelations, (record) => [record.from, record.to, record.import_name])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "calls_sql_rel.tsv"),
     ["from", "to", "note"],
-    validCallsSqlRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(validCallsSqlRelations, (record) => [record.from, record.to, record.note])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "uses_config_key_rel.tsv"),
     ["from", "to", "note"],
-    validUsesConfigKeyRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(validUsesConfigKeyRelations, (record) => [record.from, record.to, record.note])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "uses_resource_key_rel.tsv"),
     ["from", "to", "note"],
-    validUsesResourceKeyRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(validUsesResourceKeyRelations, (record) => [record.from, record.to, record.note])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "uses_setting_key_rel.tsv"),
     ["from", "to", "note"],
-    validUsesSettingKeyRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(validUsesSettingKeyRelations, (record) => [record.from, record.to, record.note])
   );
 
   writeTsv(
@@ -3312,7 +3620,7 @@ async function main() {
       "trust_level",
       "status"
     ],
-    projectRecords.map((record) => [
+    mapRows(projectRecords, (record) => [
       record.id,
       record.path,
       record.name,
@@ -3331,38 +3639,41 @@ async function main() {
   writeTsv(
     path.join(DB_IMPORT_DIR, "includes_file_rel.tsv"),
     ["from", "to"],
-    projectIncludesFileRelations.map((record) => [record.from, record.to])
+    mapRows(projectIncludesFileRelations, (record) => [record.from, record.to])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "references_project_rel.tsv"),
     ["from", "to", "note"],
-    projectReferencesProjectRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(projectReferencesProjectRelations, (record) => [record.from, record.to, record.note])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "uses_resource_rel.tsv"),
     ["from", "to", "note"],
-    usesResourceRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(usesResourceRelations, (record) => [record.from, record.to, record.note])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "uses_setting_rel.tsv"),
     ["from", "to", "note"],
-    usesSettingRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(usesSettingRelations, (record) => [record.from, record.to, record.note])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "uses_config_rel.tsv"),
     ["from", "to", "note"],
-    usesConfigRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(usesConfigRelations, (record) => [record.from, record.to, record.note])
   );
 
   writeTsv(
     path.join(DB_IMPORT_DIR, "transforms_config_rel.tsv"),
     ["from", "to", "note"],
-    configTransformRelations.map((record) => [record.from, record.to, record.note])
+    mapRows(configTransformRelations, (record) => [record.from, record.to, record.note])
   );
+  memoryTrace.checkpoint("writes:db_complete", {
+    tsv_files: 21
+  });
 
   const manifest = {
     generated_at: new Date().toISOString(),
@@ -3403,6 +3714,30 @@ async function main() {
   };
 
   fs.writeFileSync(path.join(CACHE_DIR, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  memoryTrace.checkpoint("writes:manifest_complete", {
+    files: manifest.counts.files,
+    chunks: manifest.counts.chunks,
+    total_relations:
+      manifest.counts.relations_constrains +
+      manifest.counts.relations_implements +
+      manifest.counts.relations_supersedes +
+      manifest.counts.relations_defines +
+      manifest.counts.relations_calls +
+      manifest.counts.relations_imports +
+      manifest.counts.relations_calls_sql +
+      manifest.counts.relations_uses_config_key +
+      manifest.counts.relations_uses_resource_key +
+      manifest.counts.relations_uses_setting_key +
+      manifest.counts.relations_contains +
+      manifest.counts.relations_contains_module +
+      manifest.counts.relations_exports +
+      manifest.counts.relations_includes_file +
+      manifest.counts.relations_references_project +
+      manifest.counts.relations_uses_resource +
+      manifest.counts.relations_uses_setting +
+      manifest.counts.relations_uses_config +
+      manifest.counts.relations_transforms_config
+  });
 
   console.log(`[ingest] mode=${mode}`);
   if (incrementalMode) {

--- a/scaffold/scripts/parsers/javascript/ast.mjs
+++ b/scaffold/scripts/parsers/javascript/ast.mjs
@@ -35,6 +35,8 @@ base.Class = (node, st, visit) => {
 
 const tsNodeHandlers = {
   TSAsExpression(node, st, visit) { visit(node.expression, st); },
+  TSSatisfiesExpression(node, st, visit) { visit(node.expression, st); },
+  TSTypeAssertion(node, st, visit) { visit(node.expression, st); },
   TSTypeAnnotation(node, st, visit) {
     if (node.typeAnnotation) {
       visit(node.typeAnnotation, st);
@@ -63,15 +65,80 @@ const tsNodeHandlers = {
       visit(node.typeParameters, st);
     }
   },
-  TSInterfaceDeclaration() {},
-  TSTypeAliasDeclaration() {},
-  TSEnumDeclaration() {},
+  TSQualifiedName(node, st, visit) {
+    if (node.left) visit(node.left, st);
+    if (node.right) visit(node.right, st);
+  },
+  TSInterfaceDeclaration(node, st, visit) {
+    if (node.extends) {
+      for (const extendedType of node.extends) {
+        visit(extendedType, st);
+      }
+    }
+    if (node.body) {
+      visit(node.body, st);
+    }
+  },
+  TSInterfaceBody(node, st, visit) {
+    for (const member of node.body || []) {
+      visit(member, st);
+    }
+  },
+  TSTypeAliasDeclaration(node, st, visit) {
+    if (node.typeParameters) {
+      visit(node.typeParameters, st);
+    }
+    if (node.typeAnnotation) {
+      visit(node.typeAnnotation, st);
+    }
+  },
+  TSEnumDeclaration(node, st, visit) {
+    for (const member of node.members || []) {
+      visit(member, st);
+    }
+  },
+  TSEnumMember(node, st, visit) {
+    if (node.initializer) {
+      visit(node.initializer, st);
+    }
+  },
   TSModuleDeclaration() {},
   TSDeclareFunction() {},
-  TSPropertySignature() {},
-  TSMethodSignature() {},
-  TSIndexSignature() {},
-  TSTypeLiteral() {},
+  TSPropertySignature(node, st, visit) {
+    if (node.computed && node.key) {
+      visit(node.key, st);
+    }
+    if (node.typeAnnotation) {
+      visit(node.typeAnnotation, st);
+    }
+  },
+  TSMethodSignature(node, st, visit) {
+    if (node.computed && node.key) {
+      visit(node.key, st);
+    }
+    if (node.typeParameters) {
+      visit(node.typeParameters, st);
+    }
+    for (const param of node.params || []) {
+      visit(param, st);
+    }
+    if (node.returnType) {
+      visit(node.returnType, st);
+    }
+  },
+  TSIndexSignature(node, st, visit) {
+    for (const param of node.params || []) {
+      visit(param, st);
+    }
+    if (node.typeAnnotation) {
+      visit(node.typeAnnotation, st);
+    }
+  },
+  TSTypeLiteral(node, st, visit) {
+    for (const member of node.members || node.body || []) {
+      visit(member, st);
+    }
+  },
   TSUnionType(node, st, visit) {
     for (const typeNode of node.types || []) {
       visit(typeNode, st);
@@ -132,8 +199,93 @@ const tsNodeHandlers = {
     }
   },
   TSNonNullExpression(node, st, visit) { visit(node.expression, st); },
-  TSInstantiationExpression(node, st, visit) { visit(node.expression, st); }
+  TSInstantiationExpression(node, st, visit) { visit(node.expression, st); },
+  JSXElement(node, st, visit) {
+    if (node.openingElement) {
+      visit(node.openingElement, st);
+    }
+    for (const child of node.children || []) {
+      visit(child, st);
+    }
+    if (node.closingElement) {
+      visit(node.closingElement, st);
+    }
+  },
+  JSXFragment(node, st, visit) {
+    if (node.openingFragment) {
+      visit(node.openingFragment, st);
+    }
+    for (const child of node.children || []) {
+      visit(child, st);
+    }
+    if (node.closingFragment) {
+      visit(node.closingFragment, st);
+    }
+  },
+  JSXOpeningElement(node, st, visit) {
+    if (node.name) {
+      visit(node.name, st);
+    }
+    for (const attribute of node.attributes || []) {
+      visit(attribute, st);
+    }
+  },
+  JSXClosingElement(node, st, visit) {
+    if (node.name) {
+      visit(node.name, st);
+    }
+  },
+  JSXAttribute(node, st, visit) {
+    if (node.value) {
+      visit(node.value, st);
+    }
+  },
+  JSXExpressionContainer(node, st, visit) {
+    if (node.expression && node.expression.type !== "JSXEmptyExpression") {
+      visit(node.expression, st);
+    }
+  },
+  JSXSpreadAttribute(node, st, visit) {
+    if (node.argument) {
+      visit(node.argument, st);
+    }
+  },
+  JSXMemberExpression(node, st, visit) {
+    if (node.object) {
+      visit(node.object, st);
+    }
+  },
+  JSXNamespacedName(node, st, visit) {
+    if (node.namespace) {
+      visit(node.namespace, st);
+    }
+  }
 };
+
+for (const nodeType of [
+  "JSXClosingFragment",
+  "JSXEmptyExpression",
+  "JSXIdentifier",
+  "JSXOpeningFragment",
+  "JSXText",
+  "TSAnyKeyword",
+  "TSBigIntKeyword",
+  "TSBooleanKeyword",
+  "TSIntrinsicKeyword",
+  "TSNeverKeyword",
+  "TSNullKeyword",
+  "TSNumberKeyword",
+  "TSObjectKeyword",
+  "TSStringKeyword",
+  "TSSymbolKeyword",
+  "TSUndefinedKeyword",
+  "TSUnknownKeyword",
+  "TSVoidKeyword",
+  "TSThisType",
+  "TSLiteralType"
+]) {
+  tsNodeHandlers[nodeType] = () => {};
+}
 
 Object.assign(base, tsNodeHandlers);
 

--- a/scaffold/scripts/parsers/javascript/chunks.mjs
+++ b/scaffold/scripts/parsers/javascript/chunks.mjs
@@ -45,6 +45,18 @@ export function discoverChunks(ast, code, language = "javascript") {
         }
       },
 
+      TSInterfaceDeclaration(node) {
+        pushChunk(extractTypeDeclarationChunk(node, "interface", code));
+      },
+
+      TSTypeAliasDeclaration(node) {
+        pushChunk(extractTypeDeclarationChunk(node, "type", code));
+      },
+
+      TSEnumDeclaration(node) {
+        pushChunk(extractTypeDeclarationChunk(node, "enum", code));
+      },
+
       VariableDeclaration(node) {
         for (const declarator of node.declarations || []) {
           if (!declarator.id || declarator.id.type !== "Identifier" || !declarator.init) {
@@ -95,6 +107,15 @@ function collectExportedNames(ast) {
           if (
             (node.declaration.type === "FunctionDeclaration" ||
               node.declaration.type === "ClassDeclaration") &&
+            node.declaration.id?.name
+          ) {
+            exportedNames.add(node.declaration.id.name);
+          }
+
+          if (
+            (node.declaration.type === "TSInterfaceDeclaration" ||
+              node.declaration.type === "TSTypeAliasDeclaration" ||
+              node.declaration.type === "TSEnumDeclaration") &&
             node.declaration.id?.name
           ) {
             exportedNames.add(node.declaration.id.name);
@@ -292,32 +313,118 @@ function extractClassMethods(classNode, code, language) {
   const className = classNode.id?.name || "UnknownClass";
 
   for (const member of classNode.body.body || []) {
-    if (member.type !== "MethodDefinition" || member.key.type !== "Identifier") {
-      continue;
+    const methodChunk =
+      member.type === "MethodDefinition"
+        ? extractClassMethodChunk(member, className, code, language)
+        : extractClassFieldFunctionChunk(member, className, code, language);
+
+    if (methodChunk) {
+      methods.push(methodChunk);
     }
-
-    const params = (member.value.params || []).map(formatParameterName);
-    const isStatic = member.static === true;
-    const prefix = isStatic ? "static " : "";
-    const bodyStart = findLeadingCommentStart(code, member);
-
-    methods.push({
-      name: `${className}.${member.key.name}`,
-      kind: "method",
-      signature: `${prefix}${member.key.name}(${params.join(", ")})`,
-      body: code.slice(bodyStart, member.end),
-      startLine: member.loc.start.line,
-      endLine: member.loc.end.line,
-      callNode: member.value.body,
-      importNode: member,
-      static: isStatic,
-      async: member.value.async === true,
-      generator: member.value.generator === true,
-      language
-    });
   }
 
   return methods;
+}
+
+function extractClassMethodChunk(member, className, code, language) {
+  const methodName = getPropertyName(member.key, member.computed);
+  if (!methodName) {
+    return null;
+  }
+
+  const params = (member.value.params || []).map(formatParameterName);
+  const isStatic = member.static === true;
+  const prefix = isStatic ? "static " : "";
+  const bodyStart = findLeadingCommentStart(code, member);
+
+  return {
+    name: `${className}.${methodName}`,
+    kind: "method",
+    signature: `${prefix}${methodName}(${params.join(", ")})`,
+    body: code.slice(bodyStart, member.end),
+    startLine: member.loc.start.line,
+    endLine: member.loc.end.line,
+    callNode: member.value.body,
+    importNode: member,
+    static: isStatic,
+    async: member.value.async === true,
+    generator: member.value.generator === true,
+    language
+  };
+}
+
+function extractClassFieldFunctionChunk(member, className, code, language) {
+  if (member.type !== "PropertyDefinition" && member.type !== "FieldDefinition") {
+    return null;
+  }
+
+  const value = member.value;
+  const isFunctionField =
+    value?.type === "FunctionExpression" || value?.type === "ArrowFunctionExpression";
+  if (!isFunctionField) {
+    return null;
+  }
+
+  const fieldName = getPropertyName(member.key, member.computed);
+  if (!fieldName) {
+    return null;
+  }
+
+  const params = (value.params || []).map(formatParameterName);
+  const isStatic = member.static === true;
+  const prefix = isStatic ? "static " : "";
+  const bodyStart = findLeadingCommentStart(code, member);
+
+  return {
+    name: `${className}.${fieldName}`,
+    kind: "method",
+    signature: `${prefix}${fieldName}(${params.join(", ")})`,
+    body: code.slice(bodyStart, member.end),
+    startLine: member.loc.start.line,
+    endLine: member.loc.end.line,
+    callNode: value.body || value,
+    importNode: member,
+    static: isStatic,
+    async: value.async === true,
+    generator: value.generator === true,
+    field: true,
+    language
+  };
+}
+
+function extractTypeDeclarationChunk(node, kind, code) {
+  const name = node.id?.name;
+  if (!name) {
+    return null;
+  }
+
+  const bodyStart = findLeadingCommentStart(code, node);
+  return {
+    name,
+    kind,
+    signature: `${kind} ${name}`,
+    body: code.slice(bodyStart, node.end),
+    startLine: node.loc.start.line,
+    endLine: node.loc.end.line,
+    callNode: node,
+    importNode: node
+  };
+}
+
+function getPropertyName(key, computed = false) {
+  if (!key) {
+    return null;
+  }
+
+  if (!computed && key.type === "Identifier") {
+    return key.name;
+  }
+
+  if (key.type === "Literal" && typeof key.value === "string") {
+    return key.value;
+  }
+
+  return null;
 }
 
 function findLeadingCommentStart(code, node) {

--- a/scaffold/scripts/parsers/javascript/imports.mjs
+++ b/scaffold/scripts/parsers/javascript/imports.mjs
@@ -103,16 +103,17 @@ function extractReferencedStaticImportSources(bodyNode, bindings) {
     fullAncestor(
       bodyNode,
       (node, state, ancestors) => {
-        if (node.type !== "Identifier") {
+        const localName = getReferencedImportName(node, ancestors);
+        if (!localName) {
           return;
         }
 
-        const source = importsByLocalName.get(node.name);
-        if (!source || !isReferenceIdentifier(node, ancestors)) {
+        const source = importsByLocalName.get(localName);
+        if (!source) {
           return;
         }
 
-        if (resolveIdentifier(node.name, ancestors, scopeGraph)) {
+        if (resolveIdentifier(localName, ancestors, scopeGraph)) {
           return;
         }
 
@@ -125,6 +126,39 @@ function extractReferencedStaticImportSources(bodyNode, bindings) {
   }
 
   return [...sources].sort();
+}
+
+function getReferencedImportName(node, ancestors) {
+  if (node.type === "Identifier") {
+    return isReferenceIdentifier(node, ancestors) ? node.name : null;
+  }
+
+  if (node.type !== "JSXIdentifier" || isIntrinsicJsxName(node.name)) {
+    return null;
+  }
+
+  const parent = ancestors[ancestors.length - 2] ?? null;
+  if (!parent) {
+    return null;
+  }
+
+  if (parent.type === "JSXOpeningElement" && parent.name === node) {
+    return node.name;
+  }
+
+  if (parent.type === "JSXMemberExpression" && parent.object === node) {
+    return node.name;
+  }
+
+  if (parent.type === "JSXNamespacedName" && parent.namespace === node) {
+    return node.name;
+  }
+
+  return null;
+}
+
+function isIntrinsicJsxName(name) {
+  return /^[a-z]/.test(name);
 }
 
 function extractDynamicImports(bodyNode) {

--- a/tests/bootstrapbench-aggregate.test.mjs
+++ b/tests/bootstrapbench-aggregate.test.mjs
@@ -71,6 +71,16 @@ function sampleItem(overrides = {}) {
       by_entity_type: { Chunk: lineValues.length, File: 120 },
       throughput_per_s: 10
     },
+    memory: {
+      max_rss_kb: 512_000,
+      max_rss_mb: 500,
+      max_phase: "embed",
+      sample_count: 5,
+      by_phase: {
+        ingest: { max_rss_kb: 256_000, max_rss_mb: 250, samples: 2 },
+        embed: { max_rss_kb: 512_000, max_rss_mb: 500, samples: 3 }
+      }
+    },
     graph: {
       nodes: { files: 120, chunks: lineValues.length, rules: 1, adrs: 0, modules: 0, projects: 0 },
       edges: { total: 50, by_type: { CALLS: 20, DEFINES: 25, IMPORTS: 5 } },
@@ -82,6 +92,31 @@ function sampleItem(overrides = {}) {
         isolated_pct: 33.3,
         degree: { count: lineValues.length, histogram: [] },
         top_connected: []
+      }
+    },
+    diagnostics: {
+      coverage: {
+        counts: {
+          candidate_files: 130,
+          indexed_files: 120,
+          chunks: lineValues.length,
+          text_supported_files: 125,
+          parser_supported_files: 100,
+          text_supported_no_parser_files: 25,
+          unsupported_files: 5,
+          too_large_files: 0,
+          binary_files: 0
+        },
+        skipped: {
+          by_extension: {
+            unsupported: { ".html": 3, ".css": 2 },
+            too_large: {},
+            binary: {}
+          }
+        },
+        parser_eligibility: {
+          text_supported_no_parser_by_extension: { ".json": 20, ".yaml": 5 }
+        }
       }
     }
   };
@@ -112,6 +147,16 @@ test("aggregateResults: sums totals across successful items and tracks failures"
   assert.equal(summary.totals.tracked_lines, 80_000);
   assert.equal(summary.repo_rows[0].indexed_lines, 25_000);
   assert.equal(summary.repo_rows[0].tracked_lines, 40_000);
+  assert.equal(summary.coverage_diagnostics.counts.unsupported_files, 10);
+  assert.equal(summary.coverage_diagnostics.skipped_by_extension.unsupported[".html"], 6);
+  assert.equal(summary.coverage_diagnostics.parser_eligibility.text_supported_no_parser_by_extension[".json"], 40);
+  assert.equal(summary.repo_rows[0].unsupported_files, 5);
+  assert.equal(summary.repo_rows[0].max_rss_kb, 512_000);
+  assert.equal(summary.repo_rows[0].max_rss_phase, "embed");
+  assert.equal(summary.memory.max_rss_kb, 512_000);
+  assert.equal(summary.memory.max_repo, "iamkun__dayjs");
+  assert.equal(summary.memory.by_phase.embed.max_rss_kb, 512_000);
+  assert.deepEqual(summary.repo_rows[0].top_unsupported_extensions[0], { extension: ".html", count: 3 });
 
   const model = summary.by_model["Xenova/all-MiniLM-L6-v2"];
   assert.equal(model.items, 2);

--- a/tests/bootstrapbench-stats.test.mjs
+++ b/tests/bootstrapbench-stats.test.mjs
@@ -6,15 +6,23 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { collectWorkspaceCandidates } from "../benchmark/bootstrapbench/extract-stats.mjs";
 import {
   buildHistogram,
   CHUNK_CHAR_BUCKETS,
   CHUNK_LINE_BUCKETS,
   computeChunkStats,
+  computeCoverageDiagnostics,
   computeGraphStats,
+  detectBootstrapPhase,
   mergeHistograms,
   parseBootstrapTimings,
   percentile,
+  summarizeBootstrapMemory,
   summarizeDistribution
 } from "../benchmark/bootstrapbench/stats.mjs";
 
@@ -158,6 +166,69 @@ test("computeChunkStats: empty input returns zeroed shape", () => {
   assert.deepEqual(stats.by_language, {});
 });
 
+// ─── coverage diagnostics ───────────────────────────────────────────────────
+
+test("computeCoverageDiagnostics: exposes skipped extensions and parser gaps", () => {
+  const diagnostics = computeCoverageDiagnostics({
+    candidateFiles: [
+      { path: "src/app.ts" },
+      { path: "src/component.tsx" },
+      { path: "src/module.mts" },
+      { path: "src/template.html" },
+      { path: "src/styles.css" },
+      { path: "README.md" },
+      { path: "data/schema.json" },
+      { path: "assets/logo.png" },
+      { path: "docs/huge.txt", too_large: true },
+      { path: "docs/nulls.txt", binary: true }
+    ],
+    indexedDocuments: [
+      { id: "file:src/app.ts", path: "src/app.ts" },
+      { id: "file:src/component.tsx", path: "src/component.tsx" },
+      { id: "file:src/module.mts", path: "src/module.mts" },
+      { id: "file:README.md", path: "README.md" },
+      { id: "file:data/schema.json", path: "data/schema.json" }
+    ],
+    chunkRecords: [
+      { id: "chunk:a", file_id: "file:src/app.ts" },
+      { id: "chunk:b", file_id: "file:src/app.ts" },
+      { id: "chunk:mts", file_id: "file:src/module.mts" },
+      { id: "chunk:readme", file_id: "file:README.md" }
+    ],
+    ingestSkipped: { unsupported: 3, tooLarge: 1, binary: 1 }
+  });
+
+  assert.equal(diagnostics.counts.candidate_files, 10);
+  assert.equal(diagnostics.counts.unsupported_files, 3);
+  assert.equal(diagnostics.skipped.by_extension.unsupported[".html"], 1);
+  assert.equal(diagnostics.skipped.by_extension.unsupported[".css"], 1);
+  assert.equal(diagnostics.skipped.by_extension.unsupported[".png"], 1);
+  assert.equal(diagnostics.skipped.by_extension.too_large[".txt"], 1);
+  assert.equal(diagnostics.skipped.by_extension.binary[".txt"], 1);
+  assert.equal(diagnostics.parser_eligibility.by_extension[".tsx"].parser_supported, true);
+  assert.equal(diagnostics.parser_eligibility.by_extension[".tsx"].text_supported_no_parser, false);
+  assert.equal(diagnostics.parser_eligibility.by_extension[".tsx"].indexed_files, 1);
+  assert.equal(diagnostics.parser_eligibility.by_extension[".tsx"].chunks, 0);
+  assert.equal(diagnostics.parser_eligibility.by_extension[".mts"].parser_supported, true);
+  assert.equal(diagnostics.parser_eligibility.by_extension[".mts"].chunks, 1);
+  assert.equal(diagnostics.parser_eligibility.text_supported_no_parser_by_extension[".json"], 1);
+  assert.deepEqual(diagnostics.skipped.ingest_totals, { unsupported: 3, tooLarge: 1, binary: 1 });
+});
+
+test("collectWorkspaceCandidates: de-duplicates overlapping source paths", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-bootstrapbench-extract-"));
+  fs.mkdirSync(path.join(tempRoot, "src", "nested"), { recursive: true });
+  fs.writeFileSync(path.join(tempRoot, "src", "app.ts"), "export const app = 1;\n");
+  fs.writeFileSync(path.join(tempRoot, "src", "nested", "feature.ts"), "export const feature = 1;\n");
+
+  const candidates = collectWorkspaceCandidates(tempRoot, ["src", "src/nested"]);
+
+  assert.deepEqual(
+    candidates.map((candidate) => candidate.path),
+    ["src/app.ts", "src/nested/feature.ts"]
+  );
+});
+
 // ─── graph stats ─────────────────────────────────────────────────────────────
 
 test("computeGraphStats: relation totals and chunk connectivity", () => {
@@ -221,6 +292,34 @@ test("parseBootstrapTimings: returns nulls when markers are missing", () => {
   const timings = parseBootstrapTimings([{ ts: 5, text: "unrelated" }]);
   assert.equal(timings.deps, null);
   assert.equal(timings.total, null);
+});
+
+test("detectBootstrapPhase: maps bootstrap marker lines to phase keys", () => {
+  assert.equal(detectBootstrapPhase("[cortex][2/6] Indexing repository context"), "ingest");
+  assert.equal(detectBootstrapPhase("[cortex][4/6] Loading RyuGraph"), "graph_load");
+  assert.equal(detectBootstrapPhase("unrelated"), null);
+});
+
+test("summarizeBootstrapMemory: reports total and per-phase peak RSS", () => {
+  const summary = summarizeBootstrapMemory([
+    { ts: 1000, phase: "ingest", rss_kb: 100_000 },
+    { ts: 1500, phase: "embed", rss_kb: 250_000 },
+    { ts: 2000, phase: "embed", rss_kb: 200_000 },
+    { ts: 2500, phase: "graph_load", rss_kb: 300_000 }
+  ]);
+
+  assert.equal(summary.max_rss_kb, 300_000);
+  assert.equal(summary.max_rss_mb, 292.97);
+  assert.equal(summary.max_phase, "graph_load");
+  assert.equal(summary.sample_count, 4);
+  assert.equal(summary.duration_ms, 1500);
+  assert.equal(summary.by_phase.ingest.max_rss_kb, 100_000);
+  assert.equal(summary.by_phase.embed.max_rss_kb, 250_000);
+});
+
+test("summarizeBootstrapMemory: empty or invalid samples yield null", () => {
+  assert.equal(summarizeBootstrapMemory([]), null);
+  assert.equal(summarizeBootstrapMemory([{ phase: "ingest", rss_kb: "nope" }]), null);
 });
 
 // Buckets are exported so the frontend adapter and tests agree on shape.

--- a/tests/ingest-memory-trace.test.mjs
+++ b/tests/ingest-memory-trace.test.mjs
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const INGEST = path.join(REPO_ROOT, "scaffold", "scripts", "ingest.mjs");
+
+function writeFixture(root) {
+  fs.mkdirSync(path.join(root, ".context"), { recursive: true });
+  fs.mkdirSync(path.join(root, "src"), { recursive: true });
+  fs.writeFileSync(path.join(root, ".context", "config.yaml"), "repo_id: fixture\nsource_paths:\n  - src\n", "utf8");
+  fs.writeFileSync(
+    path.join(root, ".context", "rules.yaml"),
+    [
+      "rules:",
+      "  - id: rule.trace",
+      "    description: Trace rule references application source",
+      "    priority: 10",
+      "    enforce: true",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(root, "src", "app.js"),
+    [
+      "export function runTrace(value) {",
+      "  // rule.trace",
+      "  return helperTrace(value);",
+      "}",
+      "function helperTrace(value) {",
+      "  return value + 1;",
+      "}",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+}
+
+function runIngest(root, extraEnv = {}) {
+  const env = {
+    ...process.env,
+    CORTEX_PROJECT_ROOT: root,
+    CORTEX_INGEST_WORKERS: "0",
+    ...extraEnv
+  };
+  if (!Object.prototype.hasOwnProperty.call(extraEnv, "CORTEX_INGEST_TRACE_MEMORY")) {
+    delete env.CORTEX_INGEST_TRACE_MEMORY;
+  }
+
+  return spawnSync(process.execPath, [INGEST], {
+    cwd: root,
+    env,
+    encoding: "utf8"
+  });
+}
+
+test("ingest memory trace is opt-in and emits checkpoint JSON lines", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-ingest-trace-"));
+  try {
+    writeFixture(root);
+
+    const normal = runIngest(root);
+    assert.equal(normal.status, 0, normal.stderr);
+    assert.equal(normal.stderr, "", "normal ingest should not emit memory trace stderr");
+    assert.match(normal.stdout, /^\[ingest\] mode=full/m);
+
+    const traced = runIngest(root, { CORTEX_INGEST_TRACE_MEMORY: "1" });
+    assert.equal(traced.status, 0, traced.stderr);
+    assert.match(traced.stdout, /^\[ingest\] mode=full/m);
+
+    const records = traced.stderr
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert.ok(records.length >= 8, "expected multiple memory checkpoints");
+    assert.ok(records.every((record) => record.type === "cortex.ingest.memory"));
+    assert.ok(records.every((record) => Number.isInteger(record.rss_bytes) && record.rss_bytes > 0));
+
+    const labels = new Set(records.map((record) => record.label));
+    for (const label of [
+      "scan:file_records",
+      "hydration:complete",
+      "parse:workers_complete",
+      "parse:merge_complete",
+      "materialize:chunks_relations",
+      "materialize:modules_projects_relations",
+      "tokens:rule_matching_complete",
+      "writes:manifest_complete"
+    ]) {
+      assert.ok(labels.has(label), `missing checkpoint ${label}`);
+    }
+
+    const scanRecord = records.find((record) => record.label === "scan:file_records");
+    assert.equal(scanRecord.counts.files, 1);
+    assert.equal(scanRecord.counts.skipped_unsupported, 0);
+
+    const writeRecord = records.find((record) => record.label === "writes:manifest_complete");
+    assert.equal(writeRecord.counts.files, 1);
+    assert.ok(writeRecord.counts.chunks >= 1);
+    assert.ok(writeRecord.counts.total_relations >= 1);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/ingest-parallel.test.mjs
+++ b/tests/ingest-parallel.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -50,23 +50,43 @@ function writeFixture(root) {
   return count;
 }
 
-function runIngest(root, workers) {
-  execFileSync("node", [INGEST], {
+function runIngest(root, workers, extraEnv = {}) {
+  const env = {
+    ...process.env,
+    CORTEX_PROJECT_ROOT: root,
+    CORTEX_INGEST_WORKERS: String(workers),
+    ...extraEnv
+  };
+  if (!Object.prototype.hasOwnProperty.call(extraEnv, "CORTEX_INGEST_TRACE_MEMORY")) {
+    delete env.CORTEX_INGEST_TRACE_MEMORY;
+  }
+  const result = spawnSync(process.execPath, [INGEST], {
     cwd: root,
-    env: { ...process.env, CORTEX_PROJECT_ROOT: root, CORTEX_INGEST_WORKERS: String(workers) },
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"]
+    env,
+    encoding: "utf8"
   });
+  assert.equal(result.status, 0, result.stderr);
+  return result;
 }
 
-function readCache(root) {
-  const cacheDir = path.join(root, ".context", "cache");
+function readOutputFiles(root) {
+  const roots = [
+    path.join(root, ".context", "cache"),
+    path.join(root, ".context", "db", "import")
+  ];
   const out = {};
-  for (const name of fs.readdirSync(cacheDir).sort()) {
-    if (!name.endsWith(".jsonl")) continue;
-    out[name] = fs.readFileSync(path.join(cacheDir, name), "utf8");
+  for (const dir of roots) {
+    for (const name of fs.readdirSync(dir).sort()) {
+      if (!name.endsWith(".jsonl") && !name.endsWith(".tsv")) continue;
+      const rel = toPosix(path.relative(root, path.join(dir, name)));
+      out[rel] = fs.readFileSync(path.join(dir, name), "utf8");
+    }
   }
   return out;
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join("/");
 }
 
 test("parallel ingest produces byte-identical cache output to sequential", () => {
@@ -83,10 +103,10 @@ test("parallel ingest produces byte-identical cache output to sequential", () =>
     assert.ok(seqCount >= 50, `fixture should exceed the worker threshold (got ${seqCount})`);
 
     runIngest(seqRoot, 0); // sequential
-    runIngest(parRoot, 4); // 4-worker pool
+    const parallelRun = runIngest(parRoot, 4, { CORTEX_INGEST_TRACE_MEMORY: "1" }); // 4-worker pool
 
-    const seqCache = readCache(seqRoot);
-    const parCache = readCache(parRoot);
+    const seqCache = readOutputFiles(seqRoot);
+    const parCache = readOutputFiles(parRoot);
 
     assert.deepEqual(
       Object.keys(parCache).sort(),
@@ -98,8 +118,20 @@ test("parallel ingest produces byte-identical cache output to sequential", () =>
     }
 
     // Sanity: chunks were actually produced (parsers ran, not all-empty).
-    const chunks = seqCache["entities.chunk.jsonl"] ?? "";
+    const chunks = seqCache[".context/cache/entities.chunk.jsonl"] ?? "";
     assert.ok(chunks.trim().length > 0, "expected chunk entities to be produced");
+
+    const traceRecords = parallelRun.stderr
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    const workersComplete = traceRecords.find((record) => record.label === "parse:workers_complete");
+    assert.ok(workersComplete, "expected parse:workers_complete trace");
+    assert.equal(workersComplete.counts.worker_results_retained, 0);
+    assert.equal(workersComplete.counts.worker_results_pending, 0);
+    assert.ok(workersComplete.counts.worker_results_retained_peak >= 0);
+    assert.ok(workersComplete.counts.worker_results_consumed > 0, "parallel worker results should be consumed");
   } finally {
     fs.rmSync(base, { recursive: true, force: true });
   }

--- a/tests/ingest-units.test.mjs
+++ b/tests/ingest-units.test.mjs
@@ -46,7 +46,11 @@ test("detectKind: treats legacy .NET project and config files as DOC metadata fo
 
 test("getChunkParserForExtension: only dispatches current chunk-capable languages", () => {
   assert.equal(getChunkParserForExtension(".ts")?.language, "typescript");
+  assert.equal(getChunkParserForExtension(".tsx")?.language, "tsx");
+  assert.equal(getChunkParserForExtension(".mts")?.language, "typescript");
+  assert.equal(getChunkParserForExtension(".cts")?.language, "typescript");
   assert.equal(getChunkParserForExtension(".js")?.language, "javascript");
+  assert.equal(getChunkParserForExtension(".jsx")?.language, "jsx");
   assert.equal(getChunkParserForExtension(".vb")?.language, "vbnet");
   assert.equal(getChunkParserForExtension(".sql")?.language, "sql");
   assert.equal(getChunkParserForExtension(".config")?.language, "config");

--- a/tests/javascript-parser.test.mjs
+++ b/tests/javascript-parser.test.mjs
@@ -98,3 +98,105 @@ test("parseCode includes leading line comments for const function chunks", () =>
 
   assert.match(body, /^\/\/ Shared helper for retries\nconst retry =/);
 });
+
+test("parseCode extracts TypeScript declaration chunks", () => {
+  const source = [
+    "import {Base} from './base';",
+    "export interface User extends Base {",
+    "  name: string;",
+    "}",
+    "export type UserId = string | number;",
+    "export enum UserKind {",
+    "  Admin = 'admin'",
+    "}"
+  ].join("\n");
+
+  const chunks = parseCode(source, "fixture.ts", "typescript").chunks;
+  const chunkByName = new Map(chunks.map((chunk) => [chunk.name, chunk]));
+
+  assert.equal(chunkByName.get("User")?.kind, "interface");
+  assert.equal(chunkByName.get("User")?.exported, true);
+  assert.equal(chunkByName.get("UserId")?.kind, "type");
+  assert.equal(chunkByName.get("UserId")?.exported, true);
+  assert.equal(chunkByName.get("UserKind")?.kind, "enum");
+  assert.equal(chunkByName.get("UserKind")?.exported, true);
+});
+
+test("parseCode tracks imports inside TypeScript declaration member types", () => {
+  const source = [
+    "import { Owner } from './owner';",
+    "export interface User {",
+    "  owner: Owner;",
+    "}",
+    "export type Box = {",
+    "  value: Owner;",
+    "};"
+  ].join("\n");
+
+  const chunks = parseCode(source, "fixture.ts", "typescript").chunks;
+  const chunkByName = new Map(chunks.map((chunk) => [chunk.name, chunk]));
+
+  assert.deepEqual(chunkByName.get("User")?.imports, ["./owner"]);
+  assert.deepEqual(chunkByName.get("Box")?.imports, ["./owner"]);
+});
+
+test("parseCode extracts class-field function chunks", () => {
+  const source = [
+    "class UserCard {",
+    "  load = () => fetchUser();",
+    "  static create = function() { return makeUser(); };",
+    "}",
+    "function fetchUser() { return null; }",
+    "function makeUser() { return null; }"
+  ].join("\n");
+
+  const chunks = parseCode(source, "fixture.ts", "typescript").chunks;
+  const chunkByName = new Map(chunks.map((chunk) => [chunk.name, chunk]));
+
+  assert.equal(chunkByName.get("UserCard.load")?.kind, "method");
+  assert.equal(chunkByName.get("UserCard.load")?.field, true);
+  assert.deepEqual(chunkByName.get("UserCard.load")?.calls, ["fetchUser"]);
+  assert.equal(chunkByName.get("UserCard.create")?.static, true);
+  assert.deepEqual(chunkByName.get("UserCard.create")?.calls, ["makeUser"]);
+});
+
+test("parseCode walks TypeScript keyword nodes without dropping chunks", () => {
+  const source = [
+    "export function normalize(value: any): unknown {",
+    "  return value as string;",
+    "}"
+  ].join("\n");
+
+  const result = parseCode(source, "fixture.ts", "typescript");
+
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.chunks.find((chunk) => chunk.name === "normalize")?.kind, "function");
+});
+
+test("parseCode handles TSX without walker crashes", () => {
+  const source = [
+    "export function UserView() {",
+    "  return <section>{name}</section>;",
+    "}"
+  ].join("\n");
+
+  const result = parseCode(source, "fixture.tsx", "tsx");
+
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.chunks.find((chunk) => chunk.name === "UserView")?.kind, "function");
+});
+
+test("parseCode walks JSX markup for calls and imported component references", () => {
+  const source = [
+    "import { Button } from './button';",
+    "import { format } from './format';",
+    "export function UserView({ name }) {",
+    "  return <Button label={format(name)} />;",
+    "}"
+  ].join("\n");
+
+  const chunk = parseCode(source, "fixture.tsx", "tsx").chunks.find((entry) => entry.name === "UserView");
+
+  assert.deepEqual(chunk?.calls, ["format"]);
+  assert.deepEqual(chunk?.imports, ["./button", "./format"]);
+});


### PR DESCRIPTION
## Summary

This PR bundles the Angular bootstrap quality fixes and the memory/RSS first pass that were validated together:

- add JSX/TSX/MTS/CTS parser and ingest coverage for Angular-style repos
- preserve JSX expression/component dependencies and TypeScript declaration member imports
- add declaration/class-field chunk extraction improvements
- add bootstrapbench coverage diagnostics and RSS aggregation
- stream graph CSV rows, embedding JSONL reads/writes, and ingest JSONL/TSV output
- avoid sending full file content to ingest workers
- add opt-in `CORTEX_INGEST_TRACE_MEMORY` checkpoints
- consume ingest worker parse results through a streaming path while preserving deterministic merge order

Stale perf branches were not merged. `origin/perf/embed-scheduler` is already contained by `main`; `origin/perf/bootstrap-stage-optimizations` is stale/superseded.

## Validation

- `node --test tests/bootstrapbench-stats.test.mjs tests/bootstrapbench-aggregate.test.mjs` passed 33/33
- `npm test` in `scaffold/mcp` passed 319/319
- focused ingest/bootstrapbench tests passed 79/79
- focused ingest tests after worker streaming passed 47/47
- full root `npm test` passed 193/193
- `git diff --check` passed
- `cortex update` and MCP reload completed

## Benchmark Evidence

`memory-rss-2026-06-16`:
- Cortex: 611.27 MB peak RSS, phase `embed`
- Angular: 1221.68 MB peak RSS, phase `ingest`

`memory-rss-trace-2026-06-16`:
- Cortex: 614.94 MB peak RSS, phase `embed`
- Angular: 1359.15 MB peak RSS, phase `ingest`
- Angular trace before worker streaming retained 7294 worker results at `parse:workers_complete`

`memory-rss-stream-2026-06-16`:
- Cortex: 609.57 MB peak RSS, phase `embed`
- Angular: 1373.12 MB peak RSS, phase `ingest`
- Angular trace after worker streaming: `worker_results_retained=0`, retained peak 436, consumed 7294

Angular semantic/resource quality is intentionally deferred to a later PR.
