### PR TITLE
Fix .NET parser publish on macOS apphost signing

### DIFF
--- a/scaffold/scripts/parsers/csharp.mjs
+++ b/scaffold/scripts/parsers/csharp.mjs
@@ -173,7 +173,8 @@ export function ensureCSharpParserPublished() {
       "-c", "Release",
       "-o", getPublishDir(),
       "--nologo",
-      "-v", "quiet"
+      "-v", "quiet",
+      "/p:UseAppHost=false"
     ],
     { encoding: "utf8", timeout: 180000 }
   );

--- a/scaffold/scripts/parsers/vbnet.mjs
+++ b/scaffold/scripts/parsers/vbnet.mjs
@@ -146,7 +146,8 @@ export function ensureVbNetParserPublished() {
       "-c", "Release",
       "-o", getPublishDir(),
       "--nologo",
-      "-v", "quiet"
+      "-v", "quiet",
+      "/p:UseAppHost=false"
     ],
     { encoding: "utf8", timeout: 180000 }
   );


### PR DESCRIPTION
## Summary

Publish the C# and VB.NET parser bridges with `/p:UseAppHost=false`.

The bridges are executed as `dotnet <dll>`, so a native apphost is unnecessary. On this macOS setup, first-use publish failed with `NETSDK1177` while trying to sign the generated apphost. Disabling apphost generation avoids that failure without changing parser runtime behavior.

This is intentionally separate from the Angular/memory PR so the optional .NET parser toolchain fix can be reviewed independently.

## Validation

- `node --check scaffold/scripts/parsers/csharp.mjs`
- `node --check scaffold/scripts/parsers/vbnet.mjs`
- `node --test tests/csharp-parser.test.mjs tests/vbnet-parser.test.mjs` passed 25/25
