### PR TITLE
Stream search candidate scoring

### DIFF
--- a/scaffold/mcp/src/contextEntities.ts
+++ b/scaffold/mcp/src/contextEntities.ts
@@ -75,8 +75,12 @@ function buildRelationSearchSignals(data: ContextData): Map<string, string> {
   return new Map([...signalsByEntity.entries()].map(([id, parts]) => [id, parts.join("\n")]));
 }
 
-export function buildSearchEntities(data: ContextData, includeContent: boolean): SearchEntity[] {
-  const entities: SearchEntity[] = [];
+function buildSearchEntityIndexes(data: ContextData): {
+  fileRuleLinks: Map<string, string[]>;
+  relationSignals: Map<string, string>;
+  adrPathSet: Set<string>;
+  filePathById: Map<string, string>;
+} {
   const fileRuleLinks = groupRuleLinks(data.relations);
   const relationSignals = buildRelationSearchSignals(data);
   const adrPathSet = new Set(
@@ -84,6 +88,15 @@ export function buildSearchEntities(data: ContextData, includeContent: boolean):
       .map((adr) => adr.path.trim().toLowerCase())
       .filter((adrPath) => adrPath.length > 0)
   );
+  const filePathById = new Map(
+    data.documents.filter((document) => document.kind === "CODE").map((document) => [document.id, document.path])
+  );
+
+  return { fileRuleLinks, relationSignals, adrPathSet, filePathById };
+}
+
+export function* iterateSearchEntities(data: ContextData, includeContent: boolean): Generator<SearchEntity> {
+  const { fileRuleLinks, relationSignals, adrPathSet, filePathById } = buildSearchEntityIndexes(data);
 
   for (const document of data.documents) {
     const normalizedPath = document.path.trim().toLowerCase();
@@ -91,7 +104,7 @@ export function buildSearchEntities(data: ContextData, includeContent: boolean):
       continue;
     }
 
-    entities.push({
+    yield {
       id: document.id,
       entity_type: "File",
       kind: document.kind,
@@ -105,11 +118,11 @@ export function buildSearchEntities(data: ContextData, includeContent: boolean):
       snippet: document.excerpt,
       matched_rules: fileRuleLinks.get(document.id) ?? [],
       content: includeContent ? document.content : undefined
-    });
+    };
   }
 
   for (const rule of data.rules) {
-    entities.push({
+    yield {
       id: rule.id,
       entity_type: "Rule",
       kind: "RULE",
@@ -123,11 +136,11 @@ export function buildSearchEntities(data: ContextData, includeContent: boolean):
       snippet: rule.body.slice(0, 500),
       matched_rules: [rule.id],
       content: includeContent ? rule.body : undefined
-    });
+    };
   }
 
   for (const adr of data.adrs) {
-    entities.push({
+    yield {
       id: adr.id,
       entity_type: "ADR",
       kind: "ADR",
@@ -141,16 +154,12 @@ export function buildSearchEntities(data: ContextData, includeContent: boolean):
       snippet: adr.body.slice(0, 500),
       matched_rules: [],
       content: includeContent ? adr.body : undefined
-    });
+    };
   }
-
-  const filePathById = new Map(
-    data.documents.filter((document) => document.kind === "CODE").map((document) => [document.id, document.path])
-  );
 
   for (const chunk of data.chunks) {
     const filePath = filePathById.get(chunk.file_id) ?? "";
-    entities.push({
+    yield {
       id: chunk.id,
       entity_type: "Chunk",
       kind: chunk.kind || "chunk",
@@ -164,11 +173,11 @@ export function buildSearchEntities(data: ContextData, includeContent: boolean):
       snippet: chunk.description || chunk.body.slice(0, 500),
       matched_rules: fileRuleLinks.get(chunk.file_id) ?? [],
       content: includeContent ? chunk.body : undefined
-    });
+    };
   }
 
   for (const module of data.modules) {
-    entities.push({
+    yield {
       id: module.id,
       entity_type: "Module",
       kind: "MODULE",
@@ -182,11 +191,11 @@ export function buildSearchEntities(data: ContextData, includeContent: boolean):
       snippet: (module.summary || "").slice(0, 500),
       matched_rules: [],
       content: includeContent ? module.summary : undefined
-    });
+    };
   }
 
   for (const project of data.projects) {
-    entities.push({
+    yield {
       id: project.id,
       entity_type: "Project",
       kind: project.kind.toUpperCase() || "PROJECT",
@@ -200,10 +209,12 @@ export function buildSearchEntities(data: ContextData, includeContent: boolean):
       snippet: (project.summary || "").slice(0, 500),
       matched_rules: [],
       content: includeContent ? project.summary : undefined
-    });
+    };
   }
+}
 
-  return entities;
+export function buildSearchEntities(data: ContextData, includeContent: boolean): SearchEntity[] {
+  return Array.from(iterateSearchEntities(data, includeContent));
 }
 
 export function buildChunkPartOfRelations(data: ContextData): RelationRecord[] {

--- a/scaffold/mcp/src/search.ts
+++ b/scaffold/mcp/src/search.ts
@@ -2,7 +2,7 @@ import { embedQuery, getEmbeddingRuntimeWarning, loadEmbeddingIndex } from "./em
 import {
   buildChunkPartOfRelations,
   buildEntitySearchMap,
-  buildSearchEntities,
+  iterateSearchEntities,
   entityCatalog
 } from "./contextEntities.js";
 import { relationDegree } from "./graphMetrics.js";
@@ -19,7 +19,7 @@ import {
   semanticScore,
   tokenize
 } from "./searchCore.js";
-import { buildSearchResults } from "./searchResults.js";
+import { buildSearchResultsWithStats } from "./searchResults.js";
 import { traverseImpactGraph } from "./impactTraversal.js";
 import { buildEmptyRelatedResponse, buildRelatedResponseMeta } from "./relatedResponse.js";
 import { traverseRelatedGraph } from "./relatedTraversal.js";
@@ -39,6 +39,7 @@ import type {
   ImpactParams,
   RelatedParams,
   RelationType,
+  SearchEntity,
   SearchParams,
   ToolPayload
 } from "./types.js";
@@ -57,6 +58,17 @@ const IMPACT_RELATION_TYPES = new Set([
   "PART_OF"
 ]);
 
+function* filterSearchCandidates(
+  candidates: Iterable<SearchEntity>,
+  includeDeprecated: boolean
+): Generator<SearchEntity> {
+  for (const entity of candidates) {
+    if (includeDeprecated || entity.status.toLowerCase() !== "deprecated") {
+      yield entity;
+    }
+  }
+}
+
 export async function runContextSearch(parsed: SearchParams): Promise<ToolPayload> {
   const searchPresetConfig = resolveSearchResponsePreset(parsed);
   const responsePreset = searchPresetConfig.responsePreset;
@@ -68,16 +80,15 @@ export async function runContextSearch(parsed: SearchParams): Promise<ToolPayloa
   const degreeByEntity = relationDegree(allRelations);
   const queryTokens = expandQueryTokens(Array.from(new Set(tokenize(parsed.query))));
   const queryPhrase = normalizeText(parsed.query).trim();
-  const candidates = buildSearchEntities(data, includeContent).filter(
-    (entity) => parsed.include_deprecated || entity.status.toLowerCase() !== "deprecated"
-  );
+  const candidates = () =>
+    filterSearchCandidates(iterateSearchEntities(data, includeContent), parsed.include_deprecated);
   const embeddings = loadEmbeddingIndex();
   const queryVector =
     embeddings.model && embeddings.vectors.size > 0
       ? await embedQuery(parsed.query, embeddings.model)
       : null;
 
-  const results = buildSearchResults({
+  const { results, totalCandidates } = buildSearchResultsWithStats({
     candidates,
     degreeByEntity,
     queryTokens,
@@ -107,7 +118,7 @@ export async function runContextSearch(parsed: SearchParams): Promise<ToolPayloa
     include_matched_rules: includeMatchedRules,
     include_content: includeContent,
     ranking: data.ranking,
-    total_candidates: candidates.length,
+    total_candidates: totalCandidates,
     context_source: data.source,
     warning: warningMessages.length > 0 ? warningMessages.join(" | ") : undefined,
     semantic_engine:

--- a/scaffold/mcp/src/searchResults.ts
+++ b/scaffold/mcp/src/searchResults.ts
@@ -7,6 +7,13 @@ type RankedSearchResult = {
   rankScore: number;
 };
 
+type SearchCandidateSource = Iterable<SearchEntity> | (() => Iterable<SearchEntity>);
+
+type BaseChunkMetadata = {
+  label: string;
+  path: string;
+};
+
 function isWindowChunkId(id: string): boolean {
   return id.includes(":window:");
 }
@@ -35,8 +42,12 @@ function pruneRankedResults(bestById: Map<string, RankedSearchResult>, limit: nu
   }
 }
 
-export function buildSearchResults(params: {
-  candidates: SearchEntity[];
+function candidatesFrom(source: SearchCandidateSource): Iterable<SearchEntity> {
+  return typeof source === "function" ? source() : source;
+}
+
+export function buildSearchResultsWithStats(params: {
+  candidates: SearchCandidateSource;
   degreeByEntity: Map<string, number>;
   queryTokens: string[];
   queryPhrase: string;
@@ -53,9 +64,9 @@ export function buildSearchResults(params: {
   vectorScorer: (a: Float32Array, b: Float32Array) => number;
   recencyScorer: (isoDate: string) => number;
   legacyDataAccessBooster: (entity: SearchEntity, queryTokens: string[], queryPhrase: string) => number;
-}): Record<string, unknown>[] {
+}): { results: Record<string, unknown>[]; totalCandidates: number } {
   if (params.topK <= 0) {
-    return [];
+    return { results: [], totalCandidates: 0 };
   }
 
   // Graph score = midrank percentile of relation degree within the entity's
@@ -65,13 +76,23 @@ export function buildSearchResults(params: {
   // (every type averages ~0.5), so hub-heavy types like rules cannot drown
   // out leaf code files or doc sections.
   const sortedDegreesByType = new Map<string, number[]>();
-  for (const entity of params.candidates) {
+  const chunkCandidatesById = new Map<string, BaseChunkMetadata>();
+  let totalCandidates = 0;
+  for (const entity of candidatesFrom(params.candidates)) {
+    totalCandidates += 1;
     const degree = params.degreeByEntity.get(entity.id) ?? 0;
     const list = sortedDegreesByType.get(entity.entity_type);
     if (list) {
       list.push(degree);
     } else {
       sortedDegreesByType.set(entity.entity_type, [degree]);
+    }
+
+    if (entity.entity_type === "Chunk" && !isWindowChunkId(entity.id)) {
+      chunkCandidatesById.set(entity.id, {
+        label: entity.label,
+        path: entity.path
+      });
     }
   }
   for (const list of sortedDegreesByType.values()) {
@@ -90,17 +111,11 @@ export function buildSearchResults(params: {
     return sorted.length > 0 ? (lo + upper) / (2 * sorted.length) : 0;
   };
 
-  const chunkCandidatesById = new Map(
-    params.candidates
-      .filter((entity) => entity.entity_type === "Chunk" && !isWindowChunkId(entity.id))
-      .map((entity) => [entity.id, entity])
-  );
-
   const resultLimit = Math.max(1, params.topK);
   const pruneThreshold = Math.max(resultLimit * 4, 64);
   const bestById = new Map<string, RankedSearchResult>();
 
-  for (const entity of params.candidates) {
+  for (const entity of candidatesFrom(params.candidates)) {
     const lexicalSemantic = params.semanticScorer(params.queryTokens, params.queryPhrase, entity.text);
     const entityVector = params.embeddingVectors.get(entity.id);
     const vectorSemantic =
@@ -183,8 +198,13 @@ export function buildSearchResults(params: {
     }
   }
 
-  return [...bestById.values()]
+  const results = [...bestById.values()]
     .sort((a, b) => b.rankScore - a.rankScore)
     .slice(0, params.topK)
     .map((ranked) => ranked.result);
+  return { results, totalCandidates };
+}
+
+export function buildSearchResults(params: Parameters<typeof buildSearchResultsWithStats>[0]): Record<string, unknown>[] {
+  return buildSearchResultsWithStats(params).results;
 }

--- a/scaffold/mcp/tests/search-graph-score.test.mjs
+++ b/scaffold/mcp/tests/search-graph-score.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildSearchResults } from "../dist/searchResults.js";
+import { buildSearchResults, buildSearchResultsWithStats } from "../dist/searchResults.js";
 
 function makeEntity(id, entityType, overrides = {}) {
   return {
@@ -164,4 +164,42 @@ test("ranking is preserved when score fields are omitted from the response", () 
 
   assert.deepEqual(results.map((result) => result.id), ["strong", "middle"]);
   assert.equal("score" in results[0], false);
+});
+
+test("search results can consume a repeatable candidate generator with stats", () => {
+  let passes = 0;
+  const candidateSource = function* () {
+    passes += 1;
+    yield makeEntity("weak", "Chunk", { text: "weak query" });
+    yield makeEntity("strong", "Chunk", { text: "strong query" });
+    yield makeEntity("middle", "Chunk", { text: "middle query" });
+  };
+
+  const { results, totalCandidates } = buildSearchResultsWithStats({
+    candidates: candidateSource,
+    degreeByEntity: new Map(),
+    queryTokens: ["query"],
+    queryPhrase: "query",
+    ranking: { semantic: 1, graph: 0, trust: 0, recency: 0 },
+    includeScores: false,
+    includeMatchedRules: false,
+    includeContent: false,
+    queryVector: null,
+    embeddingVectors: new Map(),
+    topK: 2,
+    minLexicalRelevance: 0,
+    minVectorRelevance: 0,
+    semanticScorer: (_tokens, _phrase, text) => {
+      if (text.includes("strong")) return 0.9;
+      if (text.includes("middle")) return 0.5;
+      return 0.1;
+    },
+    vectorScorer: () => 0,
+    recencyScorer: () => 0,
+    legacyDataAccessBooster: () => 0
+  });
+
+  assert.equal(passes, 2);
+  assert.equal(totalCandidates, 3);
+  assert.deepEqual(results.map((result) => result.id), ["strong", "middle"]);
 });


### PR DESCRIPTION
## Summary
- add a generator-backed `iterateSearchEntities` path while keeping `buildSearchEntities` for compatibility
- make `runContextSearch` stream filtered search candidates instead of retaining a full candidate array
- teach search ranking to consume a repeatable candidate source and report `total_candidates` from the first pass
- retain only small per-type degree arrays, base chunk metadata, and the bounded result buffer while scoring

## Validation
- npm --prefix scaffold/mcp test -- --test-name-pattern 'search results|graph score|ranking is preserved|query|context.search'
- npm test
- cortex update in the PR worktree after scaffold auto-migrate
- git diff --check

## Stack note
This is stacked on #103 (`perf/search-result-memory`). After #103 merges, retarget this PR to `main` or rebase it onto `main`.
