### PR TITLE
Reduce ingest rule matching token retention

### DIFF
--- a/scaffold/scripts/ingest.mjs
+++ b/scaffold/scripts/ingest.mjs
@@ -2056,6 +2056,27 @@ function fileTokenSet(fileRecord) {
   return new Set(tokenizeKeywords(tokenSource));
 }
 
+function collectRuleKeywordMatch(ruleKeywords, tokens, minimumMatches) {
+  const required = Math.min(minimumMatches, Math.max(1, ruleKeywords.length));
+  let count = 0;
+  const sample = [];
+
+  for (const keyword of ruleKeywords) {
+    if (!tokens.has(keyword)) {
+      continue;
+    }
+    count += 1;
+    if (sample.length < 5) {
+      sample.push(keyword);
+    }
+    if (count >= required && sample.length >= 5) {
+      break;
+    }
+  }
+
+  return { matched: count >= required, sample };
+}
+
 function chunkIdFor(filePath, chunk) {
   const startLine = Number.isFinite(chunk.startLine) ? chunk.startLine : 0;
   const endLine = Number.isFinite(chunk.endLine) ? chunk.endLine : startLine;
@@ -3331,59 +3352,84 @@ async function main() {
 
   const constrainsRelations = [];
   const implementsRelations = [];
-  const constrainsSeen = new Set();
-  const implementsSeen = new Set();
   memoryTrace.checkpoint("tokens:rule_matching_start", {
     files: fileRecords.length,
     rules: ruleRecords.length
   });
-  const tokenByFileId = new Map(fileRecords.map((fileRecord) => [fileRecord.id, fileTokenSet(fileRecord)]));
 
-  for (const ruleRecord of ruleRecords) {
-    const needle = ruleRecord.id.toLowerCase();
-    const ruleKeywords = normalizeRuleTokens(ruleRecord);
+  const ruleMatchers = ruleRecords.map((ruleRecord) => ({
+    ruleRecord,
+    needle: ruleRecord.id.toLowerCase(),
+    keywords: normalizeRuleTokens(ruleRecord)
+  }));
+  const constrainsByKey = new Map();
+  const implementsByKey = new Map();
+  let fileTokenSetsProcessed = 0;
 
-    for (const fileRecord of fileRecords) {
-      const lower = fileRecord.content.toLowerCase();
+  for (const fileRecord of fileRecords) {
+    const lower = fileRecord.content.toLowerCase();
+    const tokens = fileTokenSet(fileRecord);
+    fileTokenSetsProcessed += 1;
+
+    for (const { ruleRecord, needle, keywords } of ruleMatchers) {
       const explicitMention = lower.includes(needle);
-      const tokens = tokenByFileId.get(fileRecord.id) ?? new Set();
-      const matchedKeywords = ruleKeywords.filter((keyword) => tokens.has(keyword));
       const minimumMatches = fileRecord.kind === "CODE" ? 1 : 2;
-      const keywordMatch = matchedKeywords.length >= Math.min(minimumMatches, Math.max(1, ruleKeywords.length));
+      const keywordResult = explicitMention
+        ? { matched: false, sample: [] }
+        : collectRuleKeywordMatch(keywords, tokens, minimumMatches);
 
-      if (!explicitMention && !keywordMatch) {
+      if (!explicitMention && !keywordResult.matched) {
         continue;
       }
 
       const constrainsKey = `${ruleRecord.id}|${fileRecord.id}`;
-      if (!constrainsSeen.has(constrainsKey)) {
-        constrainsSeen.add(constrainsKey);
-        constrainsRelations.push({
+      if (!constrainsByKey.has(constrainsKey)) {
+        constrainsByKey.set(constrainsKey, {
           from: ruleRecord.id,
           to: fileRecord.id,
           note: explicitMention
             ? `Mentions ${ruleRecord.id}`
-            : `Keyword match ${matchedKeywords.slice(0, 5).join(", ")}`
+            : `Keyword match ${keywordResult.sample.join(", ")}`
         });
       }
 
       if (fileRecord.kind === "CODE") {
         const implementsKey = `${fileRecord.id}|${ruleRecord.id}`;
-        if (!implementsSeen.has(implementsKey)) {
-          implementsSeen.add(implementsKey);
-          implementsRelations.push({
+        if (!implementsByKey.has(implementsKey)) {
+          implementsByKey.set(implementsKey, {
             from: fileRecord.id,
             to: ruleRecord.id,
             note: explicitMention
               ? `Code references ${ruleRecord.id}`
-              : `Code keywords ${matchedKeywords.slice(0, 5).join(", ")}`
+              : `Code keywords ${keywordResult.sample.join(", ")}`
           });
         }
       }
     }
   }
+
+  for (const { ruleRecord } of ruleMatchers) {
+    for (const fileRecord of fileRecords) {
+      const constrainsKey = `${ruleRecord.id}|${fileRecord.id}`;
+      const constrainsRelation = constrainsByKey.get(constrainsKey);
+      if (constrainsRelation) {
+        constrainsRelations.push(constrainsRelation);
+        constrainsByKey.delete(constrainsKey);
+      }
+      if (fileRecord.kind === "CODE") {
+        const implementsKey = `${fileRecord.id}|${ruleRecord.id}`;
+        const implementsRelation = implementsByKey.get(implementsKey);
+        if (implementsRelation) {
+          implementsRelations.push(implementsRelation);
+          implementsByKey.delete(implementsKey);
+        }
+      }
+    }
+  }
+
   memoryTrace.checkpoint("tokens:rule_matching_complete", {
-    file_token_sets: tokenByFileId.size,
+    file_token_sets: fileTokenSetsProcessed,
+    file_token_sets_retained: 0,
     rules: ruleRecords.length,
     relations_constrains: constrainsRelations.length,
     relations_implements: implementsRelations.length,

--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -2328,6 +2328,27 @@ function fileTokenSet(fileRecord) {
   return new Set(tokenizeKeywords(tokenSource));
 }
 
+function collectRuleKeywordMatch(ruleKeywords, tokens, minimumMatches) {
+  const required = Math.min(minimumMatches, Math.max(1, ruleKeywords.length));
+  let count = 0;
+  const sample = [];
+
+  for (const keyword of ruleKeywords) {
+    if (!tokens.has(keyword)) {
+      continue;
+    }
+    count += 1;
+    if (sample.length < 5) {
+      sample.push(keyword);
+    }
+    if (count >= required && sample.length >= 5) {
+      break;
+    }
+  }
+
+  return { matched: count >= required, sample };
+}
+
 function chunkIdFor(filePath, chunk) {
   const startLine = Number.isFinite(chunk.startLine) ? chunk.startLine : 0;
   const endLine = Number.isFinite(chunk.endLine) ? chunk.endLine : startLine;
@@ -3207,52 +3228,70 @@ async function main() {
 
   const constrainsRelations = [];
   const implementsRelations = [];
-  const constrainsSeen = new Set();
-  const implementsSeen = new Set();
-  const lowerContentByFileId = new Map(
-    fileRecords.map((fileRecord) => [fileRecord.id, fileRecord.content.toLowerCase()])
-  );
-  const tokenByFileId = new Map(fileRecords.map((fileRecord) => [fileRecord.id, fileTokenSet(fileRecord)]));
 
-  for (const ruleRecord of ruleRecords) {
-    const needle = ruleRecord.id.toLowerCase();
-    const ruleKeywords = normalizeRuleTokens(ruleRecord);
+  const ruleMatchers = ruleRecords.map((ruleRecord) => ({
+    ruleRecord,
+    needle: ruleRecord.id.toLowerCase(),
+    keywords: normalizeRuleTokens(ruleRecord)
+  }));
+  const constrainsByKey = new Map();
+  const implementsByKey = new Map();
 
-    for (const fileRecord of fileRecords) {
-      const lower = lowerContentByFileId.get(fileRecord.id) ?? "";
+  for (const fileRecord of fileRecords) {
+    const lower = fileRecord.content.toLowerCase();
+    const tokens = fileTokenSet(fileRecord);
+
+    for (const { ruleRecord, needle, keywords } of ruleMatchers) {
       const explicitMention = lower.includes(needle);
-      const tokens = tokenByFileId.get(fileRecord.id) ?? new Set();
-      const matchedKeywords = ruleKeywords.filter((keyword) => tokens.has(keyword));
       const minimumMatches = fileRecord.kind === "CODE" ? 1 : 2;
-      const keywordMatch = matchedKeywords.length >= Math.min(minimumMatches, Math.max(1, ruleKeywords.length));
+      const keywordResult = explicitMention
+        ? { matched: false, sample: [] }
+        : collectRuleKeywordMatch(keywords, tokens, minimumMatches);
 
-      if (!explicitMention && !keywordMatch) {
+      if (!explicitMention && !keywordResult.matched) {
         continue;
       }
 
       const constrainsKey = `${ruleRecord.id}|${fileRecord.id}`;
-      if (!constrainsSeen.has(constrainsKey)) {
-        constrainsSeen.add(constrainsKey);
-        constrainsRelations.push({
+      if (!constrainsByKey.has(constrainsKey)) {
+        constrainsByKey.set(constrainsKey, {
           from: ruleRecord.id,
           to: fileRecord.id,
           note: explicitMention
             ? `Mentions ${ruleRecord.id}`
-            : `Keyword match ${matchedKeywords.slice(0, 5).join(", ")}`
+            : `Keyword match ${keywordResult.sample.join(", ")}`
         });
       }
 
       if (fileRecord.kind === "CODE") {
         const implementsKey = `${fileRecord.id}|${ruleRecord.id}`;
-        if (!implementsSeen.has(implementsKey)) {
-          implementsSeen.add(implementsKey);
-          implementsRelations.push({
+        if (!implementsByKey.has(implementsKey)) {
+          implementsByKey.set(implementsKey, {
             from: fileRecord.id,
             to: ruleRecord.id,
             note: explicitMention
               ? `Code references ${ruleRecord.id}`
-              : `Code keywords ${matchedKeywords.slice(0, 5).join(", ")}`
+              : `Code keywords ${keywordResult.sample.join(", ")}`
           });
+        }
+      }
+    }
+  }
+
+  for (const { ruleRecord } of ruleMatchers) {
+    for (const fileRecord of fileRecords) {
+      const constrainsKey = `${ruleRecord.id}|${fileRecord.id}`;
+      const constrainsRelation = constrainsByKey.get(constrainsKey);
+      if (constrainsRelation) {
+        constrainsRelations.push(constrainsRelation);
+        constrainsByKey.delete(constrainsKey);
+      }
+      if (fileRecord.kind === "CODE") {
+        const implementsKey = `${fileRecord.id}|${ruleRecord.id}`;
+        const implementsRelation = implementsByKey.get(implementsKey);
+        if (implementsRelation) {
+          implementsRelations.push(implementsRelation);
+          implementsByKey.delete(implementsKey);
         }
       }
     }

--- a/tests/ingest-memory-trace.test.mjs
+++ b/tests/ingest-memory-trace.test.mjs
@@ -59,6 +59,14 @@ function runIngest(root, extraEnv = {}) {
   });
 }
 
+function readJsonl(file) {
+  return fs.readFileSync(file, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
 test("ingest memory trace is opt-in and emits checkpoint JSON lines", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-ingest-trace-"));
   try {
@@ -104,6 +112,50 @@ test("ingest memory trace is opt-in and emits checkpoint JSON lines", () => {
     assert.equal(writeRecord.counts.files, 1);
     assert.ok(writeRecord.counts.chunks >= 1);
     assert.ok(writeRecord.counts.total_relations >= 1);
+
+    const ruleMatchRecord = records.find((record) => record.label === "tokens:rule_matching_complete");
+    assert.equal(ruleMatchRecord.counts.file_token_sets, 1);
+    assert.equal(ruleMatchRecord.counts.file_token_sets_retained, 0);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("ingest rule matching keeps duplicate rule ids de-duplicated", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-ingest-rules-"));
+  try {
+    writeFixture(root);
+    fs.writeFileSync(
+      path.join(root, ".context", "rules.yaml"),
+      [
+        "rules:",
+        "  - id: rule.trace",
+        "    description: First duplicate trace rule",
+        "    priority: 10",
+        "    enforce: true",
+        "  - id: rule.trace",
+        "    description: Second duplicate trace rule",
+        "    priority: 10",
+        "    enforce: true",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+
+    const result = runIngest(root);
+    assert.equal(result.status, 0, result.stderr);
+
+    const constrains = readJsonl(path.join(root, ".context", "cache", "relations.constrains.jsonl"));
+    const implementsRelations = readJsonl(path.join(root, ".context", "cache", "relations.implements.jsonl"));
+
+    assert.equal(
+      constrains.filter((relation) => relation.from === "rule.trace" && relation.to === "file:src/app.js").length,
+      1
+    );
+    assert.equal(
+      implementsRelations.filter((relation) => relation.from === "file:src/app.js" && relation.to === "rule.trace").length,
+      1
+    );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Stream ingest rule matching per file instead of retaining lowercased content/token sets for every file.
- Preserve deterministic rule-to-file relation output while deleting emitted map entries to avoid duplicate relations for duplicate rule ids.
- Extend ingest memory trace assertions and add a duplicate-rule regression test.

## Validation
- `node --check scaffold/scripts/ingest.mjs && node --check scripts/ingest.mjs && node --test tests/ingest-memory-trace.test.mjs tests/ingest-parallel.test.mjs tests/ingest-units.test.mjs`
- `npm test` (206/206 passing)
- `git diff --check`
- Bootstrapbench run `memory-rss-token-stream-2026-06-18`: 2/2 succeeded; Angular peak RSS 1374.43 MB in ingest, Cortex peak RSS 606.11 MB in embed; Angular still reports 22,742 chunks and 2,122 unsupported files. The benchmark tarball was built before the final duplicate-rule flush guard; the final guard only changes duplicate rule-id emission and was covered by focused/full tests after the benchmark.

## Notes
- This removes retained token/lowercase maps from rule matching but does not yet reduce Angular's observed process-tree peak below the prior ~1373 MB baseline. Next memory target remains earlier/post-parse materialization of `fileRecords.content`, chunk records, and relation arrays.
