### PR TITLE
release: prepare Cortex 2.6.0 root-only OIDC publishing

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -69,29 +69,6 @@ jobs:
           npm install --global npm@11.19.1
           test "$(npm --version)" = "11.19.1"
 
-      - name: Verify npm publication identity before mutation
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "The npm publication credential is not configured"
-            exit 1
-          fi
-          set -o pipefail
-          if ! npm whoami --registry=https://registry.npmjs.org/ 2>/dev/null | \
-            env -u NODE_AUTH_TOKEN node -e '
-              let value = "";
-              process.stdin.setEncoding("utf8");
-              process.stdin.on("data", (chunk) => { value += chunk; });
-              process.stdin.on("end", () => {
-                if (value !== "danielblomma\n") process.exitCode = 1;
-              });
-            '
-          then
-            echo "The npm publication credential did not authenticate"
-            exit 1
-          fi
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -144,7 +121,7 @@ jobs:
             server.json | LC_ALL=C sort > "${EXPECTED}"
           diff -u "${EXPECTED}" "${ACTUAL}"
 
-      - name: Bind bundle tests to the unpublished reviewed root artifact
+      - name: Bind bundle tests to the reviewed local root artifact
         env:
           ROOT_TARBALL: ${{ steps.seed.outputs.root_tarball }}
         run: |
@@ -191,7 +168,7 @@ jobs:
           git -C "${HARNESS_CHECKOUT}" checkout --detach "${HARNESS_COMMIT}"
           node scripts/check-deepseek-harness-compatibility.mjs --checkout "${HARNESS_CHECKOUT}"
 
-      - name: Create and verify duplicate dual-package artifacts
+      - name: Create and verify duplicate local root and bundle artifacts
         id: artifacts
         run: |
           ARTIFACT_DIR="${RUNNER_TEMP}/cortex-release-artifacts"
@@ -201,12 +178,10 @@ jobs:
             --report "${ARTIFACT_DIR}/report.json"
           ROOT_TARBALL="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.root.first.tarball' "${ARTIFACT_DIR}/report.json")"
           BUNDLE_TARBALL="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.bundle.first.tarball' "${ARTIFACT_DIR}/report.json")"
-          BUNDLE_INTEGRITY="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.bundle.first.integrity' "${ARTIFACT_DIR}/report.json")"
           echo "root_tarball=${ROOT_TARBALL}" >> "${GITHUB_OUTPUT}"
           echo "bundle_tarball=${BUNDLE_TARBALL}" >> "${GITHUB_OUTPUT}"
-          echo "bundle_integrity=${BUNDLE_INTEGRITY}" >> "${GITHUB_OUTPUT}"
 
-      - name: Install both unpublished artifacts with an empty cache
+      - name: Install both local artifacts with an empty cache
         env:
           ROOT_TARBALL: ${{ steps.artifacts.outputs.root_tarball }}
           BUNDLE_TARBALL: ${{ steps.artifacts.outputs.bundle_tarball }}
@@ -229,22 +204,11 @@ jobs:
             --output-dir "${RUNNER_TEMP}/cortex-harness-lifecycle" \
             --expected-version "${RELEASE_VERSION}"
 
-      - name: Require registry-only bundle install to be unavailable
-        env:
-          BUNDLE_INTEGRITY: ${{ steps.artifacts.outputs.bundle_integrity }}
-        run: |
-          STATE="$(node scripts/release-artifacts.mjs registry-state \
-            --package-name @danielblomma/dsh-cortex \
-            --version "${RELEASE_VERSION}" \
-            --integrity "${BUNDLE_INTEGRITY}" \
-            --root-dependency "${RELEASE_VERSION}")"
-          test "$(node -p 'JSON.parse(process.argv[1]).state' "${STATE}")" = "missing"
-
       - name: Verify diff, secrets, versions, and runtime boundary
         run: |
           npm run release:check-version-sync
           git diff --check
-          if git diff | grep -E '(npm_[A-Za-z0-9]{36}|gh[pousr]_[A-Za-z0-9]{20,}|_authToken|NODE_AUTH_TOKEN|/private/tmp/|/tmp/cortex-release)'; then
+          if git diff | grep -E '(npm_[A-Za-z0-9]{36}|gh[pousr]_[A-Za-z0-9]{20,}|/private/tmp/|/tmp/cortex-release)'; then
             echo "Release diff contains a secret or disposable path"
             exit 1
           fi
@@ -256,7 +220,6 @@ jobs:
             package.json \
             package-lock.json \
             server.json \
-            mcp-registry-submission.json \
             plugins/cortex/.claude-plugin/plugin.json \
             plugins/cortex/.codex-plugin/plugin.json \
             plugins/dsh-cortex/package.json \

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -69,7 +69,7 @@ jobs:
           node scripts/sync-release-version.mjs --check
           echo "value=${TAG_VERSION}" >> "${GITHUB_OUTPUT}"
 
-      - name: Install five independently published dependency trees
+      - name: Install five committed dependency trees
         run: |
           npm ci
           npm ci --prefix frontend
@@ -141,7 +141,7 @@ jobs:
           git -C "${HARNESS_CHECKOUT}" checkout --detach "${HARNESS_COMMIT}"
           node scripts/check-deepseek-harness-compatibility.mjs --checkout "${HARNESS_CHECKOUT}"
 
-      - name: Recreate and verify the reviewed dual artifacts
+      - name: Recreate and verify the reviewed local artifacts
         id: artifacts
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
@@ -154,14 +154,12 @@ jobs:
           ROOT_TARBALL="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.root.first.tarball' "${ARTIFACT_DIR}/report.json")"
           BUNDLE_TARBALL="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.bundle.first.tarball' "${ARTIFACT_DIR}/report.json")"
           ROOT_INTEGRITY="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.root.first.integrity' "${ARTIFACT_DIR}/report.json")"
-          BUNDLE_INTEGRITY="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.bundle.first.integrity' "${ARTIFACT_DIR}/report.json")"
           echo "report=${ARTIFACT_DIR}/report.json" >> "${GITHUB_OUTPUT}"
           echo "root_tarball=${ROOT_TARBALL}" >> "${GITHUB_OUTPUT}"
           echo "bundle_tarball=${BUNDLE_TARBALL}" >> "${GITHUB_OUTPUT}"
           echo "root_integrity=${ROOT_INTEGRITY}" >> "${GITHUB_OUTPUT}"
-          echo "bundle_integrity=${BUNDLE_INTEGRITY}" >> "${GITHUB_OUTPUT}"
 
-      - name: Install both reviewed artifacts with an empty cache
+      - name: Install both reviewed local artifacts with an empty cache
         env:
           ROOT_TARBALL: ${{ steps.artifacts.outputs.root_tarball }}
           BUNDLE_TARBALL: ${{ steps.artifacts.outputs.bundle_tarball }}
@@ -186,36 +184,24 @@ jobs:
             --output-dir "${RUNNER_TEMP}/cortex-harness-lifecycle" \
             --expected-version "${RELEASE_VERSION}"
 
-      - name: Inspect registry for safe immutable resume
+      - name: Inspect exact root registry state for safe immutable resume
         id: registry
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
           ROOT_INTEGRITY: ${{ steps.artifacts.outputs.root_integrity }}
-          BUNDLE_INTEGRITY: ${{ steps.artifacts.outputs.bundle_integrity }}
         run: |
           ROOT_JSON="$(node scripts/release-artifacts.mjs registry-state \
             --package-name @danielblomma/cortex-mcp \
             --version "${RELEASE_VERSION}" \
             --integrity "${ROOT_INTEGRITY}")"
-          BUNDLE_JSON="$(node scripts/release-artifacts.mjs registry-state \
-            --package-name @danielblomma/dsh-cortex \
-            --version "${RELEASE_VERSION}" \
-            --integrity "${BUNDLE_INTEGRITY}" \
-            --root-dependency "${RELEASE_VERSION}")"
           ROOT_STATE="$(node -p 'JSON.parse(process.argv[1]).state' "${ROOT_JSON}")"
-          BUNDLE_STATE="$(node -p 'JSON.parse(process.argv[1]).state' "${BUNDLE_JSON}")"
-          if [ "${ROOT_STATE}" = "missing" ] && [ "${BUNDLE_STATE}" = "exact" ]; then
-            echo "Bundle exists without its exact root artifact"
-            exit 1
-          fi
           echo "root_state=${ROOT_STATE}" >> "${GITHUB_OUTPUT}"
-          echo "bundle_state=${BUNDLE_STATE}" >> "${GITHUB_OUTPUT}"
 
-      - name: Publish exact root artifact first
+      - name: Publish exact reviewed root artifact
         if: steps.registry.outputs.root_state == 'missing'
         run: npm publish "${{ steps.artifacts.outputs.root_tarball }}" --access public --provenance
 
-      - name: Verify exact root registry artifact before bundle publication
+      - name: Verify exact root registry artifact
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
           ROOT_INTEGRITY: ${{ steps.artifacts.outputs.root_integrity }}
@@ -233,57 +219,15 @@ jobs:
           echo "Exact root artifact was not visible within the bounded verification window"
           exit 1
 
-      - name: Publish exact DeepSeek Harness bundle second
-        if: steps.registry.outputs.bundle_state == 'missing'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "The npm bootstrap credential is not configured"
-            exit 1
-          fi
-          npm publish "${{ steps.artifacts.outputs.bundle_tarball }}" --access public --provenance
-
-      - name: Verify exact bundle registry artifact
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-          BUNDLE_INTEGRITY: ${{ steps.artifacts.outputs.bundle_integrity }}
-        run: |
-          for attempt in $(seq 1 12); do
-            STATE_JSON="$(node scripts/release-artifacts.mjs registry-state \
-              --package-name @danielblomma/dsh-cortex \
-              --version "${RELEASE_VERSION}" \
-              --integrity "${BUNDLE_INTEGRITY}" \
-              --root-dependency "${RELEASE_VERSION}")"
-            if [ "$(node -p 'JSON.parse(process.argv[1]).state' "${STATE_JSON}")" = "exact" ]; then
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "Exact bundle artifact was not visible within the bounded verification window"
-          exit 1
-
-      - name: Run fresh registry-only dual-package smoke
+      - name: Run fresh empty-cache root-only registry smoke
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
         run: |
-          node scripts/release-artifacts.mjs install-registry \
-            --output-dir "${RUNNER_TEMP}/cortex-registry-install" \
-            --expected-version "${RELEASE_VERSION}"
           GLOBAL_PREFIX="${RUNNER_TEMP}/cortex-global"
           GLOBAL_CACHE="${RUNNER_TEMP}/cortex-global-empty-cache"
           npm install --global --prefix "${GLOBAL_PREFIX}" --cache "${GLOBAL_CACHE}" \
             "@danielblomma/cortex-mcp@${RELEASE_VERSION}"
           "${GLOBAL_PREFIX}/bin/cortex" --version | grep -F "${RELEASE_VERSION}"
-
-      - name: Run fresh registry-only Harness lifecycle smoke
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          node scripts/release-artifacts.mjs harness-registry \
-            --harness-checkout "${RUNNER_TEMP}/deepseek-harness" \
-            --output-dir "${RUNNER_TEMP}/cortex-registry-harness" \
-            --expected-version "${RELEASE_VERSION}"
 
       - name: Record immutable release evidence
         env:
@@ -291,11 +235,13 @@ jobs:
           REPORT: ${{ steps.artifacts.outputs.report }}
         run: |
           {
-            echo "## Cortex ${RELEASE_VERSION} dual-package publication"
+            echo "## Cortex ${RELEASE_VERSION} root package publication"
             echo "- run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             echo "- tag: ${GITHUB_REF_NAME}"
             echo "- commit: $(git rev-parse HEAD)"
             echo "- tree: $(git rev-parse HEAD^{tree})"
+            echo "- published npm artifact: @danielblomma/cortex-mcp@${RELEASE_VERSION}"
+            echo "- DeepSeek Harness bundle: locally validated; separate npm distribution deferred"
             echo '```json'
             cat "${REPORT}"
             echo '```'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Added
 
-- Added the opt-in `@danielblomma/dsh-cortex` package for the pinned DeepSeek
-  Harness `0.1.1-rc.2` release. It exposes the four explicit, agent-scoped
+- Added the opt-in DeepSeek Harness V1 integration source and validated it
+  against the pinned Harness `0.1.1-rc.2` release. It exposes the four explicit, agent-scoped
   `cortex_search`, `cortex_related`, `cortex_impact`, and `cortex_rules` tools
   plus five synchronized canonical Cortex behavior skills.
 - Bound every invocation to its owning agent workspace and the package-owned
@@ -13,11 +13,11 @@
   handling are bounded; installing the bundle does not initialize, update, or
   watch a repository.
 
-### Install and remove
+### Distribution
 
-- Add Cortex to a named Harness profile with
-  `dsh plugin --profile web add @danielblomma/dsh-cortex` and remove it with
-  `dsh plugin --profile web remove @danielblomma/dsh-cortex`.
+- Cortex 2.6.0 publishes only `@danielblomma/cortex-mcp`. Separate npm bundle
+  distribution for the DeepSeek Harness integration is deferred and currently
+  unavailable.
 - Retrieval remains explicit and user-controlled. Proactive V2 retrieval is
   not included in 2.6.0 and remains planned/experimental.
 

--- a/README.md
+++ b/README.md
@@ -101,12 +101,9 @@ run `cortex connect`.
 ## DeepSeek Harness integration
 
 Cortex supports DeepSeek Harness through the V1 explicit tools and skills
-integration. The initially supported Harness version is `0.1.1-rc.2`. Install
-the bundle into a named profile with:
-
-```bash
-dsh plugin --profile web add @danielblomma/dsh-cortex
-```
+integration. Cortex 2.6.0 contains and validates the integration source against
+the pinned Harness `0.1.1-rc.2` release. Separate npm bundle distribution is
+deferred and currently unavailable.
 
 The bundle provides four agent-scoped tools (`cortex_search`,
 `cortex_related`, `cortex_impact`, and `cortex_rules`) and five Cortex behavior
@@ -116,7 +113,7 @@ user-controlled. The integration does not automatically initialize, update,
 or watch a repository.
 
 V2 proactive/assistive retrieval remains planned and experimental; it is not
-available in Cortex 2.6.0. See the
+included in Cortex 2.6.0. See the
 [V1-to-V2 integration plan](docs/superpowers/plans/2026-08-25-deepseek-harness-integration.md)
 for details.
 

--- a/scripts/release-fresh-checkout.mjs
+++ b/scripts/release-fresh-checkout.mjs
@@ -57,8 +57,8 @@ const mcpOutput = run("npm", ["--prefix", "scaffold/mcp", "run", "test:ci"]);
 if (!/81 passed, 0 failed/.test(rootOutput)) {
   fail("context regression suite did not report 81/81");
 }
-if (!/^# tests 411$/m.test(rootOutput)) {
-  fail("root node:test suite did not report 411/411");
+if (!/^# tests 417$/m.test(rootOutput)) {
+  fail("root node:test suite did not report 417/417");
 }
 if (!/^# tests 6$/m.test(rootOutput)) {
   fail("DeepSeek Harness bundle suite did not report 6/6");
@@ -68,7 +68,7 @@ if (!/^ℹ tests 426$/m.test(mcpOutput)) fail("MCP compatibility suite did not r
 process.stdout.write(`${JSON.stringify({
   ok: true,
   context: "81/81",
-  root: "411/411",
+  root: "417/417",
   deepseekHarnessBundle: "6/6",
   mcp: "426/426",
 })}\n`);

--- a/tests/release-workflows.test.mjs
+++ b/tests/release-workflows.test.mjs
@@ -26,6 +26,7 @@ const supportedNpmVersion = "11.19.1";
 const npmSetupStepName = "Install and verify supported npm CLI";
 const rootPublishStepName = "Publish exact reviewed root artifact";
 const rootRegistryStepName = "Inspect exact root registry state for safe immutable resume";
+const bundlePackageName = "@danielblomma/dsh-cortex";
 
 function stepBlock(source, name) {
   const marker = `      - name: ${name}`;
@@ -43,6 +44,16 @@ function swapStepNames(source, first, second) {
     .replace(`- name: ${placeholder}`, `- name: ${second}`);
 }
 
+function insertWorkflowStep(source, beforeStepName, name, commands) {
+  const marker = `      - name: ${beforeStepName}`;
+  assert.ok(source.includes(marker), `missing insertion point ${beforeStepName}`);
+  const commandBlock = commands.map((command) => `          ${command}`).join("\n");
+  return source.replace(
+    marker,
+    `      - name: ${name}\n        run: |\n${commandBlock}\n\n${marker}`,
+  );
+}
+
 function validateSupportedNpmSetup(workflow, beforeStepName) {
   const setup = stepBlock(workflow, npmSetupStepName);
   assert.match(setup, new RegExp(`npm install --global npm@${supportedNpmVersion.replaceAll(".", "\\.")}`));
@@ -58,6 +69,28 @@ function validateNoNpmCredentials(workflow) {
     workflow,
     /NPM_TOKEN|NODE_AUTH_TOKEN|npm\s+whoami|_authToken|npm\s+(?:login|adduser)|token fallback/i,
     "release workflows must use root trusted publishing without token or login paths",
+  );
+}
+
+function validateNoBundleRegistryActions(workflow) {
+  const bundleIdentity = /@danielblomma\/dsh-cortex|\bBUNDLE_(?:PACKAGE|TARBALL|INTEGRITY|STATE)\b|bundle[_-]tarball/i;
+  for (const block of workflow.split(/(?=^      - name: )/m)) {
+    if (!bundleIdentity.test(block)) continue;
+    assert.doesNotMatch(
+      block,
+      /\bnpm(?:\s|$)/i,
+      "release workflows must not run npm registry or package operations for the bundle",
+    );
+    assert.doesNotMatch(
+      block,
+      /release-artifacts\.mjs\s+(?:registry-state|install-registry|harness-registry)\b/i,
+      "release workflows must not run bundle registry helpers",
+    );
+  }
+  assert.doesNotMatch(
+    workflow,
+    /release-artifacts\.mjs\s+(?:install-registry|harness-registry)\b/i,
+    "release workflows must not restore bundle registry installation or Harness paths",
   );
 }
 
@@ -87,6 +120,7 @@ const synchronizedFiles = [
 ];
 
 function validateBumpWorkflow(workflow) {
+  validateNoBundleRegistryActions(workflow);
   assertBefore(workflow, "- name: Reject non-main dispatch", "- name: Checkout current main");
   assert.match(workflow, /BASE_VERSION: "2\.5\.2"/);
   assert.match(workflow, /RELEASE_VERSION: "2\.6\.0"/);
@@ -126,10 +160,12 @@ function validateBumpWorkflow(workflow) {
   assert.match(workflow, /git push --atomic origin "HEAD:main" "refs\/tags\/\$\{RELEASE_TAG\}"/);
   validateSupportedNpmSetup(workflow, "Create exact 2.6.0 metadata and root artifact lock");
   validateNoNpmCredentials(workflow);
+  assert.doesNotMatch(workflow, /\bnpm publish\b/i, "release bump must not publish any artifact");
   assert.doesNotMatch(workflow, /release-artifacts\.mjs registry-state/);
 }
 
 function validatePublishWorkflow(workflow) {
+  validateNoBundleRegistryActions(workflow);
   assertBefore(workflow, "- name: Reject branch dispatches and non-strict tags", "- name: Checkout immutable tag");
   assert.match(workflow, /test "\$\{GITHUB_REF_TYPE\}" = "tag"/);
   assert.match(workflow, /\^v\(0\|\[1-9\]\[0-9\]\*\)\\\.\(0\|\[1-9\]\[0-9\]\*\)\\\.\(0\|\[1-9\]\[0-9\]\*\)\$/);
@@ -198,6 +234,11 @@ function validateReleaseDocumentation(readme, changelog) {
   assert.doesNotMatch(combined, /dsh plugin[^\n]*@danielblomma\/dsh-cortex/i);
   assert.doesNotMatch(combined, /npm (?:install|i|uninstall|remove)[^\n]*@danielblomma\/dsh-cortex/i);
   assert.doesNotMatch(combined, /(?:publicly|registry)[ -]available[^\n]*dsh-cortex|dsh-cortex[^\n]*(?:publicly|registry)[ -]available/i);
+  assert.doesNotMatch(
+    combined,
+    /@danielblomma\/dsh-cortex[^\n.!?]*(?:available\s+(?:from|on|via|through)\s+(?:the\s+)?npm|published\s+(?:to|on|via|through)\s+(?:the\s+)?npm)|(?:available\s+(?:from|on|via|through)\s+(?:the\s+)?npm|published\s+(?:to|on|via|through)\s+(?:the\s+)?npm)[^\n.!?]*@danielblomma\/dsh-cortex/i,
+    "release documentation must not claim that the bundle is available or published on npm",
+  );
 }
 
 test("committed candidate keeps every root and bundle version at 2.5.2", () => {
@@ -328,8 +369,34 @@ test("release publish rejects OIDC, provenance, runner, tag, version, and resume
   }
 });
 
-test("release publish rejects bundle registry, publication, install, Harness, and summary mutations", () => {
+test("release workflows reject bundle registry, publication, install, Harness, and summary mutations", () => {
+  const bump = readText(".github/workflows/release-bump.yml");
   const workflow = readText(".github/workflows/release-publish.yml");
+  const directCommands = [
+    [`npm view ${bundlePackageName}@2.6.0 version`],
+    [`npm publish ${bundlePackageName} --access public --provenance`],
+    [
+      `npm view ${bundlePackageName}@2.6.0 version`,
+      `npm publish ${bundlePackageName} --access public --provenance`,
+    ],
+  ];
+  for (const [source, validator] of [
+    [bump, validateBumpWorkflow],
+    [workflow, validatePublishWorkflow],
+  ]) {
+    for (const commands of directCommands) {
+      const invalid = insertWorkflowStep(
+        source,
+        "Setup .NET",
+        "Illicit package operation mutation",
+        commands,
+      );
+      assert.throws(
+        () => validator(invalid),
+        /must not (?:run npm registry or package operations for the bundle|publish any artifact)/,
+      );
+    }
+  }
   const registryCommand = "          ROOT_JSON=\"$(node scripts/release-artifacts.mjs registry-state";
   const publishCommand = '        run: npm publish "${{ steps.artifacts.outputs.root_tarball }}" --access public --provenance';
   const smokeCommand = '          npm install --global --prefix "${GLOBAL_PREFIX}" --cache "${GLOBAL_CACHE}" \\';
@@ -440,6 +507,8 @@ test("release documentation rejects bundle commands and availability drift", () 
     [readme, changelog.replace("Separate npm bundle", "npm install @danielblomma/dsh-cortex\n\nSeparate npm bundle")],
     [readme.replace("deferred and currently unavailable", "publicly available"), changelog],
     [readme, changelog.replace("deferred and currently\n  unavailable", "available from the registry")],
+    [`${readme}\n\nThe \`${bundlePackageName}\` package is available from npm.`, changelog],
+    [readme, `${changelog}\n\nThe \`${bundlePackageName}\` package is published on npm.`],
     [readme.replace("not\nincluded in Cortex 2.6.0", "included in Cortex 2.6.0"), changelog],
   ];
   for (const [candidateReadme, candidateChangelog] of mutations) {

--- a/tests/release-workflows.test.mjs
+++ b/tests/release-workflows.test.mjs
@@ -24,8 +24,8 @@ function assertBefore(source, earlier, later, message) {
 
 const supportedNpmVersion = "11.19.1";
 const npmSetupStepName = "Install and verify supported npm CLI";
-const bumpCredentialStepName = "Verify npm publication identity before mutation";
-const bundlePublishStepName = "Publish exact DeepSeek Harness bundle second";
+const rootPublishStepName = "Publish exact reviewed root artifact";
+const rootRegistryStepName = "Inspect exact root registry state for safe immutable resume";
 
 function stepBlock(source, name) {
   const marker = `      - name: ${name}`;
@@ -53,51 +53,12 @@ function validateSupportedNpmSetup(workflow, beforeStepName) {
   assertBefore(workflow, `- name: ${npmSetupStepName}`, `- name: ${beforeStepName}`);
 }
 
-function validateStepScopedToken(workflow, allowedStepName) {
-  const allowed = stepBlock(workflow, allowedStepName);
-  const withoutAllowed = workflow.replace(allowed, "");
+function validateNoNpmCredentials(workflow) {
   assert.doesNotMatch(
-    withoutAllowed,
-    /secrets\.NPM_TOKEN|^\s+(?:NODE_AUTH_TOKEN|NPM_TOKEN):/m,
-    "npm credential must not escape its single authorized step",
+    workflow,
+    /NPM_TOKEN|NODE_AUTH_TOKEN|npm\s+whoami|_authToken|npm\s+(?:login|adduser)|token fallback/i,
+    "release workflows must use root trusted publishing without token or login paths",
   );
-  assert.match(
-    allowed,
-    /env:\n          NODE_AUTH_TOKEN: \$\{\{ secrets\.NPM_TOKEN \}\}/,
-  );
-  assert.doesNotMatch(allowed, /\b(?:echo|printf)\b[^\n]*(?:NODE_AUTH_TOKEN|NPM_TOKEN)/i);
-  assert.doesNotMatch(allowed, /\bset\s+(?:-x|-o\s+xtrace)\b/);
-  assert.doesNotMatch(allowed, /^\s*(?:env|printenv)\s*(?:$|[>|])/m);
-  assert.doesNotMatch(allowed, /npm config (?:get|list|ls)/i);
-  assert.doesNotMatch(allowed, /GITHUB_(?:OUTPUT|STEP_SUMMARY)|actions\/(?:cache|upload-artifact)/);
-  assert.doesNotMatch(
-    allowed,
-    /^\s*(?:npm|node|gh|git|curl)\b[^\n]*(?:NODE_AUTH_TOKEN|NPM_TOKEN)/m,
-    "npm credential must not be passed as a command argument",
-  );
-}
-
-function validateBumpCredentialGate(workflow) {
-  validateSupportedNpmSetup(workflow, bumpCredentialStepName);
-  validateStepScopedToken(workflow, bumpCredentialStepName);
-  const gate = stepBlock(workflow, bumpCredentialStepName);
-  assert.match(gate, /if \[ -z "\$\{NODE_AUTH_TOKEN:-\}" \]; then/);
-  assert.match(gate, /npm whoami --registry=https:\/\/registry\.npmjs\.org\//);
-  assert.match(gate, /value !== "danielblomma\\n"/);
-  assert.match(gate, /env -u NODE_AUTH_TOKEN node/);
-  for (const mutationStep of [
-    "Install all committed dependency trees",
-    "Create exact 2.6.0 metadata and root artifact lock",
-    "Stage only the complete release metadata set",
-    "Commit and create immutable release tag",
-  ]) {
-    assertBefore(workflow, `- name: ${bumpCredentialStepName}`, `- name: ${mutationStep}`);
-  }
-  assertBefore(workflow, `- name: ${bumpCredentialStepName}`, "npm version minor");
-  assertBefore(workflow, `- name: ${bumpCredentialStepName}`, "sync-release-version.mjs --root-tarball");
-  assertBefore(workflow, `- name: ${bumpCredentialStepName}`, "git add ");
-  assertBefore(workflow, `- name: ${bumpCredentialStepName}`, "git commit -m");
-  assertBefore(workflow, `- name: ${bumpCredentialStepName}`, "git tag -a");
 }
 
 function validatePublishAuthentication(workflow) {
@@ -105,25 +66,19 @@ function validatePublishAuthentication(workflow) {
   assert.match(workflow, /jobs:\n  publish:\n    runs-on: ubuntu-latest/);
   validateSupportedNpmSetup(workflow, "Verify annotated tag and all metadata versions");
 
-  const rootPublish = stepBlock(workflow, "Publish exact root artifact first");
+  const rootPublish = stepBlock(workflow, rootPublishStepName);
   assert.match(rootPublish, /if: steps\.registry\.outputs\.root_state == 'missing'/);
   assert.match(rootPublish, /--access public --provenance/);
-  assert.doesNotMatch(rootPublish, /NPM_TOKEN|NODE_AUTH_TOKEN|secrets\./);
-
-  const bundlePublish = stepBlock(workflow, bundlePublishStepName);
-  validateStepScopedToken(workflow, bundlePublishStepName);
-  assert.match(bundlePublish, /if: steps\.registry\.outputs\.bundle_state == 'missing'/);
-  assert.match(bundlePublish, /if \[ -z "\$\{NODE_AUTH_TOKEN:-\}" \]; then/);
-  assert.match(bundlePublish, /--access public --provenance/);
-  assertBefore(workflow, "- name: Inspect registry for safe immutable resume", `- name: ${bundlePublishStepName}`);
-  assertBefore(workflow, "- name: Verify exact root registry artifact before bundle publication", `- name: ${bundlePublishStepName}`);
+  assert.doesNotMatch(rootPublish, /env:|secrets\./);
+  assert.equal((workflow.match(/\bnpm publish\b/g) ?? []).length, 1);
+  assert.doesNotMatch(workflow, /npm publish[^\n]*bundle_tarball/i);
+  validateNoNpmCredentials(workflow);
 }
 
 const synchronizedFiles = [
   "package.json",
   "package-lock.json",
   "server.json",
-  "mcp-registry-submission.json",
   "plugins/cortex/.claude-plugin/plugin.json",
   "plugins/cortex/.codex-plugin/plugin.json",
   "plugins/dsh-cortex/package.json",
@@ -138,9 +93,14 @@ function validateBumpWorkflow(workflow) {
   assert.match(workflow, /test "\$\{RELEASE_TYPE\}" = "minor"/);
   assert.match(workflow, /test "\$\(git rev-parse HEAD\)" = "\$\(git rev-parse origin\/main\)"/);
   assert.match(workflow, /sync-release-version\.mjs --root-tarball/);
+  const mutationSet = stepBlock(workflow, "Verify complete metadata mutation set");
+  const stagedSet = stepBlock(workflow, "Stage only the complete release metadata set");
   for (const file of synchronizedFiles) {
-    assert.ok(workflow.includes(file), `release bump omits synchronized file ${file}`);
+    assert.ok(mutationSet.includes(file), `release bump omits mutated metadata file ${file}`);
+    assert.ok(stagedSet.includes(file), `release bump omits staged metadata file ${file}`);
   }
+  assert.doesNotMatch(mutationSet, /mcp-registry-submission\.json/);
+  assert.doesNotMatch(stagedSet, /mcp-registry-submission\.json/);
   for (const gate of [
     "Run focused release contract tests",
     "Prepare isolated repository test context",
@@ -149,8 +109,8 @@ function validateBumpWorkflow(workflow) {
     "Run context runtime and MCP compatibility tests",
     "Audit all six committed dependency trees",
     "Verify pinned DeepSeek Harness contract",
-    "Create and verify duplicate dual-package artifacts",
-    "Install both unpublished artifacts with an empty cache",
+    "Create and verify duplicate local root and bundle artifacts",
+    "Install both local artifacts with an empty cache",
     "Run packed Harness headless and Web lifecycle",
     "Run executable fresh-checkout regression",
   ]) {
@@ -164,14 +124,20 @@ function validateBumpWorkflow(workflow) {
   assertBefore(workflow, "- name: Prepare isolated MCP test context", "- name: Run context runtime and MCP compatibility tests");
   assert.match(workflow, /release:prepare-mcp-test-context/);
   assert.match(workflow, /git push --atomic origin "HEAD:main" "refs\/tags\/\$\{RELEASE_TAG\}"/);
-  validateBumpCredentialGate(workflow);
+  validateSupportedNpmSetup(workflow, "Create exact 2.6.0 metadata and root artifact lock");
+  validateNoNpmCredentials(workflow);
+  assert.doesNotMatch(workflow, /release-artifacts\.mjs registry-state/);
 }
 
 function validatePublishWorkflow(workflow) {
   assertBefore(workflow, "- name: Reject branch dispatches and non-strict tags", "- name: Checkout immutable tag");
   assert.match(workflow, /test "\$\{GITHUB_REF_TYPE\}" = "tag"/);
   assert.match(workflow, /\^v\(0\|\[1-9\]\[0-9\]\*\)\\\.\(0\|\[1-9\]\[0-9\]\*\)\\\.\(0\|\[1-9\]\[0-9\]\*\)\$/);
-  assertBefore(workflow, 'test "${TAG_VERSION}" = "${BUNDLE_DEPENDENCY}"', "- name: Install five independently published dependency trees");
+  assert.match(workflow, /test "\$\(git cat-file -t "\$\{TAG_NAME\}"\)" = "tag"/);
+  assert.match(workflow, /test "\$\(git rev-list -n 1 "\$\{TAG_NAME\}"\)" = "\$\(git rev-parse HEAD\)"/);
+  assert.match(workflow, /test -z "\$\(git status --porcelain\)"/);
+  assert.match(workflow, /test "\$\{TAG_VERSION\}" = "\$\{ROOT_VERSION\}"/);
+  assertBefore(workflow, 'test "${TAG_VERSION}" = "${BUNDLE_DEPENDENCY}"', "- name: Install five committed dependency trees");
   for (const gate of [
     "Run focused release contract tests",
     "Prepare isolated repository test context",
@@ -180,23 +146,22 @@ function validatePublishWorkflow(workflow) {
     "Run context runtime and MCP compatibility tests",
     "Audit all six committed dependency trees",
     "Verify pinned DeepSeek Harness contract",
-    "Recreate and verify the reviewed dual artifacts",
-    "Install both reviewed artifacts with an empty cache",
+    "Recreate and verify the reviewed local artifacts",
+    "Install both reviewed local artifacts with an empty cache",
     "Run packed Harness headless and Web lifecycle",
     "Run executable fresh-checkout regression",
   ]) {
-    assertBefore(workflow, `- name: ${gate}`, "- name: Publish exact root artifact first");
+    assertBefore(workflow, `- name: ${gate}`, `- name: ${rootPublishStepName}`);
   }
-  assertBefore(workflow, "- name: Publish exact root artifact first", "- name: Verify exact root registry artifact before bundle publication");
-  assertBefore(workflow, "- name: Verify exact root registry artifact before bundle publication", "- name: Publish exact DeepSeek Harness bundle second");
-  assertBefore(workflow, "- name: Publish exact DeepSeek Harness bundle second", "- name: Verify exact bundle registry artifact");
+  assertBefore(workflow, `- name: ${rootRegistryStepName}`, `- name: ${rootPublishStepName}`);
+  assertBefore(workflow, `- name: ${rootPublishStepName}`, "- name: Verify exact root registry artifact");
+  assertBefore(workflow, "- name: Verify exact root registry artifact", "- name: Run fresh empty-cache root-only registry smoke");
   assert.match(workflow, /if: steps\.registry\.outputs\.root_state == 'missing'/);
-  assert.match(workflow, /if: steps\.registry\.outputs\.bundle_state == 'missing'/);
   assert.match(workflow, /release-artifacts\.mjs registry-state/);
-  const registry = stepBlock(workflow, "Inspect registry for safe immutable resume");
+  const registry = stepBlock(workflow, rootRegistryStepName);
   assert.match(registry, /--package-name @danielblomma\/cortex-mcp[\s\S]*?--integrity "\$\{ROOT_INTEGRITY\}"/);
-  assert.match(registry, /--package-name @danielblomma\/dsh-cortex[\s\S]*?--integrity "\$\{BUNDLE_INTEGRITY\}"[\s\S]*?--root-dependency "\$\{RELEASE_VERSION\}"/);
-  assert.match(registry, /"\$\{ROOT_STATE\}" = "missing"[\s\S]*?"\$\{BUNDLE_STATE\}" = "exact"/);
+  assert.match(registry, /root_state=\$\{ROOT_STATE\}/);
+  assert.doesNotMatch(registry, /dsh-cortex|BUNDLE|root-dependency/);
   assert.match(workflow, /Run full root and bundle tests[\s\S]*?CORTEX_EXPECTED_RELEASE_VERSION: \$\{\{ steps\.version\.outputs\.value \}\}[\s\S]*?run: npm test/);
   assertBefore(workflow, "- name: Prepare isolated repository test context", "- name: Run full root and bundle tests");
   assert.match(workflow, /release:prepare-root-test-context/);
@@ -204,9 +169,35 @@ function validatePublishWorkflow(workflow) {
   assertBefore(workflow, "- name: Prepare isolated MCP test context", "- name: Run context runtime and MCP compatibility tests");
   assert.match(workflow, /release:prepare-mcp-test-context/);
   assert.match(workflow, /npm publish "\$\{\{ steps\.artifacts\.outputs\.root_tarball \}\}"/);
-  assert.match(workflow, /npm publish "\$\{\{ steps\.artifacts\.outputs\.bundle_tarball \}\}"/);
+  const verification = stepBlock(workflow, "Verify exact root registry artifact");
+  assert.match(verification, /for attempt in \$\(seq 1 12\)/);
+  assert.match(verification, /--package-name @danielblomma\/cortex-mcp/);
+  assert.match(verification, /--integrity "\$\{ROOT_INTEGRITY\}"/);
+  assert.match(verification, /\)" = "exact"/);
+  const registrySmoke = stepBlock(workflow, "Run fresh empty-cache root-only registry smoke");
+  assert.match(registrySmoke, /--cache "\$\{GLOBAL_CACHE\}"/);
+  assert.match(registrySmoke, /@danielblomma\/cortex-mcp@\$\{RELEASE_VERSION\}/);
+  assert.match(registrySmoke, /\/bin\/cortex" --version/);
+  assert.doesNotMatch(registrySmoke, /dsh-cortex|install-registry|harness-registry/);
+  const registryTail = workflow.slice(workflow.indexOf(`- name: ${rootRegistryStepName}`));
+  assert.doesNotMatch(registryTail, /@danielblomma\/dsh-cortex|bundle_tarball|bundle_integrity|install-registry|harness-registry/i);
+  assert.doesNotMatch(workflow, /dual-package publication|dual publication|bundle registry/i);
+  assert.match(workflow, /DeepSeek Harness bundle: locally validated; separate npm distribution deferred/);
   assert.doesNotMatch(workflow, /@latest/);
   validatePublishAuthentication(workflow);
+}
+
+function validateReleaseDocumentation(readme, changelog) {
+  const combined = `${readme}\n${changelog}`;
+  assert.match(readme, /Cortex 2\.6\.0 contains and validates the integration source/);
+  assert.match(readme, /Separate npm bundle distribution is\s+deferred and currently unavailable/);
+  assert.match(changelog, /Separate npm bundle\s+distribution[^.]*deferred and currently\s+unavailable/);
+  assert.match(readme, /V2 proactive\/assistive retrieval remains planned and experimental/);
+  assert.match(readme, /not\s+included in Cortex 2\.6\.0/);
+  assert.match(changelog, /Proactive V2 retrieval is\s+not included in 2\.6\.0/);
+  assert.doesNotMatch(combined, /dsh plugin[^\n]*@danielblomma\/dsh-cortex/i);
+  assert.doesNotMatch(combined, /npm (?:install|i|uninstall|remove)[^\n]*@danielblomma\/dsh-cortex/i);
+  assert.doesNotMatch(combined, /(?:publicly|registry)[ -]available[^\n]*dsh-cortex|dsh-cortex[^\n]*(?:publicly|registry)[ -]available/i);
 }
 
 test("committed candidate keeps every root and bundle version at 2.5.2", () => {
@@ -263,7 +254,7 @@ test("release bump regression validator rejects omitted bundle lock staging", ()
     "plugins/dsh-cortex/package-lock.json",
     "plugins/dsh-cortex/omitted-lock.json",
   );
-  assert.throws(() => validateBumpWorkflow(workflow), /omits synchronized file/);
+  assert.throws(() => validateBumpWorkflow(workflow), /omits (?:mutated|staged) metadata file/);
 });
 
 test("release workflows reject absent, unsupported, or late npm setup", () => {
@@ -273,53 +264,34 @@ test("release workflows reject absent, unsupported, or late npm setup", () => {
   for (const [candidate, validator] of [
     [bump.replace(setupMarker, "- name: omitted npm setup"), validateBumpWorkflow],
     [bump.replaceAll(supportedNpmVersion, "11.5.0"), validateBumpWorkflow],
-    [swapStepNames(bump, npmSetupStepName, bumpCredentialStepName), validateBumpWorkflow],
+    [swapStepNames(bump, npmSetupStepName, "Create exact 2.6.0 metadata and root artifact lock"), validateBumpWorkflow],
     [publish.replace(setupMarker, "- name: omitted npm setup"), validatePublishWorkflow],
     [publish.replaceAll(supportedNpmVersion, "10.9.8"), validatePublishWorkflow],
+    [swapStepNames(publish, npmSetupStepName, "Verify annotated tag and all metadata versions"), validatePublishWorkflow],
   ]) {
     assert.throws(() => validator(candidate));
   }
 });
 
-test("release bump credential gate rejects auth and ordering mutations", () => {
-  const workflow = readText(".github/workflows/release-bump.yml");
-  const gateMarker = `- name: ${bumpCredentialStepName}`;
-  const mutations = [
-    workflow.replace(gateMarker, "- name: omitted credential gate"),
-    workflow.replace('if [ -z "${NODE_AUTH_TOKEN:-}" ]; then', "if false; then"),
-    workflow.replace('value !== "danielblomma\\n"', 'value !== "another-owner\\n"'),
-    workflow.replace("npm whoami --registry=https://registry.npmjs.org/", "npm whoami"),
-    swapStepNames(
-      workflow,
-      bumpCredentialStepName,
-      "Create exact 2.6.0 metadata and root artifact lock",
-    ),
-  ];
-  for (const invalid of mutations) {
-    assert.throws(() => validateBumpWorkflow(invalid));
-  }
-});
-
-test("release workflows reject broadened or observable npm credentials", () => {
+test("release workflows reject every npm credential and login path", () => {
   const bump = readText(".github/workflows/release-bump.yml");
   const publish = readText(".github/workflows/release-publish.yml");
-  const invalid = [
-    [bump.replace("    env:\n      BASE_VERSION", "    env:\n      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}\n      BASE_VERSION"), validateBumpWorkflow],
-    [bump.replace("- name: Run focused release contract tests", "- name: Run focused release contract tests\n        env:\n          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}"), validateBumpWorkflow],
-    [bump.replace("          set -o pipefail", '          echo "${NODE_AUTH_TOKEN}"\n          set -o pipefail'), validateBumpWorkflow],
-    [bump.replace("          set -o pipefail", '          printf "%s" "${NODE_AUTH_TOKEN}"\n          set -o pipefail'), validateBumpWorkflow],
-    [bump.replace("          set -o pipefail", "          set -x\n          set -o pipefail"), validateBumpWorkflow],
-    [bump.replace("          set -o pipefail", "          printenv\n          set -o pipefail"), validateBumpWorkflow],
-    [bump.replace("          set -o pipefail", "          npm config list\n          set -o pipefail"), validateBumpWorkflow],
-    [bump.replace("          set -o pipefail", '          npm whoami "${NODE_AUTH_TOKEN}"\n          set -o pipefail'), validateBumpWorkflow],
-    [publish.replace("    env:\n      HARNESS_COMMIT", "    env:\n      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}\n      HARNESS_COMMIT"), validatePublishWorkflow],
-    [publish.replace("          npm publish \"${{ steps.artifacts.outputs.bundle_tarball }}\"", '          echo "${NODE_AUTH_TOKEN}" >> "${GITHUB_OUTPUT}"\n          npm publish "${{ steps.artifacts.outputs.bundle_tarball }}"'), validatePublishWorkflow],
-    [publish.replace("          npm publish \"${{ steps.artifacts.outputs.bundle_tarball }}\"", '          echo "${NODE_AUTH_TOKEN}" >> "${GITHUB_STEP_SUMMARY}"\n          npm publish "${{ steps.artifacts.outputs.bundle_tarball }}"'), validatePublishWorkflow],
-    [publish.replace("          npm publish \"${{ steps.artifacts.outputs.bundle_tarball }}\"", "          uses: actions/cache@v4\n          npm publish \"${{ steps.artifacts.outputs.bundle_tarball }}\""), validatePublishWorkflow],
-    [publish.replace("          npm publish \"${{ steps.artifacts.outputs.bundle_tarball }}\"", "          uses: actions/upload-artifact@v4\n          npm publish \"${{ steps.artifacts.outputs.bundle_tarball }}\""), validatePublishWorkflow],
+  const marker = "      HARNESS_COMMIT:";
+  const mutations = [
+    [bump, "      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}\n"],
+    [publish, "      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}\n"],
+    [bump, "      AUTH_CHECK: npm whoami\n"],
+    [publish, "      AUTH_CONFIG: //registry.npmjs.org/:_authToken=placeholder\n"],
+    [bump, "      LOGIN_COMMAND: npm login\n"],
+    [publish, "      LOGIN_COMMAND: npm adduser\n"],
+    [publish, "      AUTH_MODE: token fallback\n"],
   ];
-  for (const [candidate, validator] of invalid) {
-    assert.throws(() => validator(candidate));
+  for (const [workflow, insertion] of mutations) {
+    const candidate = workflow.includes(marker)
+      ? workflow.replace(marker, `${insertion}${marker}`)
+      : workflow.replace("      BASE_VERSION:", `${insertion}      BASE_VERSION:`);
+    const validator = workflow === bump ? validateBumpWorkflow : validatePublishWorkflow;
+    assert.throws(() => validator(candidate), /trusted publishing without token or login paths/);
   }
 });
 
@@ -327,38 +299,56 @@ test("release publish is tag-only, root-first, exact-artifact, and resumable", (
   validatePublishWorkflow(readText(".github/workflows/release-publish.yml"));
 });
 
-test("release publish regression validator rejects bundle-before-root verification", () => {
+test("release publish rejects publication before local artifact and Harness gates", () => {
   const workflow = readText(".github/workflows/release-publish.yml");
-  const rootVerify = "- name: Verify exact root registry artifact before bundle publication";
-  const bundlePublish = "- name: Publish exact DeepSeek Harness bundle second";
-  const invalid = workflow.replace(rootVerify, "- name: deferred root verification")
-    .replace(bundlePublish, rootVerify)
-    .replace("- name: deferred root verification", bundlePublish);
+  const invalid = swapStepNames(
+    workflow,
+    rootPublishStepName,
+    "Run packed Harness headless and Web lifecycle",
+  );
   assert.throws(() => validatePublishWorkflow(invalid), /must precede/);
 });
 
-test("release publish rejects OIDC, provenance, runner, fallback, and resume mutations", () => {
+test("release publish rejects OIDC, provenance, runner, tag, version, and resume mutations", () => {
   const workflow = readText(".github/workflows/release-publish.yml");
   const mutations = [
     workflow.replace("id-token: write", "id-token: none"),
     workflow.replace("runs-on: ubuntu-latest", "runs-on: self-hosted"),
     workflow.replace('npm publish "${{ steps.artifacts.outputs.root_tarball }}" --access public --provenance', 'npm publish "${{ steps.artifacts.outputs.root_tarball }}" --access public'),
-    workflow.replace('npm publish "${{ steps.artifacts.outputs.bundle_tarball }}" --access public --provenance', 'npm publish "${{ steps.artifacts.outputs.bundle_tarball }}" --access public'),
-    workflow.replace("      - name: Publish exact root artifact first\n", "      - name: Publish exact root artifact first\n        env:\n          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}\n"),
-    workflow.replace("          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}", "          BOOTSTRAP_DISABLED: true"),
-    workflow.replace("if: steps.registry.outputs.bundle_state == 'missing'", "if: always()"),
+    workflow.replace("if: steps.registry.outputs.root_state == 'missing'", "if: always()"),
     workflow.replace('--integrity "${ROOT_INTEGRITY}"', '--integrity "unchecked"'),
     workflow.replace('test "${GITHUB_REF_TYPE}" = "tag"', 'test "${GITHUB_REF_TYPE}" = "branch"'),
     workflow.replace("^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$", "^v.*$"),
+    workflow.replace('test "$(git cat-file -t "${TAG_NAME}")" = "tag"', "true # lightweight tag accepted"),
+    workflow.replace('test "${TAG_VERSION}" = "${ROOT_VERSION}"', "true # tag/root drift accepted"),
     workflow.replace('test "${TAG_VERSION}" = "${BUNDLE_DEPENDENCY}"', "true # mutable dependency accepted"),
-    workflow.replace("@danielblomma/dsh-cortex", "@danielblomma/dsh-cortex@latest"),
   ];
   for (const invalid of mutations) {
     assert.throws(() => validatePublishWorkflow(invalid));
   }
 });
 
-test("artifact helper fixes the bundle inventory and verifies local plus registry installs", () => {
+test("release publish rejects bundle registry, publication, install, Harness, and summary mutations", () => {
+  const workflow = readText(".github/workflows/release-publish.yml");
+  const registryCommand = "          ROOT_JSON=\"$(node scripts/release-artifacts.mjs registry-state";
+  const publishCommand = '        run: npm publish "${{ steps.artifacts.outputs.root_tarball }}" --access public --provenance';
+  const smokeCommand = '          npm install --global --prefix "${GLOBAL_PREFIX}" --cache "${GLOBAL_CACHE}" \\';
+  const summary = '            echo "## Cortex ${RELEASE_VERSION} root package publication"';
+  const mutations = [
+    workflow.replace(
+      publishCommand,
+      `${publishCommand}\n` + '          npm publish "${{ steps.artifacts.outputs.bundle_tarball }}" --access public --provenance',
+    ),
+    workflow.replace(registryCommand, '          node scripts/release-artifacts.mjs registry-state --package-name @danielblomma/dsh-cortex --version "${RELEASE_VERSION}" --integrity unchecked\n' + registryCommand),
+    workflow.replace(smokeCommand, '          node scripts/release-artifacts.mjs install-registry --output-dir registry --expected-version "${RELEASE_VERSION}"\n' + smokeCommand),
+    workflow.replace(smokeCommand, '          node scripts/release-artifacts.mjs harness-registry --harness-checkout harness --output-dir registry-harness --expected-version "${RELEASE_VERSION}"\n' + smokeCommand),
+    workflow.replace(summary, '            echo "## Cortex ${RELEASE_VERSION} dual-package publication"'),
+    workflow.replace("      - name: Verify exact root registry artifact\n", "      - name: Verify exact bundle registry artifact\n"),
+  ];
+  for (const invalid of mutations) assert.throws(() => validatePublishWorkflow(invalid));
+});
+
+test("artifact helper fixes the bundle inventory and exact root registry checks", () => {
   const helper = readText("scripts/release-artifacts.mjs");
   for (const entry of [
     "cordis.patch.yml",
@@ -378,8 +368,8 @@ test("artifact helper fixes the bundle inventory and verifies local plus registr
   assert.match(helper, /assertTwins\("root"/);
   assert.match(helper, /assertTwins\("bundle"/);
   assert.match(helper, /empty-npm-cache/);
-  assert.match(helper, /install-registry/);
-  assert.match(helper, /harness-registry/);
+  assert.match(helper, /manifest\.name !== packageName \|\| manifest\.version !== version \|\| manifest\.dist\?\.integrity !== integrity/);
+  assert.match(helper, /latest !== version/);
   assert.match(helper, /mcp-context/);
   assert.match(helper, /root-context/);
   assert.match(helper, /load-ryu\.sh/);
@@ -438,10 +428,21 @@ test("artifact helper fixes the bundle inventory and verifies local plus registr
 test("release documentation distinguishes shipped explicit V1 from unavailable V2", () => {
   const readme = readText("README.md");
   const changelog = readText("CHANGELOG.md");
-  assert.match(readme, /supports DeepSeek Harness through the V1 explicit tools and skills/);
-  assert.match(readme, /dsh plugin --profile web add @danielblomma\/dsh-cortex/);
-  assert.match(readme, /V2 proactive\/assistive retrieval remains planned and experimental/);
-  assert.match(readme, /not\s+available in Cortex 2\.6\.0/);
   assert.match(changelog, /## 2\.6\.0 — 2026-08-30/);
-  assert.match(changelog, /Proactive V2 retrieval is\n  not included in 2\.6\.0/);
+  validateReleaseDocumentation(readme, changelog);
+});
+
+test("release documentation rejects bundle commands and availability drift", () => {
+  const readme = readText("README.md");
+  const changelog = readText("CHANGELOG.md");
+  const mutations = [
+    [readme.replace("Separate npm bundle distribution", "dsh plugin --profile web add @danielblomma/dsh-cortex\n\nSeparate npm bundle distribution"), changelog],
+    [readme, changelog.replace("Separate npm bundle", "npm install @danielblomma/dsh-cortex\n\nSeparate npm bundle")],
+    [readme.replace("deferred and currently unavailable", "publicly available"), changelog],
+    [readme, changelog.replace("deferred and currently\n  unavailable", "available from the registry")],
+    [readme.replace("not\nincluded in Cortex 2.6.0", "included in Cortex 2.6.0"), changelog],
+  ];
+  for (const [candidateReadme, candidateChangelog] of mutations) {
+    assert.throws(() => validateReleaseDocumentation(candidateReadme, candidateChangelog));
+  }
 });


### PR DESCRIPTION
## Summary

- prepare the existing release workflows for a root-only Cortex `2.6.0` release through the proven npm OIDC/trusted-publisher path
- publish only `@danielblomma/cortex-mcp`; retain local DeepSeek Harness V1 bundle validation while keeping separate `@danielblomma/dsh-cortex` npm distribution deferred and currently unavailable
- preserve strict annotated-tag, deterministic artifact, exact-resume, integrity, provenance, and post-publish root install/version gates
- align the fresh-checkout root-test assertion with the accepted `417/417` total and strengthen focused mutation negatives

## Exact reviewed identity

- head: `a0c6a6a312f33ca0132684085a01214a6707edad`
- tree: `a05c6e09d1b3b44f06bbe7d40b7a105a0a94b527`
- base: `4dd2e810e9b3cac17452a6dabc6913057823234f`
- relation: exactly two commits and six packet-owned paths
- candidate metadata remains `2.5.2`; the release workflow performs the controlled `2.6.0` bump after merge

## Validation

Accepted implementation and fresh independent re-review evidence includes:

- `npm run release:test`: 24/24
- `npm run release:check-version-sync`: pass at `2.5.2`
- six clean installs and dependency audits: zero findings
- context/root/bundle/MCP suites: 81/81, 417/417, 6/6, 426/426
- fresh-checkout and packed-containment gates: pass
- deterministic disposable `2.6.0` root and local bundle packs, empty-cache dual-local install, pinned Harness 18/18, and packed headless/Web lifecycle: pass
- exact six-path allow-list, syntax/JSON/YAML, `git diff --check`, source/artifact credential and dependency scans: pass

## Finding closure

- `WO067-IR-001`: closed; direct and combined bundle registry/publication mutations now fail closed in both workflows, and Release Bump rejects every publish command
- `WO067-IR-002`: closed; contradictory bundle npm availability/publication claims now fail closed in README and CHANGELOG validation
- no current blocker, major, minor, deferred, or waived finding

This PR performs release preparation only. It does not merge, dispatch workflows, create or move tags, publish either package, create a GitHub Release, or change npm/GitHub secrets or trusted-publisher configuration.
