### PR TITLE
docs: replace README with minimal CLI guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,20 @@
 
 # Cortex
 
-**Local code context for AI coding agents.**
+**Give AI coding agents the right context from your repository.**
 
 [![npm version](https://img.shields.io/npm/v/%40danielblomma%2Fcortex-mcp)](https://www.npmjs.com/package/@danielblomma/cortex-mcp)
-[![npm downloads](https://img.shields.io/npm/dw/%40danielblomma%2Fcortex-mcp)](https://www.npmjs.com/package/@danielblomma/cortex-mcp)
 [![license](https://img.shields.io/npm/l/%40danielblomma%2Fcortex-mcp)](./LICENSE)
-[![website](https://img.shields.io/badge/website-cortex-2563eb)](https://danielblomma.github.io/cortex/)
 
-Cortex gives coding agents a map of your repository before they answer a
-question or change code. It indexes files, symbols, relationships, and project
-rules, then makes that context available through a simple CLI.
+Cortex builds a local map of your code, symbols, relationships, and project
+rules. Coding agents query that map through the CLI instead of guessing or
+reading the whole repository.
 
-Your source code and index stay on your machine. **MCP is not required.**
+Your code stays on your machine. MCP is not required.
 
-## Quick start
+## Start
 
-Requirements: Node.js 20.9 or newer and a Git repository.
+Requires Node.js 20.9+ and Git.
 
 ```bash
 npm install --global @danielblomma/cortex-mcp
@@ -27,125 +25,63 @@ cd your-project
 cortex init --bootstrap
 ```
 
-The last command:
+This indexes the repository, adds Cortex instructions to `AGENTS.md`, installs
+Git hooks, and starts the background watcher.
 
-- creates the local `.context/` runtime;
-- indexes the repository;
-- adds Cortex instructions for coding agents to `AGENTS.md`;
-- installs Git hooks that keep context fresh;
-- starts the background watcher.
-
-Check that everything works:
+Check the setup:
 
 ```bash
 cortex doctor
-cortex search "where is authentication handled?" --json
 ```
 
-That is enough to start using Cortex.
-
-## How agents use Cortex
-
-`cortex init` teaches repository-aware agents to search before guessing. The
-normal workflow is:
-
-1. Search for the relevant code.
-2. Follow relationships when more context is needed.
-3. Check rules and impact before changing code.
-4. Refresh and review context after a substantial change.
+## Use
 
 ```bash
-# Find relevant code and symbols.
-cortex search "payment retry behavior" --json
+# Find relevant code.
+cortex search "where is authentication handled?" --json
 
-# Explore dependencies around a result.
-cortex related file:src/payments/retry.ts --json
+# Follow relationships from a search result.
+cortex related <entity-id> --json
 
-# Understand the likely blast radius of a change.
-cortex impact "payment retry behavior" --json
+# See what a change may affect.
+cortex impact "authentication" --json
 
-# Read active architectural rules.
+# Read repository rules.
 cortex rules --json
 
-# Compare a changed file with nearby repository patterns.
-cortex pattern-evidence src/payments/retry.ts --json
+# Compare a changed file with nearby patterns.
+cortex pattern-evidence src/auth.ts --json
+```
 
-# Refresh context after significant changes.
+Agents can run these commands directly. `cortex init` adds instructions that
+tell them to search before answering and check impact before refactoring.
+
+## Keep the index fresh
+
+Git hooks and the watcher normally update Cortex automatically.
+
+```bash
+cortex status
+cortex watch status
 cortex update
 ```
 
-Codex and other agents can run these commands directly in the repository. They
-do not need an MCP connection.
-
-## What Cortex adds
-
-Without Cortex, an agent often searches by filename and reads many unrelated
-files. Cortex gives it structured repository context:
-
-- semantic search across code, rules, and architecture decisions;
-- symbol definitions and file relationships;
-- caller and dependency traversal;
-- impact analysis before refactoring;
-- active rules, deprecations, and source-of-truth signals;
-- incremental updates after Git and filesystem changes.
-
-The pipeline is local and straightforward:
-
-```text
-repository -> local index -> Cortex CLI -> coding agent
-```
-
-## Commands you will use
-
-| Command | Purpose |
-| --- | --- |
-| `cortex search "..." --json` | Find relevant code and context |
-| `cortex related <entity-id> --json` | Follow relationships from a result |
-| `cortex impact "..." --json` | Estimate the blast radius of a change |
-| `cortex rules --json` | Show active repository rules |
-| `cortex pattern-evidence <file> --json` | Find nearby implementation patterns |
-| `cortex update` | Refresh changed context |
-| `cortex status` | Show index status |
-| `cortex doctor` | Diagnose the local setup |
-| `cortex watch status` | Check background synchronization |
-| `cortex dashboard` | Open the local status dashboard |
-
-Run `cortex help` for the complete command list.
+Run `cortex update` manually after a large change or when results look stale.
 
 ## Large repositories
 
-Normal `cortex bootstrap` completes the whole index before returning. For a
-large first-time index, you can make lexical and graph search available first
-and let semantic indexing continue in the background:
+Make lexical and graph search available first while semantic indexing continues
+in the background:
 
 ```bash
 cortex bootstrap --background --profile interactive
 cortex indexing status --json
 ```
 
-Pause or resume that background work when needed:
+This mode supports macOS, Linux, and WSL. Native Windows should use normal
+foreground bootstrap.
 
-```bash
-cortex indexing pause
-cortex indexing resume
-```
-
-The interactive profile uses conservative resource limits. It is supported on
-macOS, Linux, and WSL. Native Windows should use normal foreground bootstrap.
-
-## Keep context fresh
-
-Git hooks and the watcher normally update Cortex automatically.
-
-```bash
-cortex watch status
-cortex status
-```
-
-Run `cortex update` manually after a large change or whenever search results
-look stale.
-
-## Upgrade Cortex
+## Upgrade
 
 ```bash
 npm install --global @danielblomma/cortex-mcp@latest
@@ -154,70 +90,18 @@ cortex bootstrap
 cortex update
 ```
 
-`cortex init --force` updates Cortex-managed scaffold files while preserving
-project configuration, rules, Enterprise settings, and agent instructions.
-See [CHANGELOG.md](CHANGELOG.md) for version-specific notes.
+Project configuration and rules are preserved. See
+[CHANGELOG.md](CHANGELOG.md) for version-specific notes.
 
-## Configuration
+## Optional MCP compatibility
 
-Project configuration lives in `.context/config.yaml`, and repository rules
-live in `.context/rules.yaml`.
-
-New projects index the repository root. Standard Git-ignored, untracked paths
-are skipped. Add a specific ignored directory to `source_paths` only when it
-intentionally belongs in the context index.
-
-## Optional integrations
-
-The CLI is the primary interface. No integration is required for Codex or any
-agent that can run shell commands.
-
-Claude Code users can optionally install the Cortex behavior plugin:
-
-```text
-/plugin marketplace add DanielBlomma/cortex
-/plugin install cortex@cortex
-```
-
-If a client explicitly requires MCP, run `cortex connect`. MCP is a
-compatibility bridge to the same local context; it is not the normal Cortex
-workflow.
-
-## Dashboard
-
-```bash
-cortex dashboard
-```
-
-![Cortex dashboard](https://raw.githubusercontent.com/DanielBlomma/cortex/main/docs/dashboard-screenshot.png)
-
-The dashboard shows index health, freshness, relations, embeddings, and the
-most connected parts of the repository.
-
-## Privacy
-
-- Source code stays on the local machine.
-- Context data is stored under `.context/` in each repository.
-- Core search and indexing require no cloud service.
-- Each repository has its own context instance.
-
-## Troubleshooting
-
-```bash
-cortex doctor
-```
-
-- Runtime missing: run `cortex bootstrap`.
-- Search results look stale: run `cortex update`.
-- Watcher is not running: run `cortex watch start`.
-- Large initial index: use the interactive background profile shown above.
-- Windows: run Cortex inside WSL.
+The normal Cortex workflow uses the CLI. If a client explicitly requires MCP,
+run `cortex connect`.
 
 ## Links
 
 - [Website](https://danielblomma.github.io/cortex/)
 - [Changelog](CHANGELOG.md)
-- [Bootstrap benchmark](benchmark/bootstrapbench/README.md)
 - [Issues](https://github.com/DanielBlomma/cortex/issues)
 
 ## License


### PR DESCRIPTION
## Summary

Replace the README with a minimal CLI-first guide.

- 225 lines to 109 lines
- 878 words to 317 words
- keep only start, core CLI usage, index freshness, large repositories, upgrade, and links
- reduce MCP to a two-sentence optional compatibility note

## Validation

- referenced local files exist
- command names checked against CLI help
- git diff --check passed