### PR TITLE
Bound search result ranking memory

### DIFF
--- a/scaffold/mcp/src/searchResults.ts
+++ b/scaffold/mcp/src/searchResults.ts
@@ -1,5 +1,12 @@
 import type { RankingWeights, SearchEntity } from "./types.js";
 
+type SearchResult = Record<string, unknown>;
+
+type RankedSearchResult = {
+  result: SearchResult;
+  rankScore: number;
+};
+
 function isWindowChunkId(id: string): boolean {
   return id.includes(":window:");
 }
@@ -12,6 +19,20 @@ function baseChunkId(id: string): string {
 function baseChunkLabel(label: string): string {
   const markerIndex = label.indexOf("#window");
   return markerIndex === -1 ? label : label.slice(0, markerIndex);
+}
+
+function pruneRankedResults(bestById: Map<string, RankedSearchResult>, limit: number): void {
+  if (bestById.size <= limit) {
+    return;
+  }
+
+  const retained = [...bestById.entries()]
+    .sort(([, a], [, b]) => b.rankScore - a.rankScore)
+    .slice(0, limit);
+  bestById.clear();
+  for (const [id, result] of retained) {
+    bestById.set(id, result);
+  }
 }
 
 export function buildSearchResults(params: {
@@ -33,6 +54,10 @@ export function buildSearchResults(params: {
   recencyScorer: (isoDate: string) => number;
   legacyDataAccessBooster: (entity: SearchEntity, queryTokens: string[], queryPhrase: string) => number;
 }): Record<string, unknown>[] {
+  if (params.topK <= 0) {
+    return [];
+  }
+
   // Graph score = midrank percentile of relation degree within the entity's
   // own type. The previous min(1, degree/4) saturated at degree >= 4, which
   // nearly every entity exceeds, making the graph weight a constant. Per-type
@@ -65,102 +90,101 @@ export function buildSearchResults(params: {
     return sorted.length > 0 ? (lo + upper) / (2 * sorted.length) : 0;
   };
 
-  const rawResults = params.candidates
-    .map((entity) => {
-      const lexicalSemantic = params.semanticScorer(params.queryTokens, params.queryPhrase, entity.text);
-      const entityVector = params.embeddingVectors.get(entity.id);
-      const vectorSemantic =
-        params.queryVector && entityVector
-          ? Math.max(0, Math.min(1, params.vectorScorer(params.queryVector, entityVector)))
-          : 0;
-      const hasRelevanceSignal =
-        lexicalSemantic >= params.minLexicalRelevance || vectorSemantic >= params.minVectorRelevance;
-      if (!hasRelevanceSignal) {
-        return null;
-      }
-
-      const semantic =
-        vectorSemantic > 0 ? vectorSemantic * 0.75 + lexicalSemantic * 0.25 : lexicalSemantic;
-      const degree = params.degreeByEntity.get(entity.id) ?? 0;
-      const graphScore = midrankPercentile(sortedDegreesByType.get(entity.entity_type) ?? [], degree);
-      const trustScore = Math.max(0, Math.min(1, entity.trust_level / 100));
-      const dateScore = params.recencyScorer(entity.updated_at);
-
-      let score = 0;
-      score += params.ranking.semantic * semantic;
-      score += params.ranking.graph * graphScore;
-      score += params.ranking.trust * trustScore;
-      score += params.ranking.recency * dateScore;
-      score += params.legacyDataAccessBooster(entity, params.queryTokens, params.queryPhrase);
-
-      if (entity.source_of_truth) {
-        score += 0.1 * semantic;
-      }
-
-      return {
-        id: entity.id,
-        entity_type: entity.entity_type,
-        kind: entity.kind,
-        title: entity.label,
-        path: entity.path || undefined,
-        source_of_truth: entity.source_of_truth,
-        status: entity.status,
-        updated_at: entity.updated_at,
-        excerpt: entity.snippet,
-        ...(params.includeScores
-          ? {
-              score: Number(score.toFixed(4)),
-              semantic_score: Number(semantic.toFixed(4)),
-              embedding_score: Number(vectorSemantic.toFixed(4)),
-              lexical_score: Number(lexicalSemantic.toFixed(4)),
-              graph_score: Number(graphScore.toFixed(4))
-            }
-          : {}),
-        ...(params.includeMatchedRules
-          ? {
-              matched_rules: entity.matched_rules
-            }
-          : {}),
-        ...(params.includeContent
-          ? {
-              content: entity.content
-            }
-          : {})
-      };
-    })
-    .filter((result): result is NonNullable<typeof result> => result !== null)
-    .sort((a, b) => Number(b.score ?? 0) - Number(a.score ?? 0));
-
   const chunkCandidatesById = new Map(
-    params.candidates.filter((entity) => entity.entity_type === "Chunk").map((entity) => [entity.id, entity])
+    params.candidates
+      .filter((entity) => entity.entity_type === "Chunk" && !isWindowChunkId(entity.id))
+      .map((entity) => [entity.id, entity])
   );
-  const normalizedById = new Map<string, (typeof rawResults)[number]>();
 
-  for (const result of rawResults) {
-    if (result.entity_type !== "Chunk" || !isWindowChunkId(String(result.id))) {
-      if (!normalizedById.has(String(result.id))) {
-        normalizedById.set(String(result.id), result);
-      }
+  const resultLimit = Math.max(1, params.topK);
+  const pruneThreshold = Math.max(resultLimit * 4, 64);
+  const bestById = new Map<string, RankedSearchResult>();
+
+  for (const entity of params.candidates) {
+    const lexicalSemantic = params.semanticScorer(params.queryTokens, params.queryPhrase, entity.text);
+    const entityVector = params.embeddingVectors.get(entity.id);
+    const vectorSemantic =
+      params.queryVector && entityVector
+        ? Math.max(0, Math.min(1, params.vectorScorer(params.queryVector, entityVector)))
+        : 0;
+    const hasRelevanceSignal =
+      lexicalSemantic >= params.minLexicalRelevance || vectorSemantic >= params.minVectorRelevance;
+    if (!hasRelevanceSignal) {
       continue;
     }
 
-    const canonicalId = baseChunkId(String(result.id));
-    const baseChunk = chunkCandidatesById.get(canonicalId);
-    const normalizedResult = baseChunk
-      ? {
-          ...result,
-          id: canonicalId,
-          title: baseChunkLabel(baseChunk.label),
-          path: baseChunk.path || undefined
-        }
-      : result;
-    const existing = normalizedById.get(String(normalizedResult.id));
-    if (!existing || Number(normalizedResult.score ?? 0) > Number(existing.score ?? 0)) {
-      normalizedById.set(String(normalizedResult.id), normalizedResult);
+    const semantic =
+      vectorSemantic > 0 ? vectorSemantic * 0.75 + lexicalSemantic * 0.25 : lexicalSemantic;
+    const degree = params.degreeByEntity.get(entity.id) ?? 0;
+    const graphScore = midrankPercentile(sortedDegreesByType.get(entity.entity_type) ?? [], degree);
+    const trustScore = Math.max(0, Math.min(1, entity.trust_level / 100));
+    const dateScore = params.recencyScorer(entity.updated_at);
+
+    let score = 0;
+    score += params.ranking.semantic * semantic;
+    score += params.ranking.graph * graphScore;
+    score += params.ranking.trust * trustScore;
+    score += params.ranking.recency * dateScore;
+    score += params.legacyDataAccessBooster(entity, params.queryTokens, params.queryPhrase);
+
+    if (entity.source_of_truth) {
+      score += 0.1 * semantic;
+    }
+
+    const result: SearchResult = {
+      id: entity.id,
+      entity_type: entity.entity_type,
+      kind: entity.kind,
+      title: entity.label,
+      path: entity.path || undefined,
+      source_of_truth: entity.source_of_truth,
+      status: entity.status,
+      updated_at: entity.updated_at,
+      excerpt: entity.snippet,
+      ...(params.includeScores
+        ? {
+            score: Number(score.toFixed(4)),
+            semantic_score: Number(semantic.toFixed(4)),
+            embedding_score: Number(vectorSemantic.toFixed(4)),
+            lexical_score: Number(lexicalSemantic.toFixed(4)),
+            graph_score: Number(graphScore.toFixed(4))
+          }
+        : {}),
+      ...(params.includeMatchedRules
+        ? {
+            matched_rules: entity.matched_rules
+          }
+        : {}),
+      ...(params.includeContent
+        ? {
+            content: entity.content
+          }
+        : {})
+    };
+
+    if (entity.entity_type === "Chunk" && isWindowChunkId(entity.id)) {
+      const canonicalId = baseChunkId(entity.id);
+      const baseChunk = chunkCandidatesById.get(canonicalId);
+      if (baseChunk) {
+        result.id = canonicalId;
+        result.title = baseChunkLabel(baseChunk.label);
+        result.path = baseChunk.path || undefined;
+      }
+    }
+
+    const resultId = String(result.id);
+    const existing = bestById.get(resultId);
+    if (!existing || score > existing.rankScore) {
+      bestById.set(resultId, { result, rankScore: score });
+    }
+
+    if (bestById.size > pruneThreshold) {
+      pruneRankedResults(bestById, resultLimit);
     }
   }
 
-  return [...normalizedById.values()]
-    .sort((a, b) => Number(b.score ?? 0) - Number(a.score ?? 0))
-    .slice(0, params.topK);
+  return [...bestById.values()]
+    .sort((a, b) => b.rankScore - a.rankScore)
+    .slice(0, params.topK)
+    .map((ranked) => ranked.result);
 }

--- a/scaffold/mcp/tests/search-graph-score.test.mjs
+++ b/scaffold/mcp/tests/search-graph-score.test.mjs
@@ -130,3 +130,38 @@ test("graph score never saturates to a shared constant for common degrees", () =
 
   assert.equal(unique.size, 3);
 });
+
+test("ranking is preserved when score fields are omitted from the response", () => {
+  const candidates = [
+    makeEntity("weak", "Chunk", { text: "weak query" }),
+    makeEntity("strong", "Chunk", { text: "strong query" }),
+    makeEntity("middle", "Chunk", { text: "middle query" })
+  ];
+
+  const results = buildSearchResults({
+    candidates,
+    degreeByEntity: new Map(),
+    queryTokens: ["query"],
+    queryPhrase: "query",
+    ranking: { semantic: 1, graph: 0, trust: 0, recency: 0 },
+    includeScores: false,
+    includeMatchedRules: false,
+    includeContent: false,
+    queryVector: null,
+    embeddingVectors: new Map(),
+    topK: 2,
+    minLexicalRelevance: 0,
+    minVectorRelevance: 0,
+    semanticScorer: (_tokens, _phrase, text) => {
+      if (text.includes("strong")) return 0.9;
+      if (text.includes("middle")) return 0.5;
+      return 0.1;
+    },
+    vectorScorer: () => 0,
+    recencyScorer: () => 0,
+    legacyDataAccessBooster: () => 0
+  });
+
+  assert.deepEqual(results.map((result) => result.id), ["strong", "middle"]);
+  assert.equal("score" in results[0], false);
+});


### PR DESCRIPTION
## Summary
- avoid materializing and sorting a full raw search-results array for every query
- keep only the best normalized result per entity within a bounded top-k buffer while scanning candidates
- preserve canonical window-chunk normalization and response fields
- keep ranking internally even when score fields are omitted from the API response

## Validation
- npm --prefix scaffold/mcp test -- --test-name-pattern 'graph score|ranking is preserved|Float32Array'
- npm test
- cortex update in the PR worktree after scaffold auto-migrate
- git diff --check

## Memory note
This is the next deeper memory pass after the ingest PR. It reduces extra query-time retention in the CLI/runtime path by replacing the full `rawResults` materialization with bounded ranked retention. It does not yet remove the full candidate array from `buildSearchEntities`; that remains the next, larger search-memory target.
