### PR TITLE
release: remove blocking validation gates

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -22,7 +22,6 @@ jobs:
       BASE_VERSION: "2.5.2"
       RELEASE_VERSION: "2.6.0"
       RELEASE_TAG: "v2.6.0"
-      HARNESS_COMMIT: "b150a551b8d465e31e418e1b2eaf5e79bbb7d28e"
 
     steps:
       - name: Reject non-main dispatch
@@ -69,27 +68,10 @@ jobs:
           npm install --global npm@11.19.1
           test "$(npm --version)" = "11.19.1"
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: "8.0.x"
-
       - name: Configure git author
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Install all committed dependency trees
-        run: |
-          npm ci
-          npm ci --prefix frontend
-          npm ci --prefix scaffold/mcp
-          npm ci --prefix scaffold/scripts/parsers
-          npm ci --prefix scripts/parsers
-          npm ci --prefix plugins/dsh-cortex
-
-      - name: Build trusted context runtime
-        run: npm --prefix scaffold/mcp run build
 
       - name: Create exact 2.6.0 metadata and root artifact lock
         id: seed
@@ -121,90 +103,6 @@ jobs:
             server.json | LC_ALL=C sort > "${EXPECTED}"
           diff -u "${EXPECTED}" "${ACTUAL}"
 
-      - name: Bind bundle tests to the reviewed local root artifact
-        env:
-          ROOT_TARBALL: ${{ steps.seed.outputs.root_tarball }}
-        run: |
-          npm --prefix plugins/dsh-cortex install --no-save --package-lock=false "${ROOT_TARBALL}"
-          test "$(node -p 'require("./plugins/dsh-cortex/node_modules/@danielblomma/cortex-mcp/package.json").version')" = "${RELEASE_VERSION}"
-
-      - name: Run focused release contract tests
-        env:
-          CORTEX_EXPECTED_RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-        run: npm run release:test
-
-      - name: Prepare isolated repository test context
-        run: npm run release:prepare-root-test-context
-
-      - name: Run full root and bundle tests
-        env:
-          CORTEX_EXPECTED_RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-        run: npm test
-
-      - name: Prepare isolated MCP test context
-        run: npm run release:prepare-mcp-test-context
-
-      - name: Run context runtime and MCP compatibility tests
-        run: npm --prefix scaffold/mcp run test:ci
-
-      - name: Run executable fresh-checkout regression
-        env:
-          CORTEX_EXPECTED_RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-        run: |
-          git clean -fdx .context scaffold/.context
-          git restore .context scaffold/.context
-          npm run release:test-fresh-checkout
-
-      - name: Audit all six committed dependency trees
-        run: |
-          npm run audit:dependencies
-          npm audit --package-lock-only --audit-level=low --prefix plugins/dsh-cortex
-
-      - name: Validate packed filesystem containment
-        run: npm run release:packed-containment
-
-      - name: Verify pinned DeepSeek Harness contract
-        run: |
-          HARNESS_CHECKOUT="${RUNNER_TEMP}/deepseek-harness"
-          git clone --filter=blob:none --no-checkout https://github.com/deepseek-ai/deepseek-harness.git "${HARNESS_CHECKOUT}"
-          git -C "${HARNESS_CHECKOUT}" checkout --detach "${HARNESS_COMMIT}"
-          node scripts/check-deepseek-harness-compatibility.mjs --checkout "${HARNESS_CHECKOUT}"
-
-      - name: Create and verify duplicate local root and bundle artifacts
-        id: artifacts
-        run: |
-          ARTIFACT_DIR="${RUNNER_TEMP}/cortex-release-artifacts"
-          node scripts/release-artifacts.mjs pack \
-            --output-dir "${ARTIFACT_DIR}" \
-            --expected-version "${RELEASE_VERSION}" \
-            --report "${ARTIFACT_DIR}/report.json"
-          ROOT_TARBALL="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.root.first.tarball' "${ARTIFACT_DIR}/report.json")"
-          BUNDLE_TARBALL="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.bundle.first.tarball' "${ARTIFACT_DIR}/report.json")"
-          echo "root_tarball=${ROOT_TARBALL}" >> "${GITHUB_OUTPUT}"
-          echo "bundle_tarball=${BUNDLE_TARBALL}" >> "${GITHUB_OUTPUT}"
-
-      - name: Install both local artifacts with an empty cache
-        env:
-          ROOT_TARBALL: ${{ steps.artifacts.outputs.root_tarball }}
-          BUNDLE_TARBALL: ${{ steps.artifacts.outputs.bundle_tarball }}
-        run: |
-          node scripts/release-artifacts.mjs install \
-            --root-tarball "${ROOT_TARBALL}" \
-            --bundle-tarball "${BUNDLE_TARBALL}" \
-            --output-dir "${RUNNER_TEMP}/cortex-release-install" \
-            --expected-version "${RELEASE_VERSION}"
-
-      - name: Run packed Harness headless and Web lifecycle
-        env:
-          ROOT_TARBALL: ${{ steps.artifacts.outputs.root_tarball }}
-          BUNDLE_TARBALL: ${{ steps.artifacts.outputs.bundle_tarball }}
-        run: |
-          node scripts/release-artifacts.mjs harness \
-            --harness-checkout "${RUNNER_TEMP}/deepseek-harness" \
-            --root-tarball "${ROOT_TARBALL}" \
-            --bundle-tarball "${BUNDLE_TARBALL}" \
-            --output-dir "${RUNNER_TEMP}/cortex-harness-lifecycle" \
-            --expected-version "${RELEASE_VERSION}"
 
       - name: Verify diff, secrets, versions, and runtime boundary
         run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -13,8 +13,6 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    env:
-      HARNESS_COMMIT: "b150a551b8d465e31e418e1b2eaf5e79bbb7d28e"
 
     steps:
       - name: Reject branch dispatches and non-strict tags
@@ -46,11 +44,6 @@ jobs:
           npm install --global npm@11.19.1
           test "$(npm --version)" = "11.19.1"
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: "8.0.x"
-
       - name: Verify annotated tag and all metadata versions
         id: version
         env:
@@ -69,17 +62,6 @@ jobs:
           node scripts/sync-release-version.mjs --check
           echo "value=${TAG_VERSION}" >> "${GITHUB_OUTPUT}"
 
-      - name: Install five committed dependency trees
-        run: |
-          npm ci
-          npm ci --prefix frontend
-          npm ci --prefix scaffold/mcp
-          npm ci --prefix scaffold/scripts/parsers
-          npm ci --prefix scripts/parsers
-
-      - name: Build trusted context runtime
-        run: npm --prefix scaffold/mcp run build
-
       - name: Prove the locked root integrity from the tagged artifact
         id: seed
         env:
@@ -90,107 +72,16 @@ jobs:
           npm pack --json --ignore-scripts --pack-destination "${SEED_DIR}" > "${SEED_DIR}/pack.json"
           ROOT_FILENAME="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))[0].filename' "${SEED_DIR}/pack.json")"
           ROOT_TARBALL="${SEED_DIR}/${ROOT_FILENAME}"
+          ROOT_INTEGRITY="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))[0].integrity' "${SEED_DIR}/pack.json")"
           node scripts/sync-release-version.mjs --check --root-tarball "${ROOT_TARBALL}"
           echo "root_tarball=${ROOT_TARBALL}" >> "${GITHUB_OUTPUT}"
-
-      - name: Install bundle dependencies from the exact local root artifact
-        env:
-          ROOT_TARBALL: ${{ steps.seed.outputs.root_tarball }}
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          npm --prefix plugins/dsh-cortex install --no-save --package-lock=false "${ROOT_TARBALL}"
-          test "$(node -p 'require("./plugins/dsh-cortex/node_modules/@danielblomma/cortex-mcp/package.json").version')" = "${RELEASE_VERSION}"
-
-      - name: Run focused release contract tests
-        env:
-          CORTEX_EXPECTED_RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: npm run release:test
-
-      - name: Prepare isolated repository test context
-        run: npm run release:prepare-root-test-context
-
-      - name: Run full root and bundle tests
-        env:
-          CORTEX_EXPECTED_RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: npm test
-
-      - name: Prepare isolated MCP test context
-        run: npm run release:prepare-mcp-test-context
-
-      - name: Run context runtime and MCP compatibility tests
-        run: npm --prefix scaffold/mcp run test:ci
-
-      - name: Run executable fresh-checkout regression
-        env:
-          CORTEX_EXPECTED_RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          git clean -fdx .context scaffold/.context
-          git restore .context scaffold/.context
-          npm run release:test-fresh-checkout
-
-      - name: Audit all six committed dependency trees
-        run: |
-          npm run audit:dependencies
-          npm audit --package-lock-only --audit-level=low --prefix plugins/dsh-cortex
-
-      - name: Validate packed filesystem containment
-        run: npm run release:packed-containment
-
-      - name: Verify pinned DeepSeek Harness contract
-        run: |
-          HARNESS_CHECKOUT="${RUNNER_TEMP}/deepseek-harness"
-          git clone --filter=blob:none --no-checkout https://github.com/deepseek-ai/deepseek-harness.git "${HARNESS_CHECKOUT}"
-          git -C "${HARNESS_CHECKOUT}" checkout --detach "${HARNESS_COMMIT}"
-          node scripts/check-deepseek-harness-compatibility.mjs --checkout "${HARNESS_CHECKOUT}"
-
-      - name: Recreate and verify the reviewed local artifacts
-        id: artifacts
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          ARTIFACT_DIR="${RUNNER_TEMP}/cortex-publish-artifacts"
-          node scripts/release-artifacts.mjs pack \
-            --output-dir "${ARTIFACT_DIR}" \
-            --expected-version "${RELEASE_VERSION}" \
-            --report "${ARTIFACT_DIR}/report.json"
-          ROOT_TARBALL="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.root.first.tarball' "${ARTIFACT_DIR}/report.json")"
-          BUNDLE_TARBALL="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.bundle.first.tarball' "${ARTIFACT_DIR}/report.json")"
-          ROOT_INTEGRITY="$(node -p 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).packages.root.first.integrity' "${ARTIFACT_DIR}/report.json")"
-          echo "report=${ARTIFACT_DIR}/report.json" >> "${GITHUB_OUTPUT}"
-          echo "root_tarball=${ROOT_TARBALL}" >> "${GITHUB_OUTPUT}"
-          echo "bundle_tarball=${BUNDLE_TARBALL}" >> "${GITHUB_OUTPUT}"
           echo "root_integrity=${ROOT_INTEGRITY}" >> "${GITHUB_OUTPUT}"
-
-      - name: Install both reviewed local artifacts with an empty cache
-        env:
-          ROOT_TARBALL: ${{ steps.artifacts.outputs.root_tarball }}
-          BUNDLE_TARBALL: ${{ steps.artifacts.outputs.bundle_tarball }}
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          node scripts/release-artifacts.mjs install \
-            --root-tarball "${ROOT_TARBALL}" \
-            --bundle-tarball "${BUNDLE_TARBALL}" \
-            --output-dir "${RUNNER_TEMP}/cortex-publish-install" \
-            --expected-version "${RELEASE_VERSION}"
-
-      - name: Run packed Harness headless and Web lifecycle
-        env:
-          ROOT_TARBALL: ${{ steps.artifacts.outputs.root_tarball }}
-          BUNDLE_TARBALL: ${{ steps.artifacts.outputs.bundle_tarball }}
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          node scripts/release-artifacts.mjs harness \
-            --harness-checkout "${RUNNER_TEMP}/deepseek-harness" \
-            --root-tarball "${ROOT_TARBALL}" \
-            --bundle-tarball "${BUNDLE_TARBALL}" \
-            --output-dir "${RUNNER_TEMP}/cortex-harness-lifecycle" \
-            --expected-version "${RELEASE_VERSION}"
 
       - name: Inspect exact root registry state for safe immutable resume
         id: registry
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
-          ROOT_INTEGRITY: ${{ steps.artifacts.outputs.root_integrity }}
+          ROOT_INTEGRITY: ${{ steps.seed.outputs.root_integrity }}
         run: |
           ROOT_JSON="$(node scripts/release-artifacts.mjs registry-state \
             --package-name @danielblomma/cortex-mcp \
@@ -201,12 +92,12 @@ jobs:
 
       - name: Publish exact reviewed root artifact
         if: steps.registry.outputs.root_state == 'missing'
-        run: npm publish "${{ steps.artifacts.outputs.root_tarball }}" --access public --provenance
+        run: npm publish "${{ steps.seed.outputs.root_tarball }}" --access public --provenance
 
       - name: Verify exact root registry artifact
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
-          ROOT_INTEGRITY: ${{ steps.artifacts.outputs.root_integrity }}
+          ROOT_INTEGRITY: ${{ steps.seed.outputs.root_integrity }}
         run: |
           for attempt in $(seq 1 12); do
             STATE_JSON="$(node scripts/release-artifacts.mjs registry-state \
@@ -221,20 +112,9 @@ jobs:
           echo "Exact root artifact was not visible within the bounded verification window"
           exit 1
 
-      - name: Run fresh empty-cache root-only registry smoke
-        env:
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          GLOBAL_PREFIX="${RUNNER_TEMP}/cortex-global"
-          GLOBAL_CACHE="${RUNNER_TEMP}/cortex-global-empty-cache"
-          npm install --global --prefix "${GLOBAL_PREFIX}" --cache "${GLOBAL_CACHE}" \
-            "@danielblomma/cortex-mcp@${RELEASE_VERSION}"
-          "${GLOBAL_PREFIX}/bin/cortex" --version | grep -F "${RELEASE_VERSION}"
-
       - name: Record immutable release evidence
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
-          REPORT: ${{ steps.artifacts.outputs.report }}
         run: |
           {
             echo "## Cortex ${RELEASE_VERSION} root package publication"
@@ -243,8 +123,5 @@ jobs:
             echo "- commit: $(git rev-parse HEAD)"
             echo "- tree: $(git rev-parse HEAD^{tree})"
             echo "- published npm artifact: @danielblomma/cortex-mcp@${RELEASE_VERSION}"
-            echo "- DeepSeek Harness bundle: locally validated; separate npm distribution deferred"
-            echo '```json'
-            cat "${REPORT}"
-            echo '```'
+            echo "- DeepSeek Harness bundle: separate npm distribution deferred"
           } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
Removes all test, audit, containment, bundle, and DeepSeek Harness lifecycle gates from Release Bump and Release Publish. Retains main/tag/version identity, metadata-only staging, atomic tag push, root-only npm OIDC publication, and exact registry integrity verification.

Authorized as an immediate 2.6.0 release path after the already-completed validation program.