### PR TITLE
Recover immutable v2.8.0 npm publication

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -86,7 +86,6 @@ jobs:
           npm ci --prefix scaffold/mcp
           npm ci --prefix scaffold/scripts/parsers
           npm ci --prefix scripts/parsers
-          npm ci --prefix plugins/dsh-cortex
 
       - name: Build trusted context runtime
         run: npm --prefix scaffold/mcp run build
@@ -125,6 +124,8 @@ jobs:
         env:
           ROOT_TARBALL: ${{ steps.seed.outputs.root_tarball }}
         run: |
+          npm cache add "${ROOT_TARBALL}"
+          npm ci --prefix plugins/dsh-cortex --prefer-offline
           npm --prefix plugins/dsh-cortex install --no-save --package-lock=false "${ROOT_TARBALL}"
           test "$(node -p 'require("./plugins/dsh-cortex/node_modules/@danielblomma/cortex-mcp/package.json").version')" = "${RELEASE_VERSION}"
 

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -56,7 +56,6 @@ jobs:
           npm ci --prefix scaffold/mcp
           npm ci --prefix scaffold/scripts/parsers
           npm ci --prefix scripts/parsers
-          npm ci --prefix plugins/dsh-cortex
 
       - name: Build trusted context runtime
         run: npm --prefix scaffold/mcp run build
@@ -95,6 +94,8 @@ jobs:
         env:
           ROOT_TARBALL: ${{ steps.seed.outputs.root_tarball }}
         run: |
+          npm cache add "${ROOT_TARBALL}"
+          npm ci --prefix plugins/dsh-cortex --prefer-offline
           npm --prefix plugins/dsh-cortex install --no-save --package-lock=false "${ROOT_TARBALL}"
           test "$(node -p 'require("./plugins/dsh-cortex/node_modules/@danielblomma/cortex-mcp/package.json").version')" = "${RELEASE_VERSION}"
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      recover_2_8:
+        description: Resume the immutable v2.8.0 release from reviewed main orchestration
+        type: boolean
+        default: false
+        required: false
 
 permissions:
   contents: read
@@ -18,21 +24,40 @@ jobs:
 
     steps:
       - name: Reject branch dispatches and non-strict tags
+        id: source
         env:
           GITHUB_REF_TYPE: ${{ github.ref_type }}
           TAG_NAME: ${{ github.ref_name }}
+          RECOVER_2_8: ${{ inputs.recover_2_8 == true }}
         run: |
-          test "${GITHUB_REF_TYPE}" = "tag"
+          if [ "${RECOVER_2_8}" = "true" ]; then
+            test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"
+            test "${GITHUB_REF}" = "refs/heads/main"
+            TAG_NAME="v2.8.0"
+          else
+            test "${GITHUB_REF_TYPE}" = "tag"
+          fi
           if ! [[ "${TAG_NAME}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "Release publish requires a strict immutable vX.Y.Z tag"
             exit 1
           fi
+          echo "tag=${TAG_NAME}" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout immutable tag
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: refs/tags/${{ steps.source.outputs.tag }}
           fetch-depth: 0
+
+      - name: Verify recovery source identity
+        if: inputs.recover_2_8 == true
+        run: |
+          test "$(git cat-file -t v2.8.0)" = "tag"
+          test "$(git rev-parse refs/tags/v2.8.0)" = "e07de9de09e57ddf6375df72c241ba7c5b7ae8f5"
+          test "$(git rev-parse HEAD)" = "00258d7fe40c58fa54e0723236e452630feb7009"
+          test "$(git rev-parse 'v2.8.0^{commit}')" = "$(git rev-parse HEAD)"
+          test "$(git rev-parse 'HEAD^{tree}')" = "72c8ef3565a8b1b102da738de41c821cab6cb997"
+          test -z "$(git status --porcelain)"
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -54,7 +79,7 @@ jobs:
       - name: Verify annotated tag and all metadata versions
         id: version
         env:
-          TAG_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ steps.source.outputs.tag }}
         run: |
           test "$(git cat-file -t "${TAG_NAME}")" = "tag"
           test "$(git rev-list -n 1 "${TAG_NAME}")" = "$(git rev-parse HEAD)"
@@ -131,10 +156,24 @@ jobs:
       - name: Run executable fresh-checkout regression
         env:
           CORTEX_EXPECTED_RELEASE_VERSION: ${{ steps.version.outputs.value }}
+          RECOVER_2_8: ${{ inputs.recover_2_8 == true }}
         run: |
           git clean -fdx .context scaffold/.context
           git restore .context scaffold/.context
-          npm run release:test-fresh-checkout
+          if [ "${RECOVER_2_8}" = "true" ]; then
+            node --input-type=module <<'NODE'
+          import { runFreshCheckout, executeChild } from './scripts/release-fresh-checkout.mjs';
+          if (process.env.NODE_OPTIONS) throw new Error('Recovery requires an unmodified parent NODE_OPTIONS');
+          await runFreshCheckout({
+            executor: (command, args, options) => executeChild(command, args,
+              command === 'npm' && args.length === 1 && args[0] === 'test' && options.cwd === process.cwd()
+                ? { ...options, env: { ...options.env, NODE_OPTIONS: '--test-reporter=tap' } }
+                : options),
+          });
+          NODE
+          else
+            npm run release:test-fresh-checkout
+          fi
 
       - name: Audit all six committed dependency trees
         run: |
@@ -175,6 +214,20 @@ jobs:
           echo "root_tarball=${ROOT_TARBALL}" >> "${GITHUB_OUTPUT}"
           echo "bundle_tarball=${BUNDLE_TARBALL}" >> "${GITHUB_OUTPUT}"
           echo "root_integrity=${ROOT_INTEGRITY}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify original immutable release artifact bytes
+        if: inputs.recover_2_8 == true
+        env:
+          ROOT_TARBALL: ${{ steps.artifacts.outputs.root_tarball }}
+          BUNDLE_TARBALL: ${{ steps.artifacts.outputs.bundle_tarball }}
+          ROOT_INTEGRITY: ${{ steps.artifacts.outputs.root_integrity }}
+          BUNDLE_INTEGRITY: ${{ steps.artifacts.outputs.bundle_integrity }}
+        run: |
+          test "${ROOT_INTEGRITY}" = "sha512-QOiP27vDAVo7982ZFpf/cbb6KpT4dwbyW3r+h7AQR6AuATEjsVLPhau4SYS4mNruj+43lfgr5GhU2usTXDMkRA=="
+          test "${BUNDLE_INTEGRITY}" = "sha512-+vARd84pIBwxaa7kY0eA5FDV8fhgaE1ltZa55W0Y4w6ofriI5nf4gsebl7gtDxvw5Icbq/a8k2OehGEdCCNfPA=="
+          printf '%s  %s\n' \
+            834585c01bafc60e9d9a7551a51b3815d577ba3e1329cdcc614151b5f78d723e "${ROOT_TARBALL}" \
+            6f00ac246fd77630bcb8f173e63a1c06205dcbf6b1b7617ac4cc4cad0b78d59c "${BUNDLE_TARBALL}" | sha256sum --check --strict
 
       - name: Install both reviewed local artifacts with an empty cache
         env:
@@ -297,11 +350,16 @@ jobs:
       - name: Record immutable release evidence
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
+          RELEASE_TAG: ${{ steps.source.outputs.tag }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
         run: |
           {
             echo "## Cortex ${RELEASE_VERSION} npm publication"
             echo "- run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-            echo "- tag: ${GITHUB_REF_NAME}"
+            echo "- tag: ${RELEASE_TAG}"
+            echo "- annotated tag object: $(git rev-parse "refs/tags/${RELEASE_TAG}")"
+            echo "- workflow: ${WORKFLOW_REF} at ${WORKFLOW_SHA}"
             echo "- commit: $(git rev-parse HEAD)"
             echo "- tree: $(git rev-parse HEAD^{tree})"
             echo "- published npm artifact: @danielblomma/cortex-mcp@${RELEASE_VERSION}"

--- a/docs/agent-control/acceptance-matrix.md
+++ b/docs/agent-control/acceptance-matrix.md
@@ -208,3 +208,47 @@ patterns succeed. Full native final-head release gates remain mandatory.
 See local-007-release-completion-report.md and the two independent review reports.
 Auto-advance under existing authority to coordinated draft PR130 update, native
 preflight, then guarded merge/Bump/Publish only after actual green gates.
+
+## WO-LOCAL-007 actual native acceptance and guarded merge
+
+Both reviewers formally bind exact6672c3259478034b079fd0cd9564f58ab020a351.
+Coordinated fast-forward PR130 from6275039 to6672c32. Actual native Ubuntu
+preflight34600081411 completedSUCCESS,29/29 steps success. Full focused47,
+context81/root437/bundle6/MCP651 and pristine81/437/6/651 pass with zero skips;
+six audits report zero vulnerabilities. Containment/frontend, pinned Harness,
+identical duplicate artifacts, empty-cache install, real headless/Web/disposal/
+profile-removal and final diff/secrets/version/runtime boundary all pass.
+Raw log: local-007-evidence/preflight-34600081411.log; structured reports and
+step JSON retained alongside it. Historical native failure remains unclassified.
+
+Rechecked PR130 OPEN/DRAFT, head6672c32, main37a511f, no comments/reviews/pause,
+MERGEABLE/CLEAN, required validateSUCCESS. Synthetic merge
+9ead1dd9955f1ac89ad033b55434c02b9ebaf99c has tree
+f9975b49f75061dbb9247c5b172461e429c3a058, exactly local merge-tree. No conflict
+or dependent stack. Root independently confirms nativeSUCCESS. Manager accepts
+final source/native gates and auto-advances existing authorized ready+guarded
+merge, then existing minor Bump/Publish chain. No release gate waiver.
+
+## WO-LOCAL-007 Publish outcome / WO-LOCAL-008 bounded handoff
+
+Actual Publish34603037854 FAILED before any npm publication: pristine npm test
+exits0 with81/437/6 pass, but original root summary parser requiresTAP '#' and
+Node24.20.0 defaults to spec 'ℹ'. First full tagged MCP651 passed; pristine MCP
+was never reached. All later audits/artifacts/Harness/publication steps skipped.
+Both2.8.0 registry endpoints rechecked404. Immutable v2.8.0 object/commit remain
+e07de9de09e57ddf6375df72c241ba7c5b7ae8f5 /
+00258d7fe40c58fa54e0723236e452630feb7009; actual main is same releasecommit.
+
+Exact Node24.20.0 diagnostic proves globalNODE_OPTIONS TAP would break explicit
+MCPspec via duplicate reporters, so no global flag/rerun is attempted. A scoped
+original-executor wrapper is conditional pending fresh independent review and
+exact clean-tag full gates. Existing tag workflow has no recovery inputs and
+branch-ref rejection; safe main-workflow orchestration needs new reviewed work.
+Root authorizes that bounded recovery under existing2.8 publication scope. No
+tag rewrite, Bump rerun, version substitution, auth mutation or gate waiver.
+
+Fresh packet context-packets/local-008-immutable-publish-reporter-recovery.md
+contains completed source/native/Bump identities, all artifact bytes, actual
+failed Publish evidence, no-publication state and conditional recovery design.
+Root automatically starts a fresh manager and two fresh reviewers. This is a
+context/work-order boundary, not a user stop/reapproval request.

--- a/docs/agent-control/acceptance-matrix.md
+++ b/docs/agent-control/acceptance-matrix.md
@@ -252,3 +252,30 @@ contains completed source/native/Bump identities, all artifact bytes, actual
 failed Publish evidence, no-publication state and conditional recovery design.
 Root automatically starts a fresh manager and two fresh reviewers. This is a
 context/work-order boundary, not a user stop/reapproval request.
+
+## WO-LOCAL-008 recovery design / review assignment
+
+Fresh008 manager owns implementation; fresh008 Security and Ops reviewers were
+assigned before edits in separate clones. Infra/deploy/security-sensitive scope,
+source/workflow trust contract, preserved gates, installation-order issue and
+required acceptance evidence are in local-008-publish-recovery-report.md.
+Original immutable v2.8.0 and all package bytes remain fixed. No release GO yet.
+
+## WO-LOCAL-008 source and local validation acceptance
+
+Both fresh independent reviewers approve the four source hashes with no remaining
+blocker/major finding. Both original clean-tag full helpers independently pass
+81/437/6/651 on exact Node24.20.0/npm11.19.1, with zero fail/skip/cancel/todo.
+The host-only socket correction uses short task-owned TMPDIR and changes no source,
+helper, command or guard. First long-path failures and Ops's intermediate11.19.0
+diagnostic remain explicitly scoped; only final11.19.1 runs establish acceptance.
+Ops proves wrong locked root SRI rejects offline while restoring only exact SRI
+passes against the same cache. Both independent reports are committed alongside
+local-008-publish-recovery-report.md; raw final bindings remain in008 evidence dirs.
+
+Accept for coordinated draft PR and complete hosted native preflight, not merge
+or publication ahead of native gates. Auto-advance existing authorization to
+exact-head push, PR validation, guarded merge and explicit main recover_2_8
+Publish only after required green gates. Never rerun Bump or mutate v2.8.0.
+Root alone installs existing globalCLI after actual complete Publish/registry
+byte/SRI/SHA256/empty-cache/Harness evidence. Class:infra-sensitive, no PR stack.

--- a/docs/agent-control/agent-work-orders.md
+++ b/docs/agent-control/agent-work-orders.md
@@ -233,3 +233,30 @@ contains completed source/native/Bump identities, all artifact bytes, actual
 failed Publish evidence, no-publication state and conditional recovery design.
 Root automatically starts a fresh manager and two fresh reviewers. This is a
 context/work-order boundary, not a user stop/reapproval request.
+
+## WO-LOCAL-008 recovery design / review assignment
+
+Fresh008 manager owns implementation; fresh008 Security and Ops reviewers were
+assigned before edits in separate clones. Infra/deploy/security-sensitive scope,
+source/workflow trust contract, preserved gates, installation-order issue and
+required acceptance evidence are in local-008-publish-recovery-report.md.
+Original immutable v2.8.0 and all package bytes remain fixed. No release GO yet.
+
+## WO-LOCAL-008 source and local validation acceptance
+
+Both fresh independent reviewers approve the four source hashes with no remaining
+blocker/major finding. Both original clean-tag full helpers independently pass
+81/437/6/651 on exact Node24.20.0/npm11.19.1, with zero fail/skip/cancel/todo.
+The host-only socket correction uses short task-owned TMPDIR and changes no source,
+helper, command or guard. First long-path failures and Ops's intermediate11.19.0
+diagnostic remain explicitly scoped; only final11.19.1 runs establish acceptance.
+Ops proves wrong locked root SRI rejects offline while restoring only exact SRI
+passes against the same cache. Both independent reports are committed alongside
+local-008-publish-recovery-report.md; raw final bindings remain in008 evidence dirs.
+
+Accept for coordinated draft PR and complete hosted native preflight, not merge
+or publication ahead of native gates. Auto-advance existing authorization to
+exact-head push, PR validation, guarded merge and explicit main recover_2_8
+Publish only after required green gates. Never rerun Bump or mutate v2.8.0.
+Root alone installs existing globalCLI after actual complete Publish/registry
+byte/SRI/SHA256/empty-cache/Harness evidence. Class:infra-sensitive, no PR stack.

--- a/docs/agent-control/agent-work-orders.md
+++ b/docs/agent-control/agent-work-orders.md
@@ -209,3 +209,27 @@ patterns succeed. Full native final-head release gates remain mandatory.
 See local-007-release-completion-report.md and the two independent review reports.
 Auto-advance under existing authority to coordinated draft PR130 update, native
 preflight, then guarded merge/Bump/Publish only after actual green gates.
+
+## WO-LOCAL-007 Publish outcome / WO-LOCAL-008 bounded handoff
+
+Actual Publish34603037854 FAILED before any npm publication: pristine npm test
+exits0 with81/437/6 pass, but original root summary parser requiresTAP '#' and
+Node24.20.0 defaults to spec 'ℹ'. First full tagged MCP651 passed; pristine MCP
+was never reached. All later audits/artifacts/Harness/publication steps skipped.
+Both2.8.0 registry endpoints rechecked404. Immutable v2.8.0 object/commit remain
+e07de9de09e57ddf6375df72c241ba7c5b7ae8f5 /
+00258d7fe40c58fa54e0723236e452630feb7009; actual main is same releasecommit.
+
+Exact Node24.20.0 diagnostic proves globalNODE_OPTIONS TAP would break explicit
+MCPspec via duplicate reporters, so no global flag/rerun is attempted. A scoped
+original-executor wrapper is conditional pending fresh independent review and
+exact clean-tag full gates. Existing tag workflow has no recovery inputs and
+branch-ref rejection; safe main-workflow orchestration needs new reviewed work.
+Root authorizes that bounded recovery under existing2.8 publication scope. No
+tag rewrite, Bump rerun, version substitution, auth mutation or gate waiver.
+
+Fresh packet context-packets/local-008-immutable-publish-reporter-recovery.md
+contains completed source/native/Bump identities, all artifact bytes, actual
+failed Publish evidence, no-publication state and conditional recovery design.
+Root automatically starts a fresh manager and two fresh reviewers. This is a
+context/work-order boundary, not a user stop/reapproval request.

--- a/docs/agent-control/conflict-ledger.md
+++ b/docs/agent-control/conflict-ledger.md
@@ -23,3 +23,23 @@ Remote main37a511fa76ce04804f6cf4497202966dd78ff1f0 and PR head54af80981782ad03a
 were rechecked before candidate commit; clean fast-forward ancestry, no dependent
 PR stack or conflict. Final committed head and synthetic tree are verified in
 local-006-release-completion-report.md before guarded merge.
+
+## WO-LOCAL-007 actual native acceptance and guarded merge
+
+Both reviewers formally bind exact6672c3259478034b079fd0cd9564f58ab020a351.
+Coordinated fast-forward PR130 from6275039 to6672c32. Actual native Ubuntu
+preflight34600081411 completedSUCCESS,29/29 steps success. Full focused47,
+context81/root437/bundle6/MCP651 and pristine81/437/6/651 pass with zero skips;
+six audits report zero vulnerabilities. Containment/frontend, pinned Harness,
+identical duplicate artifacts, empty-cache install, real headless/Web/disposal/
+profile-removal and final diff/secrets/version/runtime boundary all pass.
+Raw log: local-007-evidence/preflight-34600081411.log; structured reports and
+step JSON retained alongside it. Historical native failure remains unclassified.
+
+Rechecked PR130 OPEN/DRAFT, head6672c32, main37a511f, no comments/reviews/pause,
+MERGEABLE/CLEAN, required validateSUCCESS. Synthetic merge
+9ead1dd9955f1ac89ad033b55434c02b9ebaf99c has tree
+f9975b49f75061dbb9247c5b172461e429c3a058, exactly local merge-tree. No conflict
+or dependent stack. Root independently confirms nativeSUCCESS. Manager accepts
+final source/native gates and auto-advances existing authorized ready+guarded
+merge, then existing minor Bump/Publish chain. No release gate waiver.

--- a/docs/agent-control/conflict-ledger.md
+++ b/docs/agent-control/conflict-ledger.md
@@ -43,3 +43,11 @@ f9975b49f75061dbb9247c5b172461e429c3a058, exactly local merge-tree. No conflict
 or dependent stack. Root independently confirms nativeSUCCESS. Manager accepts
 final source/native gates and auto-advances existing authorized ready+guarded
 merge, then existing minor Bump/Publish chain. No release gate waiver.
+
+## WO-LOCAL-008 isolated recovery branch
+
+Branch recovery/immutable-2.8-publish is based on actual release/main00258d7
+plus docs-only31af0dae handoff. Remote main remains00258d7 and immutable
+v2.8.0 objecte07de9de/peeled00258d7 is unchanged. No existing remote recovery
+branch, stacked PR or conflict. Exact full heads are coordinated with root
+before GitHub push; required native preflight precedes guarded merge.

--- a/docs/agent-control/context-packets/local-008-immutable-publish-reporter-recovery.md
+++ b/docs/agent-control/context-packets/local-008-immutable-publish-reporter-recovery.md
@@ -1,0 +1,180 @@
+# WO-LOCAL-008: finish immutable Cortex2.8 publication after Node24 reporter failure
+
+Fresh manager packet,2026-09-11. Infra/deploy/security-sensitive. Automatic bounded
+handoff, not user restart/permission request. User/root authority covers a reviewed
+safe main-workflow recovery for the already-authorized2.8 publication, preserving
+immutable tag/bytes, original helpers and all gates. Root owns existing global CLI
+update only after actual complete publication/registry verification. No new Bump.
+
+## Isolation and required setup
+
+Create NEW isolated clone of /private/tmp/cortex-local-007-manager at final docs-only
+handoff HEAD supplied by root. Handoff commit is based on actual release/main
+00258d7fe40c58fa54e0723236e452630feb7009, not the old feature source. All earlier
+clones and original /Users/danielnilsson/GIT/cortex stay read-only. Manager alone
+writes branch/remotes; coordinate exact full local+expected remote HEAD with root
+before GitHub pushes. Actual remote https://github.com/DanielBlomma/cortex.git;
+local clone origin is not GitHub. Always git -c core.hooksPath=/dev/null for writes.
+Never force-push or rewrite/delete existing v2.8.0 tag.
+
+Assign two NEW independent Security/Contract/CodeQuality and Ops/Validation/
+Integration reviewers BEFORE implementation, each own clone. Root+manager+two
+fits four slots. Read only this packet and direct references. Required:
+docs/agent-control/workflow-playbook.md, review-iteration-protocol.md,
+scaffold/AGENTS.md; plugins/cortex/skills/{using-cortex,change-impact,
+pattern-review,context-review}/SKILL.md. Use current CLI node bin/cortex.mjs;
+global2.4.1 old. No providers/embeddings/broad indexing/hooks. Necessary release
+lexical+graph test preparation is authorized. Use scoped config+ingest/load-ryu
+and restore tracked config. Watch stopped.
+
+Ignored runtime/deps can be cp -cR copied from manager007: .context/{mcp,scripts,
+cache,db}, scaffold/mcp/{node_modules,dist}, scaffold/scripts/parsers/node_modules,
+plugins/dsh-cortex/node_modules. Final manager007 index is scoped to the direct reporter/helper/workflow references
+and handoff control docs; new work must refresh its own clone as needed. Root Node24 binary for
+narrow diagnostics is available under
+/private/tmp/cortex-local-007-evidence/node24/node-v24.20.0-darwin-arm64/bin/node.
+Official archive and SHASUMS256.txt are retained there; archive SHA256
+b7bf7707070b950ba1ec5f1af3bb6de0f2b1962c5033973d94068ab021ef3014.
+This is local macOS Node24.20.0, not native Ubuntu acceptance. Existing owned
+Linux x64 init container cortex-local-004-ops-x64-init may be used narrowly;
+never mutate unrelated containers/trees. Native hosted gates remain authoritative.
+
+## Completed source, native acceptance and immutable release identities
+
+Read local-007-release-completion-report.md and its independent Security/Ops
+reports, plus local-006 report/direct previous references for earlier scopes.
+Reviewed source6672c3259478034b079fd0cd9564f58ab020a351, tree
+f9975b49f75061dbb9247c5b172461e429c3a058. Both fresh reviewers approve exact head;
+raw bindings /private/tmp/cortex-local-007-{security,ops}-evidence/exact-head-approval.json.
+
+PR130 is MERGED at2026-09-11T13:00:22Z with expected-head guard. Merge/main commit
+6a42922b933f5869ae188b8d9cc56afccbbd2554 has the exact reviewed/native tree above.
+Native preflight34600081411 SUCCESS, all29steps: focused47, full81/437/6/651,
+pristine81/437/6/651, six zero audits, containment/frontend, pinned Harness,
+byte-identical duplicate artifacts, empty-cache dual install, actual headless/Web,
+disposal/profile removal and final boundary. No waiver.
+
+Actual Bump34601925375 SUCCESS, including complete repeated full/pristine gates,
+all audits/artifact/Harness/final boundaries and atomic main+annotated tag push.
+Tag v2.8.0 object e07de9de09e57ddf6375df72c241ba7c5b7ae8f5 peels to
+00258d7fe40c58fa54e0723236e452630feb7009, exact GitHub main at handoff, tree
+72c8ef3565a8b1b102da738de41c821cab6cb997. Parent is reviewed merge6a42922. Exactly
+eight expected metadata paths differ from merge. Original production/tests/helpers
+and package source remain reviewed. Do NOT run Bump again or make2.9/2.8.1 by default.
+
+Actual preflight and Bump root bytes agree:
+- root SHA256834585c01bafc60e9d9a7551a51b3815d577ba3e1329cdcc614151b5f78d723e,
+  SRI sha512-QOiP27vDAVo7982ZFpf/cbb6KpT4dwbyW3r+h7AQR6AuATEjsVLPhau4SYS4mNruj+43lfgr5GhU2usTXDMkRA==,
+  size988282.
+- bundle SHA2566f00ac246fd77630bcb8f173e63a1c06205dcbf6b1b7617ac4cc4cad0b78d59c,
+  SRI sha512-+vARd84pIBwxaa7kY0eA5FDV8fhgaE1ltZa55W0Y4w6ofriI5nf4gsebl7gtDxvw5Icbq/a8k2OehGEdCCNfPA==,
+  size10260.
+Exact reviewed bundle dependency is @danielblomma/cortex-mcp2.8.0.
+
+## Actual Publish failure and no registry publication
+
+Bump automatically dispatched Publish34603037854 on immutable release00258d7.
+Run https://github.com/DanielBlomma/cortex/actions/runs/34603037854 completedFAILURE
+at `Run executable fresh-checkout regression` before all audits/artifacts/Harness
+and ALL npm publication steps. First full tagged context81/root437/bundle6/MCP651
+and focused47 passed. Pristine root command exits0 with81/437/6pass, zero failures;
+helper rejects `missing_tap_summary: root, deepseekHarnessBundle`. Pristine MCP
+never runs because root count parser fails. Do not call this successful Publish.
+
+Native Node24.20.0 emits spec `ℹ tests437`, `ℹ pass437`, `ℹ tests6`, `ℹ pass6`.
+Helper expects root/bundle TAP `#` and correctly fails closed. This is a reporter
+contract defect, not failing tests or a reason to bypass count gates. Both new
+settled-leader tests pass even in this pristine bundle6 run.
+
+Rechecked exact registry endpoints after failure: both @danielblomma/cortex-mcp
+and @danielblomma/dsh-cortex2.8.0 return404 `version not found:2.8.0`.
+No root/bundle partial publication; existing global CLI unchanged. Preserve that
+status until actual successful recovery evidence. Recheck before action.
+
+## Direct code and proved reporter behavior
+
+- scripts/release-fresh-checkout.mjs: executeChild exported270; nodeTapSummaries380;
+  validateRootTotals412 hardcodes#; validateMcpTotals423 hardcodesℹ;
+  runFreshCheckout exported429 accepts executor; actual four commands507–510.
+- package.json71 root test uses default node --test and npm bundle test.
+- plugins/dsh-cortex/package.json test also default node --test.
+- scaffold/mcp/package.json13 test:ci explicitly uses --test-reporter=spec.
+- tests/release-fresh-checkout.test.mjs, tests/release-workflows.test.mjs.
+- .github/workflows/{release-publish,release-preflight,release-bump}.yml.
+- scripts/release-artifacts.mjs exact artifacts/install/Harness/registry helpers.
+
+Manager diagnostic on official verified exact Node24.20.0, outside tracked source:
+/private/tmp/cortex-local-007-evidence/reporter-probe/results.json and *.log.
+Default simple actual node:test emits spec; NODE_OPTIONS=--test-reporter=tap emits
+TAP and exit0; normal non-test command accepts flag. BUT inherited TAP env plus
+MCP's explicit --test-reporter=spec FAILS exit1: both reporters present but only
+one destination. Therefore global NODE_OPTIONS is NOT an acceptable recovery.
+This is syntax/format proof, not full clean-tag validation of a wrapper.
+
+Potential narrowly scoped execution design (conditional, not implemented): import
+original tagged runFreshCheckout and executeChild; invoke original runFreshCheckout
+with an executor that delegates every actual command to original executeChild,
+setting NODE_OPTIONS TAP ONLY on the exact root `npm test` child. All other calls,
+especially MCP explicit spec, retain original environment. Do not synthesize
+output, transform summaries, skip commands or replace real tests. Need independent
+exact clean-tag full81/437/6/651 proof and negative count/failure/command/env probes.
+The helper's original capture/output limits, cleanup and count validation remain.
+An equally strict better design is allowed with concrete evidence; no blind rerun.
+
+## Workflow-source/resume constraint and required next work
+
+Tag's existing release-publish.yml has empty workflow_dispatch inputs, rejects
+branch ref, checks out github.ref, and gets its own workflow definition from the
+dispatched tag. Editing main YAML then re-running the old tag invocation does not
+apply the new definition. Registry safe-resume exists only later in the old flow,
+after the failed gate. No current input supplies reporter environment or alternate
+reviewed orchestration. A fresh reviewed recovery mode on main is authorized,
+provided it explicitly pins/checks out the same immutable tag/object/commit and
+preserves exact artifact bytes, original helpers and all gates. Review which
+workflow definition executes separately from which source is checked out. Keep
+Node24/npm11.19.1, OIDC, ordered dual publication, exact-registry safe-resume and
+final registryHarness. Reusing release-publish.yml filename may matter for npm
+trusted-publisher identity; verify official contract/config evidence, don't assume
+new filenames or trust changes are free. Do not alter registry auth blindly.
+
+Before implementation: map Cortex rules/impact/relationships for actual new files,
+assign fresh reviewers, document source/workflow trust model, intended minimal
+recovery and gate-equivalence. New work should branch from actual main00258d7;
+local handoff adds docs only. Review existing workflow contract tests, including
+preflight's automatic next-minor simulation now that main metadata is2.8. No
+unrequested tag/version bump follows from a preflight fixture. Do not silently
+waive a PR or release gate if existing post-release workflow assumptions surface.
+
+Then implement/review bounded recovery, focused positive+negative diagnostics,
+actual exact-clean-tag gate, coordinated reviewed PR/push/merge of workflow-only
+orchestration as required. Dispatch correct reviewed workflow source with explicit
+immutable release identity. Monitor actual Publish to completion including final
+registry Harness. Registry version appearing alone is insufficient.
+
+Finally reconcile immutable tag/source ancestry/currentmain (main may advance only
+with reviewed recovery control changes), actual successful Publish report, exact
+root/bundle registry versions/latest/dependency/SRI/SHA256 and downloaded bytes vs
+preflight/Bump/Publish artifacts. Run install-registry in a fresh empty output/cache
+and validate CLI. Send root full proof; root updates existing /opt/homebrew global
+CLI to pinned2.8 and returns command/version evidence. Record final durable control
+docs without rewriting immutable release tag. No user reapproval needed.
+
+## Evidence and primary reference locations
+
+All manager raw logs/JSON are /private/tmp/cortex-local-007-evidence:
+preflight-34600081411.log, preflight-current.json, preflight.reports.json;
+bump-34601925375.log, bump-current.json, bump.reports.json;
+publish-34603037854.log, publish-failed.log, publish-current.json;
+registry-after-failed-publish.json; native-binding.json; tag-binding.json.
+extract-reports.py parses stage JSON and counts; verify-registry.py is prepared
+but NOT EXECUTED and currently expects successful `publish.reports.json` in that
+evidence directory. Adapt paths to own evidence directory instead of mutating old.
+
+Official references opened for diagnosis:
+https://nodejs.org/docs/latest-v24.x/api/test.html#test-reporters
+https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow
+Use exact24.20 source/docs and actual diagnostics for version-specific claims.
+
+Residual previous limitations unchanged: ONNX predictabletemp/pre-check races;
+absent external frozen benchmark packet; upstream linux-arm64 Ryu package is x64.
+No provider/model calls, full emulator substitution or release gate waiver.

--- a/docs/agent-control/handoff-ledger.md
+++ b/docs/agent-control/handoff-ledger.md
@@ -425,3 +425,67 @@ patterns succeed. Full native final-head release gates remain mandatory.
 See local-007-release-completion-report.md and the two independent review reports.
 Auto-advance under existing authority to coordinated draft PR130 update, native
 preflight, then guarded merge/Bump/Publish only after actual green gates.
+
+## WO-LOCAL-007 actual native acceptance and guarded merge
+
+Both reviewers formally bind exact6672c3259478034b079fd0cd9564f58ab020a351.
+Coordinated fast-forward PR130 from6275039 to6672c32. Actual native Ubuntu
+preflight34600081411 completedSUCCESS,29/29 steps success. Full focused47,
+context81/root437/bundle6/MCP651 and pristine81/437/6/651 pass with zero skips;
+six audits report zero vulnerabilities. Containment/frontend, pinned Harness,
+identical duplicate artifacts, empty-cache install, real headless/Web/disposal/
+profile-removal and final diff/secrets/version/runtime boundary all pass.
+Raw log: local-007-evidence/preflight-34600081411.log; structured reports and
+step JSON retained alongside it. Historical native failure remains unclassified.
+
+Rechecked PR130 OPEN/DRAFT, head6672c32, main37a511f, no comments/reviews/pause,
+MERGEABLE/CLEAN, required validateSUCCESS. Synthetic merge
+9ead1dd9955f1ac89ad033b55434c02b9ebaf99c has tree
+f9975b49f75061dbb9247c5b172461e429c3a058, exactly local merge-tree. No conflict
+or dependent stack. Root independently confirms nativeSUCCESS. Manager accepts
+final source/native gates and auto-advances existing authorized ready+guarded
+merge, then existing minor Bump/Publish chain. No release gate waiver.
+
+PR130 guarded merge completed2026-09-11T13:00:22Z; merge/main commit
+6a42922b933f5869ae188b8d9cc56afccbbd2554, tree identical to native preflight.
+Dispatched existing minor Release Bump34601925375 on that main commit; full and
+pristine gates continue unchanged. No tag or Publish success has been claimed.
+
+## Release Bump completed / immutable Publish in progress
+
+Bump34601925375 completedSUCCESS, every step passed including the second actual
+full/pristine/audit/artifact/Harness/final-boundary sequence and atomic tag+main.
+Annotated v2.8.0 objecte07de9de09e57ddf6375df72c241ba7c5b7ae8f5 peels to
+00258d7fe40c58fa54e0723236e452630feb7009, exact remote main, tree
+72c8ef3565a8b1b102da738de41c821cab6cb997. Parent is reviewed merge6a42922.
+Exactly the expected eight metadata paths differ from merge; production/test
+source remains reviewed. Bump root/bundle SHA256 and SRI match native preflight
+bytes exactly. Full Bump log and extracted reports are in local-007-evidence.
+
+Existing Bump workflow automatically started Publish34603037854 at that immutable
+release commit. Actual publication, final registryHarness, downloaded bytes, fresh
+registry dual-install and root globalCLI proof remain pending. No tag is rewritten.
+
+## WO-LOCAL-007 Publish outcome / WO-LOCAL-008 bounded handoff
+
+Actual Publish34603037854 FAILED before any npm publication: pristine npm test
+exits0 with81/437/6 pass, but original root summary parser requiresTAP '#' and
+Node24.20.0 defaults to spec 'ℹ'. First full tagged MCP651 passed; pristine MCP
+was never reached. All later audits/artifacts/Harness/publication steps skipped.
+Both2.8.0 registry endpoints rechecked404. Immutable v2.8.0 object/commit remain
+e07de9de09e57ddf6375df72c241ba7c5b7ae8f5 /
+00258d7fe40c58fa54e0723236e452630feb7009; actual main is same releasecommit.
+
+Exact Node24.20.0 diagnostic proves globalNODE_OPTIONS TAP would break explicit
+MCPspec via duplicate reporters, so no global flag/rerun is attempted. A scoped
+original-executor wrapper is conditional pending fresh independent review and
+exact clean-tag full gates. Existing tag workflow has no recovery inputs and
+branch-ref rejection; safe main-workflow orchestration needs new reviewed work.
+Root authorizes that bounded recovery under existing2.8 publication scope. No
+tag rewrite, Bump rerun, version substitution, auth mutation or gate waiver.
+
+Fresh packet context-packets/local-008-immutable-publish-reporter-recovery.md
+contains completed source/native/Bump identities, all artifact bytes, actual
+failed Publish evidence, no-publication state and conditional recovery design.
+Root automatically starts a fresh manager and two fresh reviewers. This is a
+context/work-order boundary, not a user stop/reapproval request.

--- a/docs/agent-control/handoff-ledger.md
+++ b/docs/agent-control/handoff-ledger.md
@@ -489,3 +489,30 @@ contains completed source/native/Bump identities, all artifact bytes, actual
 failed Publish evidence, no-publication state and conditional recovery design.
 Root automatically starts a fresh manager and two fresh reviewers. This is a
 context/work-order boundary, not a user stop/reapproval request.
+
+## WO-LOCAL-008 recovery design / review assignment
+
+Fresh008 manager owns implementation; fresh008 Security and Ops reviewers were
+assigned before edits in separate clones. Infra/deploy/security-sensitive scope,
+source/workflow trust contract, preserved gates, installation-order issue and
+required acceptance evidence are in local-008-publish-recovery-report.md.
+Original immutable v2.8.0 and all package bytes remain fixed. No release GO yet.
+
+## WO-LOCAL-008 source and local validation acceptance
+
+Both fresh independent reviewers approve the four source hashes with no remaining
+blocker/major finding. Both original clean-tag full helpers independently pass
+81/437/6/651 on exact Node24.20.0/npm11.19.1, with zero fail/skip/cancel/todo.
+The host-only socket correction uses short task-owned TMPDIR and changes no source,
+helper, command or guard. First long-path failures and Ops's intermediate11.19.0
+diagnostic remain explicitly scoped; only final11.19.1 runs establish acceptance.
+Ops proves wrong locked root SRI rejects offline while restoring only exact SRI
+passes against the same cache. Both independent reports are committed alongside
+local-008-publish-recovery-report.md; raw final bindings remain in008 evidence dirs.
+
+Accept for coordinated draft PR and complete hosted native preflight, not merge
+or publication ahead of native gates. Auto-advance existing authorization to
+exact-head push, PR validation, guarded merge and explicit main recover_2_8
+Publish only after required green gates. Never rerun Bump or mutate v2.8.0.
+Root alone installs existing globalCLI after actual complete Publish/registry
+byte/SRI/SHA256/empty-cache/Harness evidence. Class:infra-sensitive, no PR stack.

--- a/docs/agent-control/local-007-release-completion-report.md
+++ b/docs/agent-control/local-007-release-completion-report.md
@@ -83,3 +83,75 @@ An additional optional pattern lookup for unchanged provider.mjs fails verbatim
 file evidence and direct provider source review remain separate. Reviewer Ops's
 combined-review fail-safe limitation is recorded in its report. Raw final review
 and all pattern outputs remain in the manager evidence directory.
+
+## WO-LOCAL-007 actual native acceptance and guarded merge
+
+Both reviewers formally bind exact6672c3259478034b079fd0cd9564f58ab020a351.
+Coordinated fast-forward PR130 from6275039 to6672c32. Actual native Ubuntu
+preflight34600081411 completedSUCCESS,29/29 steps success. Full focused47,
+context81/root437/bundle6/MCP651 and pristine81/437/6/651 pass with zero skips;
+six audits report zero vulnerabilities. Containment/frontend, pinned Harness,
+identical duplicate artifacts, empty-cache install, real headless/Web/disposal/
+profile-removal and final diff/secrets/version/runtime boundary all pass.
+Raw log: local-007-evidence/preflight-34600081411.log; structured reports and
+step JSON retained alongside it. Historical native failure remains unclassified.
+
+Rechecked PR130 OPEN/DRAFT, head6672c32, main37a511f, no comments/reviews/pause,
+MERGEABLE/CLEAN, required validateSUCCESS. Synthetic merge
+9ead1dd9955f1ac89ad033b55434c02b9ebaf99c has tree
+f9975b49f75061dbb9247c5b172461e429c3a058, exactly local merge-tree. No conflict
+or dependent stack. Root independently confirms nativeSUCCESS. Manager accepts
+final source/native gates and auto-advances existing authorized ready+guarded
+merge, then existing minor Bump/Publish chain. No release gate waiver.
+
+PR130 guarded merge completed2026-09-11T13:00:22Z; merge/main commit
+6a42922b933f5869ae188b8d9cc56afccbbd2554, tree identical to native preflight.
+Dispatched existing minor Release Bump34601925375 on that main commit; full and
+pristine gates continue unchanged. No tag or Publish success has been claimed.
+
+## Release Bump completed / immutable Publish in progress
+
+Bump34601925375 completedSUCCESS, every step passed including the second actual
+full/pristine/audit/artifact/Harness/final-boundary sequence and atomic tag+main.
+Annotated v2.8.0 objecte07de9de09e57ddf6375df72c241ba7c5b7ae8f5 peels to
+00258d7fe40c58fa54e0723236e452630feb7009, exact remote main, tree
+72c8ef3565a8b1b102da738de41c821cab6cb997. Parent is reviewed merge6a42922.
+Exactly the expected eight metadata paths differ from merge; production/test
+source remains reviewed. Bump root/bundle SHA256 and SRI match native preflight
+bytes exactly. Full Bump log and extracted reports are in local-007-evidence.
+
+Existing Bump workflow automatically started Publish34603037854 at that immutable
+release commit. Actual publication, final registryHarness, downloaded bytes, fresh
+registry dual-install and root globalCLI proof remain pending. No tag is rewritten.
+
+## WO-LOCAL-007 Publish outcome / WO-LOCAL-008 bounded handoff
+
+Actual Publish34603037854 FAILED before any npm publication: pristine npm test
+exits0 with81/437/6 pass, but original root summary parser requiresTAP '#' and
+Node24.20.0 defaults to spec 'ℹ'. First full tagged MCP651 passed; pristine MCP
+was never reached. All later audits/artifacts/Harness/publication steps skipped.
+Both2.8.0 registry endpoints rechecked404. Immutable v2.8.0 object/commit remain
+e07de9de09e57ddf6375df72c241ba7c5b7ae8f5 /
+00258d7fe40c58fa54e0723236e452630feb7009; actual main is same releasecommit.
+
+Exact Node24.20.0 diagnostic proves globalNODE_OPTIONS TAP would break explicit
+MCPspec via duplicate reporters, so no global flag/rerun is attempted. A scoped
+original-executor wrapper is conditional pending fresh independent review and
+exact clean-tag full gates. Existing tag workflow has no recovery inputs and
+branch-ref rejection; safe main-workflow orchestration needs new reviewed work.
+Root authorizes that bounded recovery under existing2.8 publication scope. No
+tag rewrite, Bump rerun, version substitution, auth mutation or gate waiver.
+
+Fresh packet context-packets/local-008-immutable-publish-reporter-recovery.md
+contains completed source/native/Bump identities, all artifact bytes, actual
+failed Publish evidence, no-publication state and conditional recovery design.
+Root automatically starts a fresh manager and two fresh reviewers. This is a
+context/work-order boundary, not a user stop/reapproval request.
+
+Handoff docs use a final scoped lexical+graph refresh of direct reporter/helper/
+workflow references and control docs, with tracked config restored. Required
+eight changed-file pattern calls and rules succeed; combined doc-only review
+fails verbatim `Review failed safely`. No automated pass is claimed; prescribed
+rules/pattern fallback and independent closure review remain separate. Cortex
+search identifies file:scripts/release-fresh-checkout.mjs and
+chunk:scripts/release-fresh-checkout.mjs:validateExpectedTotals:400-410.

--- a/docs/agent-control/local-008-independent-security-review.md
+++ b/docs/agent-control/local-008-independent-security-review.md
@@ -1,0 +1,44 @@
+# WO-LOCAL-008 independent Security / Contract / Code Quality review
+
+APPROVE the four exact source hashes in source-hashes.json for coordinated draft/native preflight. No unresolved blocker, major, or minor finding. Complete original helper passes81/437/6/651 on exact immutable tag with Node24.20.0/npm11.19.1 and the documented macOS TMPDIR correction. This is source/local validation approval; native PR/release gates and actual publication remain required.
+
+Fresh reviewer assigned before implementation; isolated reviewer clone at31af0dae28b106ef916fdf8bed24cda450cdb498 and separate untouched-tag fixture at00258d7fe40c58fa54e0723236e452630feb7009, tree72c8ef3565a8b1b102da738de41c821cab6cb997. Original/prior trees read-only, manager sole branch/control-doc writer. No remote writes or release/auth mutations by this reviewer.
+
+## Source and trust contract
+
+Existing release-publish.yml gains explicit Boolean recover_2_8 dispatch, admitted only for workflow_dispatch on refs/heads/main. Normal dispatch still requires strict tag. It selects fixed v2.8.0 and verifies annotated objecte07de9de09e57ddf6375df72c241ba7c5b7ae8f5, exact checkout commit/tree, peeled target, and clean tracked state before tagged code executes. All actual checkout helpers/tests/packages remain immutable. Workflow ref/SHA are recorded separately from checkout tag/object/commit/tree; GitHub environment is never rewritten to impersonate tag provenance.
+
+Same filename, owner/repository, hosted runner, Node24/npm11.19.1, OIDC permissions, provenance flag, ordered dual publication, exact-registry safe resume, six audits, containment/frontend, pinned real Harness, empty-cache installs and final registry Harness remain. Recovery additionally verifies original Bump root/bundle SRI and actual SHA256 before publication. Official npm trusted-publisher documentation binds required owner/repository/workflow filename and optional environment; GitHub OIDC documentation defines trigger ref separately from workflow ref/SHA. Existing filename preserves documented identity; historical root publication is evidence, while actual current settings for both packages are not observed. Actual hosted publication remains required; no fallback token/auth change is approved.
+
+Sources: https://docs.npmjs.com/trusted-publishers/ and https://docs.github.com/en/actions/reference/security/oidc .
+
+## Original executor and gates
+
+Extracted inline wrapper SHA2562b82f1c5a97d66f0e0bf3ae388b5b439bb207070fd1a6e501a8abf5622285644 imports original tagged runFreshCheckout and executeChild. Only exact npm + [test] + root cwd receives a copied env with NODE_OPTIONS=--test-reporter=tap. Nonempty inherited parent NODE_OPTIONS rejects before helper execution. All other options/env/commands pass unchanged, especially MCP's explicit spec reporter. Original output capture/limits, error classification, count parsing and fail-closed early stopping remain. No generated summaries, hidden tests, changed production/helper source, or gate waiver.
+
+Preflight/Bump remain Node22. Their original locked bundle npm ci moves after exact simulated-version seed/synchronized lock creation. npm cache add supplies the exact immutable root content for locked prefer-offline resolution of an unpublished next version; original local artifact binding remains. Both workflows share the same gate block. This does not dispatch Bump or publish2.9. Ops owns independent initially-empty-cache proof. Main orchestration tests run in main PR preflight; tagged tests inspect tagged workflows and cannot stand in for main source validation. New cases fit existing test declarations, preserving counts.
+
+## Independent evidence
+
+- Exact-tag Node24 pack independently reproduces both complete packet SRIs and SHA256, root988282/bundle10260bytes (seed-report.json). Installed this exact root into own bundle dependency tree; own isolated npm11.19.1 used for full proof.
+- wrapper-probes.json:24 scope and positive/negative probes execute exact extracted wrapper body. Only exact root child changes; parent/options identities retained otherwise; nonempty env fails before helper; unchanged original helper rejects each context/root/bundle/MCP count drift, missing/wrong reporter summaries and nonzero exits, stopping at same command boundary.
+- reporter-real.json: four actual Node24.20.0 executions prove default spec, inherited TAP, explicit spec, and inherited TAP+explicit spec's required exit1 reporter/destination conflict.
+- guard-probes.json:12 extracted-shell probes. Actual exact clean-tag identity passes; independently wrong type/object/HEAD/peel/tree/dirty reject. GNU coreutils9.4 in packet-authorized owned Linux container accepts original bytes and rejects root/bundle SRI mismatch or independently corrupted tarballs. Own container fixture removed. macOS sha256sum lacks GNU --strict, so that local execution was not mislabeled success.
+- focused-main.log: original focused47 declarations,46pass/1Linux-only skip/0fail on macOS. Native47/47 remains required.
+- source-review.json: Cortex diff review ok, four paths, one eligible/reviewed test code file, zero findings/conflicts. YAML reviewed directly. Six rules, refreshed seven-file lexical+graph index, final four per-file patterns all succeed. Initial preflight/Bump pattern lookups failed target-not-indexed, retained separately. No provider/embedding update; tracked config restored; watch stopped. Diff whitespace passes.
+
+## macOS fixture path correction
+
+First original full helper run exact-tag-full.log passed context81/root437/bundle6, then failed MCP650/651. Failure is original socket transaction test at scaffold/mcp/tests/analysis-state-trusted-writer.test.mjs366/375: listen EINVAL errno−22 on134-byte canonical macOS TMPDIR socket path. Local SDK sys/un.h79 has sun_path[104]. The fixture's makeRoot resolves the macOS long temp path; no test/runtime change caused it.
+
+Exact unchanged test independently reproduces1/1failure with default temp root (socket-long-tmp.log) and1/1pass with owned /private/tmp/c8s (socket-short-tmp.log), zero skips. This causally justifies one original clean-tag full rerun with only TMPDIR=/private/tmp/c8s; first failure stays recorded. Native Ubuntu gates remain authoritative. Final corrected run result will be appended.
+
+## Manager context command incident
+
+Manager update --help actually launched update and embedding stage; retained model config/tokenizer plus209636334-byte partial ONNX prove actual model-resource download. Source embed.ts1117–1130 awaits local model initialization before later local runWorkUnits1182. Installed transformers hub.js70–72 fetches resource URL with headers and no repository-text request body in that path. This supports a model-download classification; without network trace no categorical absence-of-source-upload claim is justified. Manager killed owned process tree, exit143, no embedding snapshot/inference result observed, retained inventory/hashes/log, removed only newly owned model cache and restored explicit scoped ingest/graph workflow. Root informed and directed continuation. Candid report closes process finding without claiming the unauthorized download did not occur; release source/tag/package integrity is independently unchanged.
+
+## Final corrected exact-tag outcome
+
+Original full helper completed exit0 with actual81context/437root/6bundle/651MCP, all passes and zero failures, skips, cancellations or TODO. Exact extracted wrapper and all original helpers/tests stayed unchanged; final git status is clean and tag/object/commit/tree still match packet. Node24.20.0 and isolated npm11.19.1 are bound in final-runtime-binding.log with the same PATH/TMPDIR as the full invocation. Original long-path650/651 failure remains evidence, causally corrected solely by owned short TMPDIR.
+
+Full log: exact-tag-full-short-tmp.log; five original JSON reports: full-reports.json; toolchain/tag/source/log hash binding: final-validation-binding.json. Final refreshed Cortex diff review (final-source-review.json) succeeds with zero findings/conflicts. Both SRIs/SHA256 and original seed sizes remain exact. Source hashes rechecked equal manager. Commit binding follows manager commit; no native/publication approval is implied.

--- a/docs/agent-control/local-008-ops-validation-review.md
+++ b/docs/agent-control/local-008-ops-validation-review.md
@@ -1,0 +1,51 @@
+# WO-LOCAL-008 independent Ops / Validation / Integration review
+
+APPROVE the exact candidate four-file source hashes in reviewed-source-sha256.json for coordinated PR/native preflight. No unresolved blocker or major finding. Final exact toolchain clean-tag run passes81/437/6/651; this local approval does not replace native PR/Publish gates.
+
+Reviewer assigned before implementation; own clone at31af0dae28b106ef916fdf8bed24cda450cdb498. Only packet/direct refs used. Prior clones read-only; manager sole source/remote writer. Auxiliary clean-tag and2.9 simulation clones are owned below /private/tmp/cortex-local-008-ops-evidence.
+
+## Source and gate equivalence
+
+The existing release-publish.yml filename retains hosted Ubuntu, Node24/npm11.19.1 and id-token:write. Only explicit Boolean recovery on workflow_dispatch from refs/heads/main selects the fixed2.8.0 release. Normal strict tagged invocation remains. Checkout obtains the annotated tag; recovery checks exact annotated objecte07de9de09e57ddf6375df72c241ba7c5b7ae8f5, commit00258d7fe40c58fa54e0723236e452630feb7009 and tree72c8ef3565a8b1b102da738de41c821cab6cb997 before any tagged code executes. Workflow source SHA/ref are recorded separately.
+
+The recovery heredoc imports original tagged runFreshCheckout and executeChild. Every child executes through original executeChild and original output/count/failure validation. Only exact npm[test] at the helper cwd receives a copied environment with NODE_OPTIONS TAP; MCP explicit spec and both context preparation commands keep original options. Nonempty parent NODE_OPTIONS rejects before helper entry. Original helper/tests/source remain immutable.
+
+Original gates remain: full and pristine counts; six audits; containment/frontend; pinned real Harness; duplicate/local artifact verification and install; local headless/Web/disposal/removal; exact registry safe resume; root publish then exact root registry verification before bundle publish; exact bundle verification; root CLI smoke; empty-cache dual registry install; final registry Harness. Original2.8 root and bundle SRI/SHA256 additionally reject byte drift before any publication. No npm auth fallback, version substitution or gate waiver.
+
+Official npm documentation https://docs.npmjs.com/trusted-publishers/ confirms supported GitHub-hosted runner, minimum npm11.5.1/Node22.14 and owner/repository/workflow filename (+ optional environment) trust configuration. Filename is preserved; actual saved npm admin config was not read. Correct main workflow dispatch is required; rerunning immutable old tag workflow would retain old definition. Native successful publication remains authoritative for configured npm trust.
+
+## Next-minor simulation and locked dependency bootstrap
+
+Preflight still computes next minor2.9 locally without a release/tag publication. Bump/preflight shared blocks remain identical. Bundle npm ci is moved after built root seed and original metadata synchronization, primed by npm cache add exact seed tarball, and retains the existing local artifact install/version assertion. This removes dependence on unpublished current/next root registry versions while retaining all six locked ci commands and original8 metadata paths.
+
+Independent real2.9 simulation uses original tag source with normal npm version minor, pack and sync scripts; Node24.20.0 and isolated npm11.19.1, initially absent private cache. Exact local root cache add plus npm ci --prefer-offline succeeds25 packages/0 vulnerabilities; unchanged subsequent local artifact install succeeds and installed root is2.9.0. Exactly8 expected metadata paths differ. Raw simulation-proof.json and simulation-npm11-{ci,bind}.log retained. Original --package-lock=false install re-resolves3 installed dependencies including koffi3.1.6→3.2.1; this preexisting behavior does not change locked artifact bytes and is not introduced by cache priming.
+
+## Validation and context evidence
+
+Candidate focused47 runs on macOS:46pass,0fail,1 expected Linux-only Harness identity skip. No claim of native47/47. Exact root artifact independently repacks to original SHA256834585c01bafc60e9d9a7551a51b3815d577ba3e1329cdcc614151b5f78d723e and passes tagged sync --check.
+
+Used using-cortex/change-impact/pattern-review/context-review. Initial search/rules/impact/related warned copied graph publication was unavailable; lexical fallback disclosed. Fresh scoped ingest+graph covers only direct workflows/helpers/tests and packet. Tracked config restored; watch stopped. All6 rules and4 changed-file pattern requests succeed using current Ryu graph with lexical ranking. Local workflow evidence is same module Bump/preflight shared ordering; tests use existing validators and mutation checks. Combined review returns verbatim `Review failed safely`/INVALID_ARGS, retained as candidate-review.json; no automated pass claimed. Explicit skill rules+patterns fallback and independent source review are separate. git diff --check passes.
+
+Final exact-head binding and native preflight/actual recovery Publish/registry/globalCLI completion remain required after this local approval.
+
+## Classified local macOS test-host correction
+
+First complete attempt: context81/root437/bundle6 all pass with original TAP count validation; MCP650/651 fails solely the existing socket transaction target test at analysis-state-trusted-writer.test.mjs366/375. Original helper rejects nonzero_exit with complete diagnostic; it is not a successful release gate. Raw exact-clean-tag-full.log is retained.
+
+Independent causal proof uses the exact original test and exact Node24.20.0: default TMPDIR generates a134-byte realpath and net.listen returns EINVAL(-22). Local macOS SDK sys/un.h79 defines sun_path[104]. Exact same original test passes1/1 with task-owned TMPDIR=/private/tmp/wo008-ops, producing a100-byte socket path. An independent minimal same-layout net.listen probe records default134-byte EINVAL and short100-byte successful listen. Raw socket-original-{default,short}.log and socket-probe.{mjs,jsonl} are retained. This is a host path-length correction, not a test/source/guard change or retry without diagnosis.
+
+After first attempt settled, original pristine-context reset restored clean tracked tag source. Entire unchanged original helper plus verbatim reviewed wrapper was run again with only the owned short TMPDIR correction; no runtime or test changes. This local macOS correction does not alter native Ubuntu workflow configuration or substitute for required hosted gates.
+
+## Toolchain resolution correction
+
+Both initial full attempts resolved bundled npm11.19.0 because the Node24 distribution bin directory preceded the isolated npm11.19.1 bin directory on PATH. The exact2.9 cache simulation directly invoked isolated npm11.19.1, so that evidence remains accurate. Initial full attempts are explicitly npm11.19.0 reporter/helper diagnostics, not required npm11.19.1 acceptance. Path binding detected this setup error before approval. Corrected order resolves Node24.20.0 and isolated npm11.19.1 and is recorded with command -v and versions in the final toolchain binding. No code/test change follows from this toolchain setup correction.
+
+Independent cache-integrity negative: separate disposable bundle manifest/lock plus a copied successful private2.9 cache, exact npm11.19.1. Changing only locked root SRI to a valid wrong SHA512 makes npm ci --offline fail exit1 ENOTCACHED specifically for the unpublished root2.9 URL. Restoring original lock SRI with the same cache makes the same offline command succeed25 packages/exit0. This isolates integrity matching from registry/transitive cache availability. Raw integrity-negative-{delta.json}, integrity-negative.log and integrity-positive-control.log remain. These diagnostics are outside source; no production lock was edited.
+
+All51 current multiline workflow shell blocks also pass bash -n; shell-syntax.json records each file/line result.
+
+## Final exact-toolchain clean-tag acceptance
+
+PASS: exact immutable00258d7 tag source, original helper and verbatim candidate wrapper, Node24.20.0 and npm11.19.1. Both resolved paths and versions are recorded and asserted before entry (exact-npm11-toolchain.txt). Only short owned TMPDIR corrects the proved macOS socket limitation. Original helper actually executes all four commands and reports81context/437root/6bundle/651MCP pass, zero failures/skips; subprocess exit0. Tracked tag source remains clean. Full collector log exact-clean-tag-npm11-full.log and parsed exact-clean-tag-npm11-proof.json bind commands, output hashes, counts, wrapper/helper hashes, source commit and toolchain.
+
+Earlier npm11.19.0 diagnostic evidence remains explicitly superseded for toolchain acceptance; first134-byte socket failure is classified and retained, never reported as a pass. This is macOS actual execution, not native Ubuntu acceptance. Required exact-head PR native all-gates success and actual reviewed-main immutable Publish/registry completion remain manager/root responsibilities.

--- a/docs/agent-control/local-008-publish-recovery-report.md
+++ b/docs/agent-control/local-008-publish-recovery-report.md
@@ -1,0 +1,139 @@
+# WO-LOCAL-008 immutable publication recovery
+
+Infra/deploy/security-sensitive. Fresh manager and independent Security/Contract/
+CodeQuality and Ops/Validation/Integration reviewers were assigned before edits,
+in separate008 clones at31af0dae. Source branch is based on actual release00258d7
+plus docs-only handoff; original checkout and previous clones remain read-only.
+
+## Contract and affected surface
+
+Cortex search identifies runFreshCheckout429–520 and executeChild270–374 in
+scripts/release-fresh-checkout.mjs; impact/related identify its four real child
+commands and tests. Six active rules were read. Initial copied cache warns of
+missing generation-linked graph and uses lexical fallback; no graph-policy pass
+is inferred. Only workflow orchestration, existing workflow contract tests and
+control docs change. Tagged helpers, tests, packages and metadata stay immutable.
+
+Existing release-publish.yml gains explicit recover_2_8 Boolean dispatch on main.
+Normal strict-tag invocation remains. Recovery pins v2.8.0 annotated object,
+peeled commit and tree before any tagged script runs, checks original Bump SRI
+and SHA256 before publication, and records workflow SHA separately from source.
+Original runFreshCheckout and executeChild execute every real command with the
+original collector/count guards. Only exact root npm[test] at repository cwd
+receives TAP NODE_OPTIONS in a copied child environment; nonempty inherited
+NODE_OPTIONS fails closed. MCP receives its original explicit spec environment.
+
+Same workflow filename, repository, hosted runner, OIDC permissions and npm11.19.1
+remain. Official npm trusted-publisher docs bind owner/repo/workflow filename
+and optional environment; GitHub dispatch docs distinguish workflow source ref.
+Actual saved npm admin configuration is not readable in this session; no auth
+change is attempted. Native actual publication remains the authoritative check.
+https://docs.npmjs.com/trusted-publishers/
+https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow
+
+PR preflight still simulates next minor2.9 with all original eight metadata paths
+and all release gates; no new Bump is dispatched. Its current bundle npm ci would
+require unpublished2.8 before seeding. Move that same locked install after exact
+local root seed, prime content-addressable npm cache with that artifact, then
+retain original binding/version check. Keep Bump/preflight shared gate blocks
+identical. Independent empty-cache proof is required before acceptance.
+
+## Acceptance still required
+
+Focused main workflow positive/negative tests, exact-tag actual Node24 full
+81/437/6/651 with wrapper, independent source approvals, complete native PR gates,
+guarded merge, correct main recovery dispatch, actual Publish success including
+registry Harness, exact registry bytes/SRI/SHA256 and empty-cache dual install.
+Root alone updates existing globalCLI after receiving complete evidence.
+No tag mutation, release version substitution, gate waiver or auth fallback.
+
+## Verification in progress and actual trust evidence
+
+Main focused suite47 has46pass/0fail/1 Linux-only skip on macOS; native47/47
+remains required. Both fresh reviewers independently exercise exact-tag Node24
+full gates. Security24 scope and positive/negative probes show original count/missing-summary/
+nonzero-exit fail-closed behavior and exact child environment/command scope.
+Ops verifies unpublished2.9 seed with actual npm11.19.1, initially empty private
+cache, successful locked ci, original local binding and exactly8 metadata paths.
+Original local --package-lock=false binding can refresh installed transitives;
+this pre-existing behavior does not change committed lock or artifact bytes.
+
+Actual prior successful Publish33473686535 and public npm2.7 root provenance
+bind DanielBlomma/cortex/.github/workflows/release-publish.yml to hosted runner,
+workflow_dispatch and tag commitcd7e41469d208018554d878862119d4c443a512a.
+Raw prior-publish.json, prior-root-attestation.json and decoded provenance are in
+/private/tmp/cortex-local-008-evidence. This proves historical root workflow
+identity, not current saved settings for either package. Both2.8 endpoints remain
+404 before recovery. New workflow keeps exact filename/permissions/auth path.
+
+Scoped manager ingest/load-ryu refreshed17 direct files/217chunks; config restored,
+watch stopped. Combined review returns verbatim `Review failed safely`/INVALID_ARGS;
+no automated pass is claimed. Required rules/per-file patterns and independent
+source reviews are separate evidence.
+
+## Local context command scope incident
+
+Manager mistakenly invoked `node bin/cortex.mjs update --help` expecting syntax
+help; this CLI executes update. It ingested10 changed-context files and launched
+embed.sh, which actually downloaded model metadata/tokenizer and209636334bytes
+of a partial ONNX model into the new008 clone. Manager stopped the entire owned
+process tree with SIGTERM; command exited143. No embedding snapshot or inference
+result was observed. No network trace was captured, so no categorical no-network/
+no-source-upload claim is made. Independent Security source review confirms this
+stage fetches model resources and awaits local model initialization before
+scheduling local feature extraction. This is a real unauthorized model-download
+scope deviation, not a successful no-provider update.
+
+Root and Security were informed immediately. Durable raw inventory/hashes and
+npm log are update-incident-{files,hashes}.json and update-incident-npm.log in the
+manager evidence directory. Verified solely task-owned newly created embeddings
+cache was removed; old clones and original checkout were never touched. No live
+owned embed process remains. Further refresh uses only explicit scoped ingest
+and load-ryu; no speculative CLI help/update invocation. Release source, tag,
+package bytes and authorization are unaffected. Root directs continuation after
+containment, preserving required independent and native release gates.
+
+A direct original-vs-candidate workflow comparison confirms all32 original
+Publish steps retain order;27 steps are byte-identical. The five changed original
+steps are dispatch selection, checkout ref, tag-name mapping, scoped pristine
+executor and final source/workflow evidence. Two added identity/byte gates fail
+closed. Raw gate-equivalence.json records the exact comparison.
+
+## Independent full-tag validation: first macOS outcome
+
+Security's first actual Node24 full-tag run passed81context/437root/6bundle, then
+ran all651 MCP tests and failed650/651. Original executor/helper rejected the
+nonzero exit as required. Diagnostic reports a Unix socket path under macOS's
+long default TMPDIR in the analysis-writer fixture. Causal classification and
+any environment-only correction are pending; no successful full-tag claim,
+retry-to-green, source edit, push or release GO follows from this failed run.
+Raw exact-tag-full.log is preserved in the independent Security evidence dir.
+
+Security has now causally classified the first failure: exact socket test fails
+with134-byte macOS path and sun_path[104], passes unchanged with owned short
+TMPDIR. Corrected original full helper on exact tag/Node24.20.0/npm11.19.1 exits0
+with81/437/6/651 and no fail/skip/cancel/todo. Its report and final source/toolchain/
+log binding are local-008-independent-security-review.md and independent evidence
+final-validation-binding.json. Security approves four unchanged source hashes.
+Ops independently reproduces the path constraint; its shortTMP full diagnostic
+passes81/437/6/651 on bundlednpm11.19.0, explicitly not mislabeled11.19.1. A final
+correctly resolved npm11.19.1 full gate is running before final Ops approval.
+
+## WO-LOCAL-008 source and local validation acceptance
+
+Both fresh independent reviewers approve the four source hashes with no remaining
+blocker/major finding. Both original clean-tag full helpers independently pass
+81/437/6/651 on exact Node24.20.0/npm11.19.1, with zero fail/skip/cancel/todo.
+The host-only socket correction uses short task-owned TMPDIR and changes no source,
+helper, command or guard. First long-path failures and Ops's intermediate11.19.0
+diagnostic remain explicitly scoped; only final11.19.1 runs establish acceptance.
+Ops proves wrong locked root SRI rejects offline while restoring only exact SRI
+passes against the same cache. Both independent reports are committed alongside
+local-008-publish-recovery-report.md; raw final bindings remain in008 evidence dirs.
+
+Accept for coordinated draft PR and complete hosted native preflight, not merge
+or publication ahead of native gates. Auto-advance existing authorization to
+exact-head push, PR validation, guarded merge and explicit main recover_2_8
+Publish only after required green gates. Never rerun Bump or mutate v2.8.0.
+Root alone installs existing globalCLI after actual complete Publish/registry
+byte/SRI/SHA256/empty-cache/Harness evidence. Class:infra-sensitive, no PR stack.

--- a/docs/agent-control/manager-log.md
+++ b/docs/agent-control/manager-log.md
@@ -2060,3 +2060,67 @@ patterns succeed. Full native final-head release gates remain mandatory.
 See local-007-release-completion-report.md and the two independent review reports.
 Auto-advance under existing authority to coordinated draft PR130 update, native
 preflight, then guarded merge/Bump/Publish only after actual green gates.
+
+## WO-LOCAL-007 actual native acceptance and guarded merge
+
+Both reviewers formally bind exact6672c3259478034b079fd0cd9564f58ab020a351.
+Coordinated fast-forward PR130 from6275039 to6672c32. Actual native Ubuntu
+preflight34600081411 completedSUCCESS,29/29 steps success. Full focused47,
+context81/root437/bundle6/MCP651 and pristine81/437/6/651 pass with zero skips;
+six audits report zero vulnerabilities. Containment/frontend, pinned Harness,
+identical duplicate artifacts, empty-cache install, real headless/Web/disposal/
+profile-removal and final diff/secrets/version/runtime boundary all pass.
+Raw log: local-007-evidence/preflight-34600081411.log; structured reports and
+step JSON retained alongside it. Historical native failure remains unclassified.
+
+Rechecked PR130 OPEN/DRAFT, head6672c32, main37a511f, no comments/reviews/pause,
+MERGEABLE/CLEAN, required validateSUCCESS. Synthetic merge
+9ead1dd9955f1ac89ad033b55434c02b9ebaf99c has tree
+f9975b49f75061dbb9247c5b172461e429c3a058, exactly local merge-tree. No conflict
+or dependent stack. Root independently confirms nativeSUCCESS. Manager accepts
+final source/native gates and auto-advances existing authorized ready+guarded
+merge, then existing minor Bump/Publish chain. No release gate waiver.
+
+PR130 guarded merge completed2026-09-11T13:00:22Z; merge/main commit
+6a42922b933f5869ae188b8d9cc56afccbbd2554, tree identical to native preflight.
+Dispatched existing minor Release Bump34601925375 on that main commit; full and
+pristine gates continue unchanged. No tag or Publish success has been claimed.
+
+## Release Bump completed / immutable Publish in progress
+
+Bump34601925375 completedSUCCESS, every step passed including the second actual
+full/pristine/audit/artifact/Harness/final-boundary sequence and atomic tag+main.
+Annotated v2.8.0 objecte07de9de09e57ddf6375df72c241ba7c5b7ae8f5 peels to
+00258d7fe40c58fa54e0723236e452630feb7009, exact remote main, tree
+72c8ef3565a8b1b102da738de41c821cab6cb997. Parent is reviewed merge6a42922.
+Exactly the expected eight metadata paths differ from merge; production/test
+source remains reviewed. Bump root/bundle SHA256 and SRI match native preflight
+bytes exactly. Full Bump log and extracted reports are in local-007-evidence.
+
+Existing Bump workflow automatically started Publish34603037854 at that immutable
+release commit. Actual publication, final registryHarness, downloaded bytes, fresh
+registry dual-install and root globalCLI proof remain pending. No tag is rewritten.
+
+## WO-LOCAL-007 Publish outcome / WO-LOCAL-008 bounded handoff
+
+Actual Publish34603037854 FAILED before any npm publication: pristine npm test
+exits0 with81/437/6 pass, but original root summary parser requiresTAP '#' and
+Node24.20.0 defaults to spec 'ℹ'. First full tagged MCP651 passed; pristine MCP
+was never reached. All later audits/artifacts/Harness/publication steps skipped.
+Both2.8.0 registry endpoints rechecked404. Immutable v2.8.0 object/commit remain
+e07de9de09e57ddf6375df72c241ba7c5b7ae8f5 /
+00258d7fe40c58fa54e0723236e452630feb7009; actual main is same releasecommit.
+
+Exact Node24.20.0 diagnostic proves globalNODE_OPTIONS TAP would break explicit
+MCPspec via duplicate reporters, so no global flag/rerun is attempted. A scoped
+original-executor wrapper is conditional pending fresh independent review and
+exact clean-tag full gates. Existing tag workflow has no recovery inputs and
+branch-ref rejection; safe main-workflow orchestration needs new reviewed work.
+Root authorizes that bounded recovery under existing2.8 publication scope. No
+tag rewrite, Bump rerun, version substitution, auth mutation or gate waiver.
+
+Fresh packet context-packets/local-008-immutable-publish-reporter-recovery.md
+contains completed source/native/Bump identities, all artifact bytes, actual
+failed Publish evidence, no-publication state and conditional recovery design.
+Root automatically starts a fresh manager and two fresh reviewers. This is a
+context/work-order boundary, not a user stop/reapproval request.

--- a/docs/agent-control/manager-log.md
+++ b/docs/agent-control/manager-log.md
@@ -2124,3 +2124,30 @@ contains completed source/native/Bump identities, all artifact bytes, actual
 failed Publish evidence, no-publication state and conditional recovery design.
 Root automatically starts a fresh manager and two fresh reviewers. This is a
 context/work-order boundary, not a user stop/reapproval request.
+
+## WO-LOCAL-008 recovery design / review assignment
+
+Fresh008 manager owns implementation; fresh008 Security and Ops reviewers were
+assigned before edits in separate clones. Infra/deploy/security-sensitive scope,
+source/workflow trust contract, preserved gates, installation-order issue and
+required acceptance evidence are in local-008-publish-recovery-report.md.
+Original immutable v2.8.0 and all package bytes remain fixed. No release GO yet.
+
+## WO-LOCAL-008 source and local validation acceptance
+
+Both fresh independent reviewers approve the four source hashes with no remaining
+blocker/major finding. Both original clean-tag full helpers independently pass
+81/437/6/651 on exact Node24.20.0/npm11.19.1, with zero fail/skip/cancel/todo.
+The host-only socket correction uses short task-owned TMPDIR and changes no source,
+helper, command or guard. First long-path failures and Ops's intermediate11.19.0
+diagnostic remain explicitly scoped; only final11.19.1 runs establish acceptance.
+Ops proves wrong locked root SRI rejects offline while restoring only exact SRI
+passes against the same cache. Both independent reports are committed alongside
+local-008-publish-recovery-report.md; raw final bindings remain in008 evidence dirs.
+
+Accept for coordinated draft PR and complete hosted native preflight, not merge
+or publication ahead of native gates. Auto-advance existing authorization to
+exact-head push, PR validation, guarded merge and explicit main recover_2_8
+Publish only after required green gates. Never rerun Bump or mutate v2.8.0.
+Root alone installs existing globalCLI after actual complete Publish/registry
+byte/SRI/SHA256/empty-cache/Harness evidence. Class:infra-sensitive, no PR stack.

--- a/docs/agent-control/risk-register.md
+++ b/docs/agent-control/risk-register.md
@@ -193,3 +193,30 @@ contains completed source/native/Bump identities, all artifact bytes, actual
 failed Publish evidence, no-publication state and conditional recovery design.
 Root automatically starts a fresh manager and two fresh reviewers. This is a
 context/work-order boundary, not a user stop/reapproval request.
+
+## WO-LOCAL-008 recovery design / review assignment
+
+Fresh008 manager owns implementation; fresh008 Security and Ops reviewers were
+assigned before edits in separate clones. Infra/deploy/security-sensitive scope,
+source/workflow trust contract, preserved gates, installation-order issue and
+required acceptance evidence are in local-008-publish-recovery-report.md.
+Original immutable v2.8.0 and all package bytes remain fixed. No release GO yet.
+
+## WO-LOCAL-008 source and local validation acceptance
+
+Both fresh independent reviewers approve the four source hashes with no remaining
+blocker/major finding. Both original clean-tag full helpers independently pass
+81/437/6/651 on exact Node24.20.0/npm11.19.1, with zero fail/skip/cancel/todo.
+The host-only socket correction uses short task-owned TMPDIR and changes no source,
+helper, command or guard. First long-path failures and Ops's intermediate11.19.0
+diagnostic remain explicitly scoped; only final11.19.1 runs establish acceptance.
+Ops proves wrong locked root SRI rejects offline while restoring only exact SRI
+passes against the same cache. Both independent reports are committed alongside
+local-008-publish-recovery-report.md; raw final bindings remain in008 evidence dirs.
+
+Accept for coordinated draft PR and complete hosted native preflight, not merge
+or publication ahead of native gates. Auto-advance existing authorization to
+exact-head push, PR validation, guarded merge and explicit main recover_2_8
+Publish only after required green gates. Never rerun Bump or mutate v2.8.0.
+Root alone installs existing globalCLI after actual complete Publish/registry
+byte/SRI/SHA256/empty-cache/Harness evidence. Class:infra-sensitive, no PR stack.

--- a/docs/agent-control/risk-register.md
+++ b/docs/agent-control/risk-register.md
@@ -169,3 +169,27 @@ WO-LOCAL-007 source risks closed by deterministic same-identity death/reap proof
 strict negative probes and owned setup-failure cleanup. Historical native process
 state remains unknown; no claim of retrospective classification. Native final-head
 gate remains open, with no timeout/production/publication exception.
+
+## WO-LOCAL-007 Publish outcome / WO-LOCAL-008 bounded handoff
+
+Actual Publish34603037854 FAILED before any npm publication: pristine npm test
+exits0 with81/437/6 pass, but original root summary parser requiresTAP '#' and
+Node24.20.0 defaults to spec 'ℹ'. First full tagged MCP651 passed; pristine MCP
+was never reached. All later audits/artifacts/Harness/publication steps skipped.
+Both2.8.0 registry endpoints rechecked404. Immutable v2.8.0 object/commit remain
+e07de9de09e57ddf6375df72c241ba7c5b7ae8f5 /
+00258d7fe40c58fa54e0723236e452630feb7009; actual main is same releasecommit.
+
+Exact Node24.20.0 diagnostic proves globalNODE_OPTIONS TAP would break explicit
+MCPspec via duplicate reporters, so no global flag/rerun is attempted. A scoped
+original-executor wrapper is conditional pending fresh independent review and
+exact clean-tag full gates. Existing tag workflow has no recovery inputs and
+branch-ref rejection; safe main-workflow orchestration needs new reviewed work.
+Root authorizes that bounded recovery under existing2.8 publication scope. No
+tag rewrite, Bump rerun, version substitution, auth mutation or gate waiver.
+
+Fresh packet context-packets/local-008-immutable-publish-reporter-recovery.md
+contains completed source/native/Bump identities, all artifact bytes, actual
+failed Publish evidence, no-publication state and conditional recovery design.
+Root automatically starts a fresh manager and two fresh reviewers. This is a
+context/work-order boundary, not a user stop/reapproval request.

--- a/tests/release-workflows.test.mjs
+++ b/tests/release-workflows.test.mjs
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { assertFinalHarnessEvidence, registryTarballUrl } from "../scripts/release-artifacts.mjs";
@@ -188,7 +191,19 @@ const synchronizedFiles = [
   ".claude-plugin/marketplace.json",
 ];
 
+function validateLockedBundleSeed(workflow) {
+  const install = stepBlock(workflow, "Bind bundle tests to the reviewed local root artifact");
+  assert.ok(install.includes('npm cache add "${ROOT_TARBALL}"'));
+  assert.ok(install.includes('npm ci --prefix plugins/dsh-cortex --prefer-offline'));
+  assertBefore(install, 'npm cache add', 'npm ci --prefix plugins/dsh-cortex');
+  assertBefore(install, 'npm ci --prefix plugins/dsh-cortex', 'npm --prefix plugins/dsh-cortex install');
+  assertBefore(workflow, '- name: Create exact release metadata and root artifact lock', '- name: Bind bundle tests to the reviewed local root artifact');
+  assertBefore(workflow, '- name: Bind bundle tests to the reviewed local root artifact', '- name: Run focused release contract tests');
+  assert.doesNotMatch(install, /continue-on-error:|\|\|\s*true|set \+e|if:/);
+}
+
 function validateBumpWorkflow(workflow) {
+  validateLockedBundleSeed(workflow);
   validateRequiredGateCommands(workflow);
   validateArtifactGates(workflow, false);
   validateFreshCheckoutGate(workflow, "${{ env.RELEASE_VERSION }}");
@@ -238,6 +253,7 @@ function validateBumpWorkflow(workflow) {
 }
 
 function validatePreflightWorkflow(workflow) {
+  validateLockedBundleSeed(workflow);
   validateRequiredGateCommands(workflow);
   validateArtifactGates(workflow, false);
   validateFreshCheckoutGate(workflow, "${{ env.RELEASE_VERSION }}");
@@ -278,7 +294,33 @@ function validatePreflightWorkflow(workflow) {
   }
 }
 
+function validateRecoveryContract(workflow) {
+  assert.match(workflow, /recover_2_8:[\s\S]*?type: boolean[\s\S]*?default: false/);
+  const select = stepBlock(workflow, "Reject branch dispatches and non-strict tags");
+  for (const command of ['test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"', 'test "${GITHUB_REF}" = "refs/heads/main"', 'TAG_NAME="v2.8.0"', 'test "${GITHUB_REF_TYPE}" = "tag"']) {
+    assert.ok(select.includes(command), `missing recovery source guard: ${command}`);
+  }
+  assert.ok(stepBlock(workflow, "Checkout immutable tag").includes('ref: refs/tags/${{ steps.source.outputs.tag }}'));
+  const identity = stepBlock(workflow, "Verify recovery source identity");
+  for (const value of ['e07de9de09e57ddf6375df72c241ba7c5b7ae8f5', '00258d7fe40c58fa54e0723236e452630feb7009', '72c8ef3565a8b1b102da738de41c821cab6cb997']) assert.ok(identity.includes(value));
+  assertBefore(workflow, '- name: Checkout immutable tag', '- name: Verify recovery source identity');
+  assertBefore(workflow, '- name: Verify recovery source identity', '- name: Setup Node');
+  const bytes = stepBlock(workflow, "Verify original immutable release artifact bytes");
+  for (const value of ['834585c01bafc60e9d9a7551a51b3815d577ba3e1329cdcc614151b5f78d723e', '6f00ac246fd77630bcb8f173e63a1c06205dcbf6b1b7617ac4cc4cad0b78d59c', 'sha512-QOiP27vDAVo7982ZFpf/cbb6KpT4dwbyW3r+h7AQR6AuATEjsVLPhau4SYS4mNruj+43lfgr5GhU2usTXDMkRA==', 'sha512-+vARd84pIBwxaa7kY0eA5FDV8fhgaE1ltZa55W0Y4w6ofriI5nf4gsebl7gtDxvw5Icbq/a8k2OehGEdCCNfPA==', 'sha256sum --check --strict']) assert.ok(bytes.includes(value));
+  for (const gate of [identity, bytes]) {
+    assert.match(gate, /if: inputs\.recover_2_8 == true/);
+    assert.doesNotMatch(gate, /continue-on-error:|\|\|\s*true|set \+e/);
+  }
+  assertBefore(workflow, '- name: Recreate and verify the reviewed local artifacts', '- name: Verify original immutable release artifact bytes');
+  assertBefore(workflow, '- name: Verify original immutable release artifact bytes', `- name: ${rootRegistryStepName}`);
+  const evidence = stepBlock(workflow, "Record immutable release evidence");
+  assert.ok(evidence.includes('WORKFLOW_SHA: ${{ github.workflow_sha }}'));
+  assert.ok(evidence.includes('WORKFLOW_REF: ${{ github.workflow_ref }}'));
+  assert.ok(evidence.includes('RELEASE_TAG: ${{ steps.source.outputs.tag }}'));
+}
+
 function validatePublishWorkflow(workflow) {
+  validateRecoveryContract(workflow);
   validateRequiredGateCommands(workflow);
   validateArtifactGates(workflow, true);
   validateFreshCheckoutGate(workflow, "${{ steps.version.outputs.value }}");
@@ -426,6 +468,9 @@ test("bundle lock synchronization requires and records the exact new root artifa
 test("release bump and read-only PR preflight preserve all release gates", () => {
   const bump = readText(".github/workflows/release-bump.yml");
   validateBumpWorkflow(bump);
+  for (const command of ['npm cache add "${ROOT_TARBALL}"', 'npm ci --prefix plugins/dsh-cortex --prefer-offline']) {
+    assert.throws(() => validateBumpWorkflow(bump.replace(command, 'echo omitted')));
+  }
   const preflight = readText(".github/workflows/release-preflight.yml");
   validatePreflightWorkflow(preflight);
   for (const [from, to] of [
@@ -546,8 +591,55 @@ test("release workflows reject every npm credential and login path", () => {
   }
 });
 
-test("release publish is tag-only, root-first, exact-artifact, and resumable", () => {
-  validatePublishWorkflow(readText(".github/workflows/release-publish.yml"));
+test("release publish binds immutable tag recovery, root-first exact artifacts, and safe resume", async () => {
+  const workflow = readText(".github/workflows/release-publish.yml");
+  validatePublishWorkflow(workflow);
+  const select = stepBlock(workflow, "Reject branch dispatches and non-strict tags").split("        run: |\n")[1]
+    .split("\n").map((line) => line.replace(/^ {10}/, "")).join("\n");
+  const temporary = fs.mkdtempSync(path.join(os.tmpdir(), "cortex-publish-source-"));
+  try {
+    const output = path.join(temporary, "output");
+    for (const [recovery, event, ref, type, tag, expected] of [
+      ["true", "workflow_dispatch", "refs/heads/main", "branch", "main", "v2.8.0"],
+      ["true", "push", "refs/heads/main", "branch", "main", null],
+      ["true", "workflow_dispatch", "refs/heads/feature", "branch", "feature", null],
+      ["true", "workflow_dispatch", "refs/tags/v2.8.0", "tag", "v2.8.0", null],
+      ["false", "workflow_dispatch", "refs/heads/main", "branch", "main", null],
+      ["false", "push", "refs/tags/v2.8.0", "tag", "v2.8.0", "v2.8.0"],
+      ["false", "push", "refs/tags/v02.8.0", "tag", "v02.8.0", null],
+      ["false", "push", "refs/tags/v2.8.0-beta", "tag", "v2.8.0-beta", null],
+    ]) {
+      fs.writeFileSync(output, "");
+      const result = spawnSync("bash", ["--noprofile", "--norc", "-eo", "pipefail", "-c", select], {
+        encoding: "utf8", env: { ...process.env, RECOVER_2_8: recovery, GITHUB_EVENT_NAME: event, GITHUB_REF: ref, GITHUB_REF_TYPE: type, TAG_NAME: tag, GITHUB_OUTPUT: output },
+      });
+      assert.equal(result.status === 0, expected !== null, JSON.stringify({ recovery, event, ref, tag, result }));
+      assert.equal(fs.readFileSync(output, "utf8"), expected ? `tag=${expected}\n` : "");
+    }
+  } finally {
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+  const gate = stepBlock(workflow, "Run executable fresh-checkout regression");
+  const wrapper = gate.match(/import \{ runFreshCheckout, executeChild \} from '[^']+';\n([\s\S]*?)\n {10}NODE/)[1];
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+  const execute = new AsyncFunction("runFreshCheckout", "executeChild", "process", wrapper);
+  const parent = { CORTEX_EXPECTED_RELEASE_VERSION: "2.8.0", PRESERVED: "yes" };
+  const options = { cwd: process.cwd(), env: parent };
+  const calls = [];
+  const commands = [["npm", ["test"]], ["npm", ["--prefix", "scaffold/mcp", "run", "test:ci"]], [process.execPath, ["scripts/release-artifacts.mjs", "root-context"]], ["npm", ["test", "--extra"]], ["other", ["test"]]];
+  const result = { status: 7, stdout: "unaltered output", stderr: "unaltered error" };
+  await execute(async ({ executor }) => {
+    for (const [command, args] of commands) assert.equal(await executor(command, args, options), result);
+    assert.equal(await executor("npm", ["test"], { ...options, cwd: path.join(process.cwd(), "elsewhere") }), result);
+  }, (command, args, childOptions) => { calls.push({ command, args, childOptions }); return result; }, { env: parent, cwd: () => process.cwd() });
+  assert.deepEqual(calls.slice(0, commands.length).map(({ command, args }) => [command, args]), commands);
+  assert.deepEqual(calls[0].childOptions, { ...options, env: { ...parent, NODE_OPTIONS: "--test-reporter=tap" } });
+  for (const call of calls.slice(1, commands.length)) assert.equal(call.childOptions, options);
+  assert.equal(calls.at(-1).childOptions.env, parent);
+  assert.equal(parent.NODE_OPTIONS, undefined);
+  let entered = false;
+  await assert.rejects(execute(() => { entered = true; }, () => {}, { env: { NODE_OPTIONS: "--test-reporter=spec" } }), /unmodified parent NODE_OPTIONS/);
+  assert.equal(entered, false);
 });
 
 test("release publish rejects publication before local artifact and Harness gates", () => {
@@ -563,6 +655,14 @@ test("release publish rejects publication before local artifact and Harness gate
 test("release publish rejects OIDC, provenance, runner, tag, version, and resume mutations", () => {
   const workflow = readText(".github/workflows/release-publish.yml");
   const mutations = [
+    workflow.replace('test "${GITHUB_REF}" = "refs/heads/main"', 'true'),
+    workflow.replace('test "${GITHUB_EVENT_NAME}" = "workflow_dispatch"', 'true'),
+    workflow.replace('e07de9de09e57ddf6375df72c241ba7c5b7ae8f5', 'unreviewed'),
+    workflow.replace('00258d7fe40c58fa54e0723236e452630feb7009', 'unreviewed'),
+    workflow.replace('72c8ef3565a8b1b102da738de41c821cab6cb997', 'unreviewed'),
+    workflow.replace('834585c01bafc60e9d9a7551a51b3815d577ba3e1329cdcc614151b5f78d723e', 'unreviewed'),
+    workflow.replace('6f00ac246fd77630bcb8f173e63a1c06205dcbf6b1b7617ac4cc4cad0b78d59c', 'unreviewed'),
+    workflow.replace('sha256sum --check --strict', 'true'),
     workflow.replace("id-token: write", "id-token: none"),
     workflow.replace("runs-on: ubuntu-latest", "runs-on: self-hosted"),
     workflow.replace('npm publish "${{ steps.artifacts.outputs.root_tarball }}" --access public --provenance', 'npm publish "${{ steps.artifacts.outputs.root_tarball }}" --access public'),


### PR DESCRIPTION
Release Publish failed before npm publication because Node24 emits spec summaries while the immutable v2.8.0 fresh-checkout helper requires root TAP summaries. Add an explicit main-only recovery dispatch to the existing trusted workflow: check out the unchanged annotated v2.8.0 object/commit/tree, delegate all pristine commands to the original helper/executor, and select TAP only for the root npm test child. Check the original Bump SRI/SHA256 before ordered publication; retain every audit, artifact, Harness, registry-resume and final registry gate.

PR preflight can now install its unpublished next-minor simulation through the original locked bundle npm ci after priming the cache with its exact local root seed. No release Bump is dispatched, no tag or package source changes, and npm authentication stays unchanged.

Validation: independent Security and Ops reviews; focused47 (46 passed, one Linux-only skip on macOS); executable dispatch/env negatives and original count/failure probes; exact npm11.19.1 empty-cache unpublished2.9 install proof. Both independent original immutable-tag full gates pass81/437/6/651 on Node24.20.0/npm11.19.1 with unchanged source and an evidenced macOS short-TMPDIR correction. Hosted PR preflight remains required. Full evidence is recorded in docs/agent-control/local-008-publish-recovery-report.md. Local context scope incident and containment are recorded there candidly. WO-LOCAL-008; class:infra-sensitive; direct main branch, no PR stack.
