### PR TITLE
Reduce large ingest memory retention

### DIFF
--- a/scaffold/scripts/ingest.mjs
+++ b/scaffold/scripts/ingest.mjs
@@ -758,6 +758,29 @@ function writeJsonl(filePath, records) {
   }
 }
 
+function stageJsonl(filePath, records) {
+  const stagedPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  writeJsonl(stagedPath, records);
+  return {
+    commit() {
+      fs.renameSync(stagedPath, filePath);
+    },
+    discard() {
+      fs.rmSync(stagedPath, { force: true });
+    }
+  };
+}
+
+function countFileContentRecords(fileRecords) {
+  let count = 0;
+  for (const fileRecord of fileRecords) {
+    if (Object.prototype.hasOwnProperty.call(fileRecord, "content")) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
 function sanitizeTsvCell(value) {
   if (value === null || value === undefined) return "";
   return String(value).replace(/\t/g, " ").replace(/\r?\n/g, " ");
@@ -2288,7 +2311,8 @@ function resolveIngestWorkerCount(taskCount) {
   const raw = process.env.CORTEX_INGEST_WORKERS;
   const configured = raw !== undefined ? Number.parseInt(raw, 10) : Number.NaN;
   const cpuBudget = Math.max(1, (os.availableParallelism?.() ?? os.cpus().length) - 1);
-  const desired = Number.isFinite(configured) && configured >= 0 ? configured : Math.min(cpuBudget, 8);
+  const defaultWorkerLimit = taskCount >= 1000 ? 4 : 8;
+  const desired = Number.isFinite(configured) && configured >= 0 ? configured : Math.min(cpuBudget, defaultWorkerLimit);
   if (desired <= 1) return 1;
   // Worker spin-up plus per-worker WASM grammar init dominates on small or
   // incremental runs; stay sequential until there is enough work to amortize.
@@ -3352,6 +3376,12 @@ async function main() {
 
   const constrainsRelations = [];
   const implementsRelations = [];
+  const stagedDocumentCache = stageJsonl(path.join(CACHE_DIR, "documents.jsonl"), fileRecords);
+  const stagedFileEntityCache = stageJsonl(path.join(CACHE_DIR, "entities.file.jsonl"), fileRecords);
+  memoryTrace.checkpoint("writes:file_cache_staged", {
+    files: fileRecords.length,
+    file_content_records: countFileContentRecords(fileRecords)
+  });
   memoryTrace.checkpoint("tokens:rule_matching_start", {
     files: fileRecords.length,
     rules: ruleRecords.length
@@ -3365,9 +3395,10 @@ async function main() {
   const constrainsByKey = new Map();
   const implementsByKey = new Map();
   let fileTokenSetsProcessed = 0;
+  let fileContentRecordsReleased = 0;
 
   for (const fileRecord of fileRecords) {
-    const lower = fileRecord.content.toLowerCase();
+    const lower = String(fileRecord.content ?? "").toLowerCase();
     const tokens = fileTokenSet(fileRecord);
     fileTokenSetsProcessed += 1;
 
@@ -3406,6 +3437,11 @@ async function main() {
         }
       }
     }
+
+    if (Object.prototype.hasOwnProperty.call(fileRecord, "content")) {
+      delete fileRecord.content;
+      fileContentRecordsReleased += 1;
+    }
   }
 
   for (const { ruleRecord } of ruleMatchers) {
@@ -3430,6 +3466,8 @@ async function main() {
   memoryTrace.checkpoint("tokens:rule_matching_complete", {
     file_token_sets: fileTokenSetsProcessed,
     file_token_sets_retained: 0,
+    file_content_records_released: fileContentRecordsReleased,
+    file_content_records_retained: countFileContentRecords(fileRecords),
     rules: ruleRecords.length,
     relations_constrains: constrainsRelations.length,
     relations_implements: implementsRelations.length,
@@ -3442,8 +3480,8 @@ async function main() {
     rules: ruleRecords.length,
     chunks: chunkRecords.length
   });
-  writeJsonl(path.join(CACHE_DIR, "documents.jsonl"), fileRecords);
-  writeJsonl(path.join(CACHE_DIR, "entities.file.jsonl"), fileRecords);
+  stagedDocumentCache.commit();
+  stagedFileEntityCache.commit();
   writeJsonl(path.join(CACHE_DIR, "entities.adr.jsonl"), adrRecords);
   writeJsonl(path.join(CACHE_DIR, "entities.rule.jsonl"), ruleRecords);
   writeJsonl(path.join(CACHE_DIR, "entities.chunk.jsonl"), chunkRecords);
@@ -3834,5 +3872,6 @@ export {
   generateSectionHandlerRelations,
   getChunkParserForExtension,
   parseFilesInWorkers,
+  resolveIngestWorkerCount,
   resolveRelativeImportTargetId
 };

--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -1036,8 +1036,27 @@ function findSupersedesReferences(content) {
 }
 
 function writeJsonl(filePath, records) {
-  const body = records.map((record) => JSON.stringify(record)).join("\n");
-  fs.writeFileSync(filePath, body ? `${body}\n` : "", "utf8");
+  const fd = fs.openSync(filePath, "w");
+  try {
+    for (const record of records) {
+      fs.writeSync(fd, `${JSON.stringify(record)}\n`, undefined, "utf8");
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function stageJsonl(filePath, records) {
+  const stagedPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  writeJsonl(stagedPath, records);
+  return {
+    commit() {
+      fs.renameSync(stagedPath, filePath);
+    },
+    discard() {
+      fs.rmSync(stagedPath, { force: true });
+    }
+  };
 }
 
 function sanitizeTsvCell(value) {
@@ -1046,11 +1065,15 @@ function sanitizeTsvCell(value) {
 }
 
 function writeTsv(filePath, headers, rows) {
-  const lines = [headers.join("\t")];
-  for (const row of rows) {
-    lines.push(row.map((value) => sanitizeTsvCell(value)).join("\t"));
+  const fd = fs.openSync(filePath, "w");
+  try {
+    fs.writeSync(fd, `${headers.join("\t")}\n`, undefined, "utf8");
+    for (const row of rows) {
+      fs.writeSync(fd, `${row.map((value) => sanitizeTsvCell(value)).join("\t")}\n`, undefined, "utf8");
+    }
+  } finally {
+    fs.closeSync(fd);
   }
-  fs.writeFileSync(filePath, `${lines.join("\n")}\n`, "utf8");
 }
 
 function readJsonlSafe(filePath) {
@@ -3228,6 +3251,8 @@ async function main() {
 
   const constrainsRelations = [];
   const implementsRelations = [];
+  const stagedDocumentCache = stageJsonl(path.join(CACHE_DIR, "documents.jsonl"), fileRecords);
+  const stagedFileEntityCache = stageJsonl(path.join(CACHE_DIR, "entities.file.jsonl"), fileRecords);
 
   const ruleMatchers = ruleRecords.map((ruleRecord) => ({
     ruleRecord,
@@ -3238,7 +3263,7 @@ async function main() {
   const implementsByKey = new Map();
 
   for (const fileRecord of fileRecords) {
-    const lower = fileRecord.content.toLowerCase();
+    const lower = String(fileRecord.content ?? "").toLowerCase();
     const tokens = fileTokenSet(fileRecord);
 
     for (const { ruleRecord, needle, keywords } of ruleMatchers) {
@@ -3276,6 +3301,8 @@ async function main() {
         }
       }
     }
+
+    delete fileRecord.content;
   }
 
   for (const { ruleRecord } of ruleMatchers) {
@@ -3297,8 +3324,8 @@ async function main() {
     }
   }
 
-  writeJsonl(path.join(CACHE_DIR, "documents.jsonl"), fileRecords);
-  writeJsonl(path.join(CACHE_DIR, "entities.file.jsonl"), fileRecords);
+  stagedDocumentCache.commit();
+  stagedFileEntityCache.commit();
   writeJsonl(path.join(CACHE_DIR, "entities.adr.jsonl"), adrRecords);
   writeJsonl(path.join(CACHE_DIR, "entities.rule.jsonl"), ruleRecords);
   writeJsonl(path.join(CACHE_DIR, "entities.chunk.jsonl"), chunkRecords);

--- a/tests/ingest-memory-trace.test.mjs
+++ b/tests/ingest-memory-trace.test.mjs
@@ -98,6 +98,7 @@ test("ingest memory trace is opt-in and emits checkpoint JSON lines", () => {
       "parse:merge_complete",
       "materialize:chunks_relations",
       "materialize:modules_projects_relations",
+      "writes:file_cache_staged",
       "tokens:rule_matching_complete",
       "writes:manifest_complete"
     ]) {
@@ -116,6 +117,16 @@ test("ingest memory trace is opt-in and emits checkpoint JSON lines", () => {
     const ruleMatchRecord = records.find((record) => record.label === "tokens:rule_matching_complete");
     assert.equal(ruleMatchRecord.counts.file_token_sets, 1);
     assert.equal(ruleMatchRecord.counts.file_token_sets_retained, 0);
+    assert.equal(ruleMatchRecord.counts.file_content_records_released, 1);
+    assert.equal(ruleMatchRecord.counts.file_content_records_retained, 0);
+
+    const stagedRecord = records.find((record) => record.label === "writes:file_cache_staged");
+    assert.equal(stagedRecord.counts.file_content_records, 1);
+
+    const documents = readJsonl(path.join(root, ".context", "cache", "documents.jsonl"));
+    const fileEntities = readJsonl(path.join(root, ".context", "cache", "entities.file.jsonl"));
+    assert.match(documents[0].content, /rule\.trace/);
+    assert.match(fileEntities[0].content, /rule\.trace/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/ingest-units.test.mjs
+++ b/tests/ingest-units.test.mjs
@@ -25,6 +25,7 @@ import {
   generateProjects,
   generateSectionHandlerRelations,
   getChunkParserForExtension,
+  resolveIngestWorkerCount,
   resolveRelativeImportTargetId
 } from "../scaffold/scripts/ingest.mjs";
 
@@ -58,6 +59,25 @@ test("getChunkParserForExtension: only dispatches current chunk-capable language
   assert.equal(getChunkParserForExtension(".settings")?.language, "settings");
   assert.equal(getChunkParserForExtension(".cpp")?.language, "cpp");
   assert.equal(getChunkParserForExtension(".c")?.language, "c");
+});
+
+test("resolveIngestWorkerCount: caps large default ingests while preserving env override", () => {
+  const original = process.env.CORTEX_INGEST_WORKERS;
+  try {
+    delete process.env.CORTEX_INGEST_WORKERS;
+    assert.equal(resolveIngestWorkerCount(49), 1);
+    assert.ok(resolveIngestWorkerCount(1000) >= 1);
+    assert.ok(resolveIngestWorkerCount(1000) <= 4);
+
+    process.env.CORTEX_INGEST_WORKERS = "8";
+    assert.equal(resolveIngestWorkerCount(1000), 8);
+  } finally {
+    if (original === undefined) {
+      delete process.env.CORTEX_INGEST_WORKERS;
+    } else {
+      process.env.CORTEX_INGEST_WORKERS = original;
+    }
+  }
 });
 
 test("extractSqlObjectReferencesFromContent: finds stored procedure command usage", () => {


### PR DESCRIPTION
## Summary
- stage document/file entity JSONL before rule matching so file content can be released afterward without changing cache output
- stream root ingest JSONL/TSV writes instead of materializing full output strings
- cap default parallel ingest workers to 4 for large runs while preserving CORTEX_INGEST_WORKERS override
- add memory trace and worker-count regression coverage

## Validation
- node --check scaffold/scripts/ingest.mjs && node --check scripts/ingest.mjs
- node --test tests/ingest-memory-trace.test.mjs tests/ingest-parallel.test.mjs tests/ingest-worker-crash.test.mjs tests/ingest-units.test.mjs
- npm test
- cortex update in the PR worktree after scaffold auto-migrate

## Angular memory evidence
Direct Angular ingest trace on angular/angular commit 71bb19d772aa77a30922fb896f775b58a0862c36, using the patched scaffold and default worker settings:
- parse:workers_start: worker_count=4, rss=264.94 MB
- parse:workers_complete: rss=985.86 MB
- tokens:rule_matching_complete peak: rss=993.98 MB
- file_content_records_released=8413, file_content_records_retained=0

Earlier default trace with 8 workers peaked around 1460 MB RSS on the same local setup. A forced CORTEX_INGEST_WORKERS=4 trace peaked around 939 MB RSS, so the new default tracks the lower-memory profile while keeping an explicit env override.